### PR TITLE
Add _y_spt_afterframes_await_load

### DIFF
--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -359,7 +359,8 @@ void ClientDLL::ResetAfterframesQueue()
 
 void ClientDLL::OnFrame()
 {
-	if (afterframesPaused) {
+	if (afterframesPaused)
+	{
 		return;
 	}
 

--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -335,6 +335,8 @@ void ClientDLL::Clear()
 	pCmd = 0;
 
 	afterframesQueue.clear();
+	afterframesPaused = false;
+
 	duckspam = false;
 
 	setPitch.set = false;
@@ -357,6 +359,10 @@ void ClientDLL::ResetAfterframesQueue()
 
 void ClientDLL::OnFrame()
 {
+	if (afterframesPaused) {
+		return;
+	}
+
 	for (auto it = afterframesQueue.begin(); it != afterframesQueue.end(); )
 	{
 		it->framesLeft--;

--- a/spt/OrangeBox/modules/ClientDLL.hpp
+++ b/spt/OrangeBox/modules/ClientDLL.hpp
@@ -59,7 +59,6 @@ public:
 
 	void PauseAfterframesQueue() { afterframesPaused = true; }
 	void ResumeAfterframesQueue() { afterframesPaused = false; }
-	//bool IsAfterframesQueuePaused() { return afterframesPaused; }
 
 	void EnableDuckspam()  { duckspam = true; }
 	void DisableDuckspam() { duckspam = false; }

--- a/spt/OrangeBox/modules/ClientDLL.hpp
+++ b/spt/OrangeBox/modules/ClientDLL.hpp
@@ -57,6 +57,10 @@ public:
 	void AddIntoAfterframesQueue(const afterframes_entry_t& entry);
 	void ResetAfterframesQueue();
 
+	void PauseAfterframesQueue() { afterframesPaused = true; }
+	void ResumeAfterframesQueue() { afterframesPaused = false; }
+	//bool IsAfterframesQueuePaused() { return afterframesPaused; }
+
 	void EnableDuckspam()  { duckspam = true; }
 	void DisableDuckspam() { duckspam = false; }
 
@@ -87,6 +91,8 @@ protected:
 	uintptr_t pCmd;
 
 	std::vector<afterframes_entry_t> afterframesQueue;
+	bool afterframesPaused = false;
+
 	bool duckspam;
 	angset_command_t setPitch, setYaw;
 	bool forceJump;

--- a/spt/OrangeBox/modules/EngineDLL.cpp
+++ b/spt/OrangeBox/modules/EngineDLL.cpp
@@ -295,7 +295,7 @@ bool __cdecl EngineDLL::HOOKED_SV_ActivateServer_Func()
 			shouldPreventNextUnpause = true;
 		}
 	}
-
+	
 	if (_y_spt_afterframes_reset_on_server_activate.GetBool())
 		clientDLL.ResetAfterframesQueue();
 
@@ -314,7 +314,9 @@ void __fastcall EngineDLL::HOOKED_FinishRestore_Func(void* thisptr, int edx)
 		shouldPreventNextUnpause = true;
 	}
 
-	return ORIG_FinishRestore(thisptr, edx);
+	ORIG_FinishRestore(thisptr, edx);
+
+	clientDLL.ResumeAfterframesQueue();
 }
 
 void __fastcall EngineDLL::HOOKED_SetPaused_Func(void* thisptr, int edx, bool paused)

--- a/spt/OrangeBox/spt-serverplugin.cpp
+++ b/spt/OrangeBox/spt-serverplugin.cpp
@@ -243,6 +243,11 @@ CON_COMMAND(_y_spt_afterframes2, "Add everything after count as a command into t
 }
 #endif
 
+CON_COMMAND(_y_spt_afterframes_await_load, "Pause reading from the afterframes queue until the next load or changelevel. Useful for writing scripts spanning multiple maps or save-load segments.")
+{
+	clientDLL.PauseAfterframesQueue();
+}
+
 CON_COMMAND(_y_spt_afterframes_reset, "Reset the afterframes queue.")
 {
 	clientDLL.ResetAfterframesQueue();


### PR DESCRIPTION
Well, here's a thing. No idea how well it works and it probably can't time stuff accurately but at least you can execute a full TAS continuously without user input :laughing:

NOTE: Totally alpha, unresearched and with NO guarantee of accuracy. Better put that full disclaimer there so that I'm definitely not claiming that this is even useful for most things.

That said, it would be nice if you'd merge :stuck_out_tongue:
Though actually if you choose not to, I wouldn't mind just being able to have it as my own fork if you push the latest changes (because this branch isn't up to date... is it?)