### PR TITLE
Add _y_spt_afterframes_await_activate

### DIFF
--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -386,7 +386,7 @@ void ClientDLL::Clear()
 	tasAddressesWereFound = false;
 
 	afterframesQueue.clear();
-	afterframesPaused = false;
+	afterframesPauseState = 0;
 
 	duckspam = false;
 
@@ -410,22 +410,20 @@ void ClientDLL::ResetAfterframesQueue()
 
 void ClientDLL::OnFrame()
 {
-	if (afterframesPaused)
+	if (!afterframesPauseState)
 	{
-		return;
-	}
-
-	for (auto it = afterframesQueue.begin(); it != afterframesQueue.end(); )
-	{
-		it->framesLeft--;
-		if (it->framesLeft <= 0)
+		for (auto it = afterframesQueue.begin(); it != afterframesQueue.end(); )
 		{
-			EngineConCmd(it->command.c_str());
-			it = afterframesQueue.erase(it);
+			it->framesLeft--;
+			if (it->framesLeft <= 0)
+			{
+				EngineConCmd(it->command.c_str());
+				it = afterframesQueue.erase(it);
+			}
+			else
+				++it;
 		}
-		else
-			++it;
-	}
+	}	
 
 	if (engineDLL.Demo_IsPlayingBack() && !engineDLL.Demo_IsPlaybackPaused())
 	{

--- a/spt/OrangeBox/modules/ClientDLL.hpp
+++ b/spt/OrangeBox/modules/ClientDLL.hpp
@@ -57,8 +57,11 @@ public:
 	void AddIntoAfterframesQueue(const afterframes_entry_t& entry);
 	void ResetAfterframesQueue();
 
-	void PauseAfterframesQueue() { afterframesPaused = true; }
-	void ResumeAfterframesQueue() { afterframesPaused = false; }
+	// The pause state is decremented at each loading stage. It must reach 0 for the afterframes queue to resume.
+	// Therefore, we set the state to 1 to unpause on ActivateServer, and 2 to unpause on FinishRestore
+	// (as FinishRestore comes last so requires the highest starting value).
+	void SetAfterframesPauseState(int state) { afterframesPauseState = state; }
+	void DecrementAfterframesPauseState() { if (afterframesPauseState > 0) afterframesPauseState--; }
 
 	void EnableDuckspam()  { duckspam = true; }
 	void DisableDuckspam() { duckspam = false; }
@@ -95,7 +98,7 @@ protected:
 	bool tasAddressesWereFound;
 
 	std::vector<afterframes_entry_t> afterframesQueue;
-	bool afterframesPaused = false;
+	unsigned int afterframesPauseState = 0;
 
 	bool duckspam;
 	angset_command_t setPitch, setYaw;

--- a/spt/OrangeBox/modules/EngineDLL.cpp
+++ b/spt/OrangeBox/modules/EngineDLL.cpp
@@ -349,6 +349,8 @@ bool __cdecl EngineDLL::HOOKED_SV_ActivateServer_Func()
 	if (_y_spt_afterframes_reset_on_server_activate.GetBool())
 		clientDLL.ResetAfterframesQueue();
 
+	clientDLL.DecrementAfterframesPauseState();
+
 	return result;
 }
 
@@ -366,7 +368,7 @@ void __fastcall EngineDLL::HOOKED_FinishRestore_Func(void* thisptr, int edx)
 
 	ORIG_FinishRestore(thisptr, edx);
 
-	clientDLL.ResumeAfterframesQueue();
+	clientDLL.DecrementAfterframesPauseState();
 }
 
 void __fastcall EngineDLL::HOOKED_SetPaused_Func(void* thisptr, int edx, bool paused)

--- a/spt/OrangeBox/spt-serverplugin.cpp
+++ b/spt/OrangeBox/spt-serverplugin.cpp
@@ -288,12 +288,18 @@ CON_COMMAND(_y_spt_afterframes2, "Add everything after count as a command into t
 
 CON_COMMAND(_y_spt_afterframes_await_load, "Pause reading from the afterframes queue until the next load or changelevel. Useful for writing scripts spanning multiple maps or save-load segments.")
 {
-	clientDLL.PauseAfterframesQueue();
+	clientDLL.SetAfterframesPauseState(2);
+}
+
+CON_COMMAND(_y_spt_afterframes_await_activate, "Pause reading from the afterframes queue until the next server activation. Similar to await_load except occurs early during the load. May be useful for recording a demo, or for specific rare occasions where early control is required.")
+{
+	clientDLL.SetAfterframesPauseState(1);
 }
 
 CON_COMMAND(_y_spt_afterframes_reset, "Reset the afterframes queue.")
 {
 	clientDLL.ResetAfterframesQueue();
+	clientDLL.SetAfterframesPauseState(0);
 }
 
 CON_COMMAND(y_spt_cvar, "CVar manipulation.")


### PR DESCRIPTION
Probably not _that_ useful, but I thought it was worth having. Also fixes what looks to me like an issue where afterframes_await_\* would break demo_pause_on_tick.

Also, if another character shows up, I'm truly sorry. I tried getting rid of one but Git just doesn't like to deal with trailing whitespace apparently. I have a feeling if I check it out with my current settings it'll just remove itself anyway. You can do some mad hacks to remove it if you want, I'm not gonna try. :stuck_out_tongue:
