### PR TITLE
Added y_spt_glitchless_bhop_enabled

### DIFF
--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -29,10 +29,10 @@ ConVar tas_reset_surface_friction("tas_reset_surface_friction", "1", 0, "If enab
 ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
-ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1.\n");
-ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents lgagst from calculating below this speed. Not reccommended to change beyond the player's crouching speed.\n");
-ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing.\n");
-ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games.\n");
+ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, jumps automatically when it's faster to move in the air than on ground. Incomplete, intended use is for tas_strafe_glitchless only.\n");
+ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents LGAGST from triggering when the player speed is below this value. The default should be fine.");
+ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "If enabled, LGAGST assumes the player is standing regardless of the actual ducking state. Useful for when you land while crouching but intend to stand up immediately.\n");
+ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "If enabled, replaces the automatic ABH with glitchless bhop: forces the player to look at the direction of velocity when jumping.\n");
 	
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_server_activate", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -29,7 +29,7 @@ ConVar tas_reset_surface_friction("tas_reset_surface_friction", "1", 0, "If enab
 ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
-ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1.");
+ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
 //ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30");
 //ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0");
 

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -29,10 +29,10 @@ ConVar tas_reset_surface_friction("tas_reset_surface_friction", "1", 0, "If enab
 ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
-ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
+ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. \n");
 ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents lgagst from calculating below this speed. Not reccommended to change beyond the player's crouching speed. \n");
 ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
-ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games. /n");
+ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games. \n");
 	
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_server_activate", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -29,7 +29,7 @@ ConVar tas_reset_surface_friction("tas_reset_surface_friction", "1", 0, "If enab
 ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
-//ConVar tas_strafe_lgagst("tas_strafe_lgagst", "1");
+ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1.");
 //ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30");
 //ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0");
 

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -29,10 +29,10 @@ ConVar tas_reset_surface_friction("tas_reset_surface_friction", "1", 0, "If enab
 ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
-ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. \n");
-ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents lgagst from calculating below this speed. Not reccommended to change beyond the player's crouching speed. \n");
-ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. \n");
-ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games. \n");
+ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1.\n");
+ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents lgagst from calculating below this speed. Not reccommended to change beyond the player's crouching speed.\n");
+ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing.\n");
+ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games.\n");
 	
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_server_activate", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -30,8 +30,13 @@ ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing as
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
 ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
-ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "50");
-ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0");
+if (DoesGameLookLikePortal()) {
+	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "50", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 50, 63.33 for HL2. /n");
+	else {
+		ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "63.33", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 63.33, 50 for Portal. /n");
+	}
+}
+ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
 
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_server_activate", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -42,7 +42,7 @@ ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_
 ConVar _y_spt_pitchspeed("_y_spt_pitchspeed", "0");
 ConVar _y_spt_yawspeed("_y_spt_yawspeed", "0");
 ConVar _y_spt_force_90fov("_y_spt_force_90fov", "0");
-ConVar _y_spt_glitchless_bhop_enabled("_y_spt_glitchless_bhop_enabled", "0");
+ConVar _y_spt_glitchless_bhop("_y_spt_glitchless_bhop", "0");
 
 ConVar *_viewmodel_fov = nullptr;
 ConVar *_sv_accelerate = nullptr;

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -31,7 +31,7 @@ ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing as
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
 ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. \n");
 ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents lgagst from calculating below this speed. Not reccommended to change beyond the player's crouching speed. \n");
-ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
+ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. \n");
 ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games. \n");
 	
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -30,11 +30,7 @@ ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing as
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
 ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
-if (DoesGameLookLikePortal()) {
-	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "50", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 50, 63.33 for HL2. /n");
-else {
-	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "63.33", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 63.33, 50 for Portal. /n");
-}
+ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30", 0, "Prevents lgagst from calculating below this speed. Not reccommended to change beyond the player's crouching speed. \n");
 ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
 ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games. /n");
 	

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -30,12 +30,10 @@ ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing as
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
 ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
-if (DoesGameLookLikePortal()) {
+if (DoesGameLookLikePortal())
 	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "50", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 50, 63.33 for HL2. /n");
-	else {
+	else
 		ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "63.33", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 63.33, 50 for Portal. /n");
-	}
-}
 ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
 
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -30,10 +30,11 @@ ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing as
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
 ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
-if (DoesGameLookLikePortal())
+if (DoesGameLookLikePortal()) {
 	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "50", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 50, 63.33 for HL2. /n");
-	else
-		ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "63.33", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 63.33, 50 for Portal. /n");
+else {
+	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "63.33", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 63.33, 50 for Portal. /n");
+}
 ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
 
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -36,13 +36,13 @@ else {
 	ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "63.33", 0, "Prevents lgagst from operating if your horizontal speed is below this number. Default value is 63.33, 50 for Portal. /n");
 }
 ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0", 0, "When enabled, uses the maxspeed to determine if the player is touching the ground. Useful for areas where you land ducked but want to unduck and continue groundstrafing while still standing. /n");
-
+ConVar tas_strafe_glitchless("tas_strafe_glitchless", "0", 0, "When set to 1, disables ABH and looks in the exact direction of velocity to prevent any accidental speed gain. Only recommended for use in OrangeBox engine games. /n");
+	
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_server_activate", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_pitchspeed("_y_spt_pitchspeed", "0");
 ConVar _y_spt_yawspeed("_y_spt_yawspeed", "0");
 ConVar _y_spt_force_90fov("_y_spt_force_90fov", "0");
-ConVar _y_spt_glitchless_bhop("_y_spt_glitchless_bhop", "0");
 
 ConVar *_viewmodel_fov = nullptr;
 ConVar *_sv_accelerate = nullptr;

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -41,6 +41,7 @@ ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_
 ConVar _y_spt_pitchspeed("_y_spt_pitchspeed", "0");
 ConVar _y_spt_yawspeed("_y_spt_yawspeed", "0");
 ConVar _y_spt_force_90fov("_y_spt_force_90fov", "0");
+ConVar _y_spt_glitchless_bhop_enabled("_y_spt_glitchless_bhop_enabled", "0");
 
 ConVar *_viewmodel_fov = nullptr;
 ConVar *_sv_accelerate = nullptr;

--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -30,8 +30,8 @@ ConVar tas_force_onground("tas_force_onground", "0", 0, "If enabled, strafing as
 
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.\n");
 ConVar tas_strafe_lgagst("tas_strafe_lgagst", "0", 0, "If enabled, only jumped from the ground when it's faster to move in the air. Only recommended in OrangeBox Engine games when _y_spt_glitchless_bhop_enabled = 1. /n");
-//ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "30");
-//ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0");
+ConVar tas_strafe_lgagst_minspeed("tas_strafe_lgagst_minspeed", "50");
+ConVar tas_strafe_lgagst_fullmaxspeed("tas_strafe_lgagst_fullmaxspeed", "0");
 
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_ARCHIVE);
 ConVar _y_spt_afterframes_reset_on_server_activate("_y_spt_afterframes_reset_on_server_activate", "1", FCVAR_ARCHIVE);

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -25,13 +25,13 @@ extern ConVar tas_log;
 extern ConVar tas_strafe_lgagst;
 extern ConVar tas_strafe_lgagst_minspeed;
 extern ConVar tas_strafe_lgagst_fullmaxspeed;
+extern ConVar tas_strafe_glitchless;
 
 extern ConVar _y_spt_autojump_ensure_legit;
 extern ConVar _y_spt_afterframes_reset_on_server_activate;
 extern ConVar _y_spt_pitchspeed;
 extern ConVar _y_spt_yawspeed;
 extern ConVar _y_spt_force_90fov;
-extern ConVar _y_spt_glitchless_bhop;
 
 extern ConVar *_viewmodel_fov;
 extern ConVar *_sv_accelerate;

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -31,7 +31,7 @@ extern ConVar _y_spt_afterframes_reset_on_server_activate;
 extern ConVar _y_spt_pitchspeed;
 extern ConVar _y_spt_yawspeed;
 extern ConVar _y_spt_force_90fov;
-extern ConVar _y_spt_glitchless_bhop_enabled;
+extern ConVar _y_spt_glitchless_bhop;
 
 extern ConVar *_viewmodel_fov;
 extern ConVar *_sv_accelerate;

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -23,8 +23,8 @@ extern ConVar tas_force_onground;
 
 extern ConVar tas_log;
 extern ConVar tas_strafe_lgagst;
-//extern ConVar tas_strafe_lgagst_minspeed;
-//extern ConVar tas_strafe_lgagst_fullmaxspeed;
+extern ConVar tas_strafe_lgagst_minspeed;
+extern ConVar tas_strafe_lgagst_fullmaxspeed;
 
 extern ConVar _y_spt_autojump_ensure_legit;
 extern ConVar _y_spt_afterframes_reset_on_server_activate;

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -22,7 +22,7 @@ extern ConVar tas_reset_surface_friction;
 extern ConVar tas_force_onground;
 
 extern ConVar tas_log;
-//extern ConVar tas_strafe_lgagst;
+extern ConVar tas_strafe_lgagst;
 //extern ConVar tas_strafe_lgagst_minspeed;
 //extern ConVar tas_strafe_lgagst_fullmaxspeed;
 

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -31,6 +31,7 @@ extern ConVar _y_spt_afterframes_reset_on_server_activate;
 extern ConVar _y_spt_pitchspeed;
 extern ConVar _y_spt_yawspeed;
 extern ConVar _y_spt_force_90fov;
+extern ConVar _y_spt_glitchless_bhop_enabled;
 
 extern ConVar *_viewmodel_fov;
 extern ConVar *_sv_accelerate;

--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -675,7 +675,9 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 
 		auto btns = StrafeButtons();
 		bool usingButtons = (sscanf(tas_strafe_buttons.GetString(), "%hhu %hhu %hhu %hhu", &btns.AirLeft, &btns.AirRight, &btns.GroundLeft, &btns.GroundRight) == 4);
-
+		auto type = static_cast<StrafeType>(tas_strafe_type.GetInt());
+		auto dir = static_cast<StrafeDir>(tas_strafe_dir.GetInt());
+		
 		ProcessedFrame out;
 		out.Jump = false;
 		{
@@ -714,9 +716,6 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 		}
 
 		Friction(pl, onground, vars);
-
-		auto type = static_cast<StrafeType>(tas_strafe_type.GetInt());
-		auto dir = static_cast<StrafeDir>(tas_strafe_dir.GetInt());
 		Strafe(pl, vars, onground, jumped, ((*reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(player) + offFlags)) & FL_DUCKING), type, dir, tas_strafe_yaw.GetFloat(), va[YAW], out, reduceWishspeed, btns, usingButtons);
 
 		//EngineDevMsg("[Strafing] Yaw = %.8f\n", out.Yaw);

--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -629,10 +629,10 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 		else
 			vars.WishspeedCap = 30;
 
-		// Lgagst requires more prediction that is done here for correct operation, so it's commented out.
-		//auto curState = CurrentState();
-		//curState.LgagstMinSpeed = tas_strafe_lgagst_minspeed.GetFloat();
-		//curState.LgagstFullMaxspeed = tas_strafe_lgagst_fullmaxspeed.GetBool();
+		// Lgagst requires more prediction that is done here for correct operation.
+		auto curState = CurrentState();
+		curState.LgagstMinSpeed = tas_strafe_lgagst_minspeed.GetFloat();
+		curState.LgagstFullMaxspeed = tas_strafe_lgagst_fullmaxspeed.GetBool();
 
 		auto pl = PlayerData();
 		CalcAbsoluteVelocity(player, 0);
@@ -698,13 +698,13 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 			}
 
 			if (!cantjump && onground) {
-				//if (tas_strafe_lgagst.GetBool()) {
-				//	LgagstJump(pl, vars, curState, onground, ((*reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(player) + offFlags)) & FL_DUCKING), tas_strafe_yaw.GetFloat(), va[YAW] * M_DEG2RAD, out, reduceWishspeed, btns, false);
-				//	if (out.Jump) {
-				//		onground = false;
-				//		jumped = true;
-				//	}
-				//}
+				if (tas_strafe_lgagst.GetBool()) {
+					LgagstJump(pl, vars, curState, onground, ((*reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(player) + offFlags)) & FL_DUCKING), tas_strafe_yaw.GetFloat(), va[YAW] * M_DEG2RAD, out, reduceWishspeed, btns, false);
+					if (out.Jump) {
+						onground = false;
+						jumped = true;
+					}
+				}
 
 				if (ORIG_GetButtonBits(thisptr, 0, 0) & IN_JUMP) {
 					onground = false;

--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -675,8 +675,6 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 
 		auto btns = StrafeButtons();
 		bool usingButtons = (sscanf(tas_strafe_buttons.GetString(), "%hhu %hhu %hhu %hhu", &btns.AirLeft, &btns.AirRight, &btns.GroundLeft, &btns.GroundRight) == 4);
-		auto type = static_cast<StrafeType>(tas_strafe_type.GetInt());
-		auto dir = static_cast<StrafeDir>(tas_strafe_dir.GetInt());
 
 		ProcessedFrame out;
 		out.Jump = false;

--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -675,6 +675,8 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 
 		auto btns = StrafeButtons();
 		bool usingButtons = (sscanf(tas_strafe_buttons.GetString(), "%hhu %hhu %hhu %hhu", &btns.AirLeft, &btns.AirRight, &btns.GroundLeft, &btns.GroundRight) == 4);
+		auto type = static_cast<StrafeType>(tas_strafe_type.GetInt());
+		auto dir = static_cast<StrafeDir>(tas_strafe_dir.GetInt());
 
 		ProcessedFrame out;
 		out.Jump = false;
@@ -699,7 +701,7 @@ void __fastcall ClientDLL::HOOKED_AdjustAngles_Func(void* thisptr, int edx, floa
 
 			if (!cantjump && onground) {
 				if (tas_strafe_lgagst.GetBool()) {
-					LgagstJump(pl, vars, curState, onground, ((*reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(player) + offFlags)) & FL_DUCKING), tas_strafe_yaw.GetFloat(), va[YAW] * M_DEG2RAD, out, reduceWishspeed, btns, false);
+					LgagstJump(pl, vars, curState, onground, ((*reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(player) + offFlags)) & FL_DUCKING), type, dir, tas_strafe_yaw.GetFloat(), va[YAW] * M_DEG2RAD, out, reduceWishspeed, btns, false);
 					if (out.Jump) {
 						onground = false;
 						jumped = true;

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -322,23 +322,18 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 {
 	//DevMsg("[Strafing] ducking = %d\n", (int)ducking);
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
-		if y_spt_glitchless_bhop_enabled = 1 {
-			const Vector vel = serverDLL.GetLastVelocity();
-			if vel.x >= 0 and vel.y >= 0 {
-				out.Yaw = NormalizeDeg(double atan(double vel.y/vel.x));
+		if tas_strafe_glitchless.GetBool() == 1 {
+			const Vector vel = player.Velocity();
+			out.Yaw = NormalizeDeg(double atan2(double vel.y/vel.x));
+		}
+		else {
+			#nif defined ( OE ) {
+				out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat());
 			}
-			if vel.x <= 0 and vel.y >= 0 {
-				out.Yaw = NormalizeDeg(double atan(double vel.y/-vel.x)+90);
-			}
-			if vel.x <= 0 and vel.y <= 0 {
-				out.Yaw = NormalizeDeg(double atan(double -vel.y/-vel.x)+180);
-			}
-			if vel.x >= 0 and vel.y <= 0 {
-				out.Yaw = NormalizeDeg(double atan(double -vel.y/vel.x)-90);
+			else {
+				out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);
 			}
 		}
-		else if y_spt_glitchless_bhop_enabled = 0 {
-			out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);
 		out.Forward = false;
 		out.Back = false;
 		out.Right = false;

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -323,8 +323,8 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 	//DevMsg("[Strafing] ducking = %d\n", (int)ducking);
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
 		if (tas_strafe_glitchless.GetBool()) {
-			const Vector vel = player.Velocity();
-			out.Yaw = NormalizeDeg(atan2(vel.y/vel.x));
+			const Vector vel = player.Velocity;
+			out.Yaw = NormalizeDeg(atan2(vel.y, vel.x));
 		}
 		else {
 			out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -322,17 +322,12 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 {
 	//DevMsg("[Strafing] ducking = %d\n", (int)ducking);
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
-		if tas_strafe_glitchless.GetBool() == 1 {
+		if (tas_strafe_glitchless.GetBool()) {
 			const Vector vel = player.Velocity();
-			out.Yaw = NormalizeDeg(double atan2(double vel.y/vel.x));
+			out.Yaw = NormalizeDeg(atan2(vel.y/vel.x));
 		}
 		else {
-			if defined ( OE ) {
-				out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat());
-			}
-			else {
-				out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);
-			}
+			out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);
 		}
 		out.Forward = false;
 		out.Back = false;

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -471,25 +471,25 @@ void Friction(PlayerData& player, bool onground, const MovementVars& vars)
 	player.Velocity *= (newspeed / speed);
 }
 
-//void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons)
-//{
-//	if (player.Velocity.Length2D() < curState.LgagstMinSpeed)
-//		return;
-//
-//	auto ground = PlayerData(player);
-//	Friction(ground, onground, vars);
-//	auto out_temp = ProcessedFrame(out);
-//	Strafe(ground, vars, onground, false, ducking, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
-//
-//	auto air = PlayerData(player);
-//	out_temp = ProcessedFrame(out);
-//	out_temp.Jump = true;
-//	onground = false;
-//	Strafe(air, vars, onground, true, ducking, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
-//
-//	auto l_gr = ground.Velocity.Length2D();
-//	auto l_air = air.Velocity.Length2D();
-//	if (l_air > l_gr) {
-//		out.Jump = true;
-//	}
-//}
+void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons)
+{
+	if (player.Velocity.Length2D() < curState.LgagstMinSpeed)
+		return;
+
+	auto ground = PlayerData(player);
+	Friction(ground, onground, vars);
+	auto out_temp = ProcessedFrame(out);
+	Strafe(ground, vars, onground, false, ducking, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
+
+	auto air = PlayerData(player);
+	out_temp = ProcessedFrame(out);
+	out_temp.Jump = true;
+	onground = false;
+	Strafe(air, vars, onground, true, ducking, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
+
+	auto l_gr = ground.Velocity.Length2D();
+	auto l_air = air.Velocity.Length2D();
+	if (l_air > l_gr) {
+		out.Jump = true;
+	}
+}

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -324,7 +324,7 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
 		if (tas_strafe_glitchless.GetBool()) {
 			const Vector vel = player.Velocity;
-			out.Yaw = NormalizeDeg(atan2(vel.y, vel.x)-90);
+			out.Yaw = NormalizeRad(atan2(vel.y, vel.x));
 		}
 		else {
 			out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -327,7 +327,7 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 			out.Yaw = NormalizeDeg(double atan2(double vel.y/vel.x));
 		}
 		else {
-			#nif defined ( OE ) {
+			if defined ( OE ) {
 				out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat());
 			}
 			else {

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -477,7 +477,7 @@ void Friction(PlayerData& player, bool onground, const MovementVars& vars)
 	player.Velocity *= (newspeed / speed);
 }
 
-void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons)
+void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons) void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, StrafeType type, StrafeDir dir, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons)
 {
 	if (player.Velocity.Length2D() < curState.LgagstMinSpeed)
 		return;
@@ -485,13 +485,13 @@ void LgagstJump(const PlayerData& player, const MovementVars& vars, const Curren
 	auto ground = PlayerData(player);
 	Friction(ground, onground, vars);
 	auto out_temp = ProcessedFrame(out);
-	Strafe(ground, vars, onground, false, ducking, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
+	Strafe(ground, vars, onground, false, ducking, type, dir, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
 
 	auto air = PlayerData(player);
 	out_temp = ProcessedFrame(out);
 	out_temp.Jump = true;
 	onground = false;
-	Strafe(air, vars, onground, true, ducking, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
+	Strafe(air, vars, onground, true, ducking, type, dir, target_yaw, vel_yaw, out_temp, reduceWishspeed && !curState.LgagstFullMaxspeed, strafeButtons, useGivenButtons);
 
 	auto l_gr = ground.Velocity.Length2D();
 	auto l_air = air.Velocity.Length2D();

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -322,9 +322,23 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 {
 	//DevMsg("[Strafing] ducking = %d\n", (int)ducking);
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
-		if y_spt_glitchless_bhop_enabled = 1;
+		if y_spt_glitchless_bhop_enabled = 1 {
 			const Vector vel = serverDLL.GetLastVelocity();
-			out.Yaw = NormalizeDeg(vel.Length2D());
+			if vel.x >= 0 and vel.y >= 0 {
+				out.Yaw = NormalizeDeg(double atan(double vel.y/vel.x));
+			}
+			if vel.x <= 0 and vel.y >= 0 {
+				out.Yaw = NormalizeDeg(double atan(double vel.y/-vel.x)+90);
+			}
+			if vel.x <= 0 and vel.y <= 0 {
+				out.Yaw = NormalizeDeg(double atan(double -vel.y/-vel.x)+180);
+			}
+			if vel.x >= 0 and vel.y <= 0 {
+				out.Yaw = NormalizeDeg(double atan(double -vel.y/vel.x)-90);
+			}
+		}
+		else if y_spt_glitchless_bhop_enabled = 0 {
+			out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);
 		out.Forward = false;
 		out.Back = false;
 		out.Right = false;

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -324,7 +324,7 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
 		if (tas_strafe_glitchless.GetBool()) {
 			const Vector vel = player.Velocity;
-			out.Yaw = NormalizeDeg(atan2(vel.y, vel.x));
+			out.Yaw = NormalizeDeg(atan2(vel.y, vel.x)-90);
 		}
 		else {
 			out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -477,7 +477,7 @@ void Friction(PlayerData& player, bool onground, const MovementVars& vars)
 	player.Velocity *= (newspeed / speed);
 }
 
-void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons) void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, StrafeType type, StrafeDir dir, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons)
+void LgagstJump(const PlayerData& player, const MovementVars& vars, const CurrentState& curState, bool onground, bool ducking, StrafeType type, StrafeDir dir, double target_yaw, double vel_yaw, ProcessedFrame& out, bool reduceWishspeed, const StrafeButtons& strafeButtons, bool useGivenButtons)
 {
 	if (player.Velocity.Length2D() < curState.LgagstMinSpeed)
 		return;

--- a/spt/strafestuff.hpp
+++ b/spt/strafestuff.hpp
@@ -322,7 +322,9 @@ bool Strafe(PlayerData& player, const MovementVars& vars, bool onground, bool ju
 {
 	//DevMsg("[Strafing] ducking = %d\n", (int)ducking);
 	if (jumped && player.Velocity.Length2D() >= vars.Maxspeed * ((ducking || (vars.Maxspeed == 320)) ? 0.1 : 0.5)) {
-		out.Yaw = NormalizeDeg(tas_strafe_yaw.GetFloat() + 180);
+		if y_spt_glitchless_bhop_enabled = 1;
+			const Vector vel = serverDLL.GetLastVelocity();
+			out.Yaw = NormalizeDeg(vel.Length2D());
 		out.Forward = false;
 		out.Back = false;
 		out.Right = false;


### PR DESCRIPTION
When enabled, jumps in the direction of velocity rather than the opposite direction of tas_strafe_yaw. The code for lgagst I could find has also been enabled since strafing in the air will almost always gain you enough velocity that it's faster to delay your jump.