### PR TITLE
Changed the default value for y_spt_pause from 1 to 0

### DIFF
--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -2,7 +2,7 @@
 
 #include "convar.h"
 
-ConVar y_spt_pause("y_spt_pause", "1", FCVAR_ARCHIVE);
+ConVar y_spt_pause("y_spt_pause", "0", FCVAR_ARCHIVE);
 ConVar y_spt_motion_blur_fix("y_spt_motion_blur_fix", "0");
 ConVar y_spt_autojump("y_spt_autojump", "0", FCVAR_ARCHIVE);
 ConVar y_spt_additional_jumpboost("y_spt_additional_jumpboost",


### PR DESCRIPTION
Nowadays the plugin is used often for other purposes than pausing so it makes sense to switch this to 0. Other cvars for TASing and segmenting purposes default to off and y_spt_pause does not.