### PR TITLE
Fixed first tick crashes with conditions

### DIFF
--- a/spt/OrangeBox/modules/ServerDLL.cpp
+++ b/spt/OrangeBox/modules/ServerDLL.cpp
@@ -844,7 +844,7 @@ bool ServerDLL::CanTracePlayerBBox()
 
 int ServerDLL::GetPlayerPhysicsFlags() const
 {
-	if (!utils::serverActive())
+	if (!utils::playerEntityAvailable())
 		return -1;
 	else
 		return *reinterpret_cast<int*>(((int)GetServerPlayer() + offM_afPhysicsFlags));
@@ -852,7 +852,7 @@ int ServerDLL::GetPlayerPhysicsFlags() const
 
 int ServerDLL::GetPlayerMoveType() const
 {
-	if (!utils::serverActive())
+	if (!utils::playerEntityAvailable())
 		return -1;
 	else
 		return *reinterpret_cast<int*>(((int)GetServerPlayer() + offM_moveType)) & 0xF;
@@ -860,7 +860,7 @@ int ServerDLL::GetPlayerMoveType() const
 
 int ServerDLL::GetPlayerMoveCollide() const
 {
-	if (!utils::serverActive())
+	if (!utils::playerEntityAvailable())
 		return -1;
 	else
 		return *reinterpret_cast<int*>(((int)GetServerPlayer() + offM_moveCollide)) & 0x7;
@@ -868,7 +868,7 @@ int ServerDLL::GetPlayerMoveCollide() const
 
 int ServerDLL::GetPlayerCollisionGroup() const
 {
-	if (!utils::serverActive())
+	if (!utils::playerEntityAvailable())
 		return -1;
 	else
 		return *reinterpret_cast<int*>(((int)GetServerPlayer() + offM_collisionGroup));
@@ -876,7 +876,7 @@ int ServerDLL::GetPlayerCollisionGroup() const
 
 int ServerDLL::GetEnviromentPortalHandle() const
 {
-	if (!utils::serverActive())
+	if (!utils::playerEntityAvailable())
 		return -1;
 	else
 	{

--- a/spt/OrangeBox/modules/vguimatsurfaceDLL.cpp
+++ b/spt/OrangeBox/modules/vguimatsurfaceDLL.cpp
@@ -482,7 +482,7 @@ void VGui_MatSurfaceDLL::DrawTopHUD(vrect_t* screen, vgui::IScheme* scheme, IMat
 		DRAW_FLAGS(L"Move collide", MOVECOLLIDE_FLAGS, flags, true);
 	}
 
-	if (y_spt_hud_vars.GetBool() && utils::serverActive())
+	if (y_spt_hud_vars.GetBool() && utils::playerEntityAvailable())
 	{
 		auto vars = clientDLL.GetMovementVars();
 		DRAW_FLOAT(L"accelerate", vars.Accelerate);
@@ -496,7 +496,7 @@ void VGui_MatSurfaceDLL::DrawTopHUD(vrect_t* screen, vgui::IScheme* scheme, IMat
 		DRAW_INT(L"onground", (int)vars.OnGround);
 	}
 
-	if (y_spt_hud_ag_sg_tester.GetBool() && utils::serverActive())
+	if (y_spt_hud_ag_sg_tester.GetBool() && utils::playerEntityAvailable())
 	{
 		Vector v = clientDLL.GetPlayerEyePos();
 		QAngle q;

--- a/spt/OrangeBox/scripts/condition.cpp
+++ b/spt/OrangeBox/scripts/condition.cpp
@@ -46,6 +46,9 @@ namespace scripts
 
 	bool PosSpeedCondition::IsTrue(int tick, int totalTicks) const
 	{
+		if (!utils::playerEntityAvailable())
+			return false;
+
 		Vector v;
 
 		if (isPos)
@@ -100,19 +103,19 @@ namespace scripts
 
 	bool AliveCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return !utils::serverActive() || utils::GetProperty<int>(0, "m_iHealth") > 0;
+		return !utils::playerEntityAvailable() || utils::GetProperty<int>(0, "m_iHealth") > 0;
 	}
 
 	bool AliveCondition::ShouldTerminate(int tick, int totalTicks) const
 	{
-		return utils::serverActive() && utils::GetProperty<int>(0, "m_iHealth") <= 0;
+		return utils::playerEntityAvailable() && utils::GetProperty<int>(0, "m_iHealth") <= 0;
 	}
 
 	LoadCondition::LoadCondition() {}
 
 	bool LoadCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return !utils::serverActive();
+		return !utils::playerEntityAvailable();
 	}
 
 	bool LoadCondition::ShouldTerminate(int tick, int totalTicks) const
@@ -128,6 +131,9 @@ namespace scripts
 
 	bool VelAngleCondition::IsTrue(int tick, int totalTicks) const
 	{
+		if (!utils::playerEntityAvailable())
+			return false;
+
 		Vector v = clientDLL.GetPlayerVelocity();
 		QAngle angles;
 		VectorAngles(v, Vector(0, 0, 1), angles);

--- a/spt/OrangeBox/spt-serverplugin.cpp
+++ b/spt/OrangeBox/spt-serverplugin.cpp
@@ -880,7 +880,7 @@ CON_COMMAND(_y_spt_setangle,
 #endif
 	Vector target;
 
-	if (args.ArgC() > 3 && utils::serverActive())
+	if (args.ArgC() > 3 && utils::playerEntityAvailable())
 	{
 		target.x = atof(args.Arg(1));
 		target.y = atof(args.Arg(2));

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -460,6 +460,9 @@ namespace utils
 		data.canJB = false;
 		data.landingHeight = std::numeric_limits<float>::max();
 
+		if (!utils::playerEntityAvailable())
+			return data;
+
 		Vector player_origin = clientDLL.GetPlayerEyePos();
 		Vector vel = clientDLL.GetPlayerVelocity();
 
@@ -498,12 +501,12 @@ namespace utils
 		return data;
 	}
 
-	bool serverActive()
+	bool playerEntityAvailable()
 	{
-#ifdef P2
-		return GetEngine()->GetEntityCount();
+#ifdef OE
+		return false;
 #else
-		return GetEngine()->PEntityOfEntIndex(0);
+		return GetClientEntity(0) != nullptr;
 #endif
 	}
 } // namespace utils

--- a/spt/utils/ent_utils.hpp
+++ b/spt/utils/ent_utils.hpp
@@ -45,5 +45,5 @@ namespace utils
 	};
 
 	JBData CanJB(float height);
-	bool serverActive();
+	bool playerEntityAvailable();
 } // namespace utils

--- a/spt/utils/property_getter.hpp
+++ b/spt/utils/property_getter.hpp
@@ -25,12 +25,16 @@ namespace utils
 #ifdef OE
 		return T();
 #else
+		auto ent = GetClientEntity(entindex);
+
+		if (!ent)
+			return T();
+
 		int offset = GetOffset(entindex, key);
 		if (offset == INVALID_OFFSET)
 			return T();
 		else
 		{
-			IClientEntity* ent = GetClientEntity(entindex);
 			return *reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(ent) + offset);
 		}
 #endif


### PR DESCRIPTION
New afterframes change broke some condition stuff resulting in typical null pointer shenanigans with non-existent entities. Also changed the serverActive function name to more correctly match its new implementation of just checking whether or not the player entity is available. That was what it was used for checking anyway, since all the functions using that function were reading some player property stuff.