### PR TITLE
Some IPC fixes and commands

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -263,7 +263,7 @@
       <PreprocessorDefinitions>SSDK2007;WIN32;_WIN32;_DEBUG;DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
-      <ExceptionHandling />
+      <ExceptionHandling>Sync</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -331,8 +331,7 @@
       <PreprocessorDefinitions>P2;COMPILER_MSVC;COMPILER_MSVC32;WIN32;_WIN32;_DEBUG;DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
-      <ExceptionHandling>
-      </ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -402,8 +401,7 @@
       <PreprocessorDefinitions>SSDK2013;WIN32;_WIN32;_DEBUG;DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
-      <ExceptionHandling>
-      </ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -473,8 +471,7 @@
       <PreprocessorDefinitions>BMS;WIN32;_WIN32;_DEBUG;DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
-      <ExceptionHandling>
-      </ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -544,8 +541,7 @@
       <PreprocessorDefinitions>OE;WIN32;_WIN32;_DEBUG;DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
-      <ExceptionHandling>
-      </ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1350,6 +1350,7 @@
     <ClCompile Include="spt\ipc\ipc-commands.cpp" />
     <ClCompile Include="spt\ipc\ipc-spt.cpp" />
     <ClCompile Include="spt\ipc\ipc.cpp" />
+    <ClCompile Include="spt\OrangeBox\modules\inputSystemDLL.cpp" />
     <ClCompile Include="spt\OrangeBox\module_hooks.cpp" />
     <ClCompile Include="spt\utils\ent_utils.cpp" />
     <ClCompile Include="spt\utils\patterncontainer.cpp" />
@@ -1748,6 +1749,7 @@
     <ClInclude Include="SPTLib\Windows\DetoursUtils.hpp" />
     <ClInclude Include="spt\ipc\ipc-spt.hpp" />
     <ClInclude Include="spt\ipc\ipc.hpp" />
+    <ClInclude Include="spt\OrangeBox\modules\inputSystemDLL.hpp" />
     <ClInclude Include="spt\OrangeBox\module_hooks.hpp" />
     <ClInclude Include="spt\strafe_utils.hpp" />
     <ClInclude Include="spt\utils\ent_utils.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="spt\ipc\ipc-commands.cpp">
       <Filter>spt\ipc</Filter>
     </ClCompile>
+    <ClCompile Include="spt\OrangeBox\modules\inputSystemDLL.cpp">
+      <Filter>spt\OrangeBox\modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">
@@ -350,6 +353,9 @@
     </ClInclude>
     <ClInclude Include="thirdparty\Signal.h">
       <Filter>thirdparty</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\OrangeBox\modules\inputSystemDLL.hpp">
+      <Filter>spt\OrangeBox\modules</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/spt/OrangeBox/modules.cpp
+++ b/spt/OrangeBox/modules.cpp
@@ -1,5 +1,6 @@
 #include "modules\ClientDLL.hpp"
 #include "modules\EngineDLL.hpp"
+#include "modules\inputSystemDLL.hpp"
 #include "modules\ServerDLL.hpp"
 #include "modules\vguimatsurfaceDLL.hpp"
 
@@ -9,3 +10,4 @@ ServerDLL serverDLL;
 #ifndef OE
 VGui_MatSurfaceDLL vgui_matsurfaceDLL;
 #endif
+InputSystemDLL inputSystemDLL;

--- a/spt/OrangeBox/modules.hpp
+++ b/spt/OrangeBox/modules.hpp
@@ -2,11 +2,13 @@
 
 #include "modules\ClientDLL.hpp"
 #include "modules\EngineDLL.hpp"
+#include "modules\inputSystemDLL.hpp"
 #include "modules\ServerDLL.hpp"
 #include "modules\vguimatsurfaceDLL.hpp"
 
 extern EngineDLL engineDLL;
 extern ClientDLL clientDLL;
+extern InputSystemDLL inputSystemDLL;
 extern ServerDLL serverDLL;
 #ifndef OE
 extern VGui_MatSurfaceDLL vgui_matsurfaceDLL;

--- a/spt/OrangeBox/modules/inputSystemDLL.cpp
+++ b/spt/OrangeBox/modules/inputSystemDLL.cpp
@@ -1,0 +1,72 @@
+#include "stdafx.h"
+
+#include "inputsystemDLL.hpp"
+
+#include "convar.h"
+
+#include "..\modules.hpp"
+#include "..\patterns.hpp"
+
+#define DEF_FUTURE(name) auto f##name = FindAsync(ORIG_##name, patterns::inputsystem::##name);
+#define GET_HOOKEDFUTURE(future_name) \
+	{ \
+		auto pattern = f##future_name.get(); \
+		if (ORIG_##future_name) \
+		{ \
+			DevMsg("[inputsystem dll] Found " #future_name " at %p (using the %s pattern).\n", \
+			       ORIG_##future_name, \
+			       pattern->name()); \
+			patternContainer.AddHook(HOOKED_##future_name, (PVOID*)&ORIG_##future_name); \
+			for (int i = 0; true; ++i) \
+			{ \
+				if (patterns::inputsystem::##future_name.at(i).name() == pattern->name()) \
+				{ \
+					patternContainer.AddIndex((PVOID*)&ORIG_##future_name, i, pattern->name()); \
+					break; \
+				} \
+			} \
+		} \
+		else \
+		{ \
+			DevWarning("[inputsystem dll] Could not find " #future_name ".\n"); \
+		} \
+	}
+
+ConVar y_spt_focus_nosleep("y_spt_focus_nosleep", "0", 0, "Improves FPS while alt-tabbed.");
+
+void InputSystemDLL::Hook(const std::wstring& moduleName,
+                          void* moduleHandle,
+                          void* moduleBase,
+                          size_t moduleLength,
+                          bool needToIntercept)
+{
+	Clear();
+	m_Name = moduleName;
+	m_Base = moduleBase;
+	m_Length = moduleLength;
+	patternContainer.Init(moduleName);
+
+	DEF_FUTURE(CInputSystem__SleepUntilInput);
+	GET_HOOKEDFUTURE(CInputSystem__SleepUntilInput);
+
+	if (!ORIG_CInputSystem__SleepUntilInput)
+	{
+		Warning("y_spt_focus_nosleep has no effect.\n");
+	}
+
+	patternContainer.Hook();
+}
+
+void InputSystemDLL::Unhook()
+{
+	patternContainer.Unhook();
+}
+
+void InputSystemDLL::Clear() {}
+
+void InputSystemDLL::HOOKED_CInputSystem__SleepUntilInput(void* thisptr, int edx, int nMaxSleepTimeMS)
+{
+	if (y_spt_focus_nosleep.GetBool())
+		nMaxSleepTimeMS = 0;
+	inputSystemDLL.ORIG_CInputSystem__SleepUntilInput(thisptr, edx, nMaxSleepTimeMS);
+}

--- a/spt/OrangeBox/modules/inputSystemDLL.hpp
+++ b/spt/OrangeBox/modules/inputSystemDLL.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <SPTLib\IHookableNameFilter.hpp>
+#include "..\..\utils\patterncontainer.hpp"
+#include "inputsystem\iinputsystem.h"
+
+typedef void(__fastcall* _CInputSystem__SleepUntilInput)(void* thisptr, int edx, int nMaxSleepTimeMS);
+
+class InputSystemDLL : public IHookableNameFilter
+{
+public:
+	InputSystemDLL() : IHookableNameFilter({L"inputsystem.dll"}){};
+	virtual void Hook(const std::wstring& moduleName,
+	                  void* moduleHandle,
+	                  void* moduleBase,
+	                  size_t moduleLength,
+	                  bool needToIntercept);
+	virtual void Unhook();
+	virtual void Clear();
+	static void __fastcall HOOKED_CInputSystem__SleepUntilInput(void* thisptr, int edx, int nMaxSleepTimeMS);
+
+private:
+	_CInputSystem__SleepUntilInput ORIG_CInputSystem__SleepUntilInput;
+	PatternContainer patternContainer;
+};

--- a/spt/OrangeBox/patterns.hpp
+++ b/spt/OrangeBox/patterns.hpp
@@ -458,4 +458,9 @@ namespace patterns
 		    "56 6A 00 E8 ?? ?? ?? ?? 8B ?? ?? ?? ?? ?? 8B 01 8B ?? ?? ?? ?? ?? 83 C4 04 FF D2 8B F0 85 F6 74 09 8B 06 8B 50 08 8B CE FF D2");
 	} // namespace vguimatsurface
 
+	namespace inputsystem
+	{
+		PATTERNS(CInputSystem__SleepUntilInput, "5135", "8B 44 24 ?? 85 C0 7D ??");
+	} // namespace inputsystem
+
 } // namespace patterns

--- a/spt/OrangeBox/spt-serverplugin.cpp
+++ b/spt/OrangeBox/spt-serverplugin.cpp
@@ -375,6 +375,7 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 
 	Hooks::AddToHookedModules(&engineDLL);
 	Hooks::AddToHookedModules(&clientDLL);
+	Hooks::AddToHookedModules(&inputSystemDLL);
 	Hooks::AddToHookedModules(&serverDLL);
 #ifndef OE
 	Hooks::AddToHookedModules(&vgui_matsurfaceDLL);

--- a/spt/ipc/ipc-commands.cpp
+++ b/spt/ipc/ipc-commands.cpp
@@ -212,3 +212,17 @@ CON_COMMAND(y_spt_ipc_playback, "Outputs the current playback tick to IPC client
 	msg["length"] = scripts::g_TASReader.GetCurrentScriptLength();
 	ipc::Send(msg);
 }
+
+CON_COMMAND(y_spt_ipc_gamedir, "Output the game directory path to IPC client.\n")
+{
+	if (!ipc::IsActive())
+	{
+		Msg("No IPC client connected.\n");
+		return;
+	}
+
+	nlohmann::json msg;
+	msg["type"] = "gamedir";
+	msg["path"] = GetGameDir();
+	ipc::Send(msg);
+}

--- a/spt/ipc/ipc-commands.cpp
+++ b/spt/ipc/ipc-commands.cpp
@@ -188,16 +188,14 @@ CON_COMMAND(y_spt_ipc_echo,
 		text += args.Arg(i);
 	}
 
-	// The json library just calls exit instead of throwing an exception on invalid UTF-8
-	// so gotta check it's valid first.
-	if (IsValidUTF8(text.c_str()))
+	try
 	{
 		msg["text"] = text;
 		ipc::Send(msg);
 	}
-	else
+	catch (const std::exception& ex)
 	{
-		Msg("Text contained non-UTF8 characters, cannot send message.\n");
+		Msg("Error sending message: %s\n", ex.what());
 	}
 }
 

--- a/spt/ipc/ipc-spt.cpp
+++ b/spt/ipc/ipc-spt.cpp
@@ -37,6 +37,10 @@ namespace ipc
 
 	void CmdCallback(const nlohmann::json& msg)
 	{
+		nlohmann::json ackMsg;
+		ackMsg["type"] = "ack";
+		ipc::Send(ackMsg);
+
 		if (msg.find("cmd") != msg.end())
 		{
 			std::string cmd = msg["cmd"];


### PR DESCRIPTION
I added the ACK message since I was having some issue in client programs terminating too early after sending a packet which wouldn't be transmitted. Previously I avoided this by adding an arbitrary wait after sending the last packet but that's probably not too smart. I think this is because TCP sends the ACK after you place the packet in the buffer but doesn't necessarily wait for the server to receive it or some bullshit like that, so I needed an application level ACK.