### PR TITLE
Added y_spt_disable_shake

### DIFF
--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -96,6 +96,14 @@ void __fastcall ClientDLL::HOOKED_CViewEffects__Fade(void* thisptr, int edx, voi
 		clientDLL.ORIG_CViewEffects__Fade(thisptr, edx, data);
 }
 
+ConVar y_spt_disable_shake("y_spt_disable_shake", "0", FCVAR_ARCHIVE, "Disables all shakes.");
+
+void __fastcall ClientDLL::HOOKED_CViewEffects__Shake(void* thisptr, int edx, void* data)
+{
+	if (!y_spt_disable_shake.GetBool())
+		clientDLL.ORIG_CViewEffects__Shake(thisptr, edx, data);
+}
+
 #define DEF_FUTURE(name) auto f##name = FindAsync(ORIG_##name, patterns::client::##name);
 #define GET_HOOKEDFUTURE(future_name) \
 	{ \
@@ -174,6 +182,7 @@ void ClientDLL::Hook(const std::wstring& moduleName,
 	DEF_FUTURE(UTIL_TraceRay);
 	DEF_FUTURE(CGameMovement__CanUnDuckJump);
 	DEF_FUTURE(CViewEffects__Fade);
+	DEF_FUTURE(CViewEffects__Shake);
 	DEF_FUTURE(CHudDamageIndicator__GetDamagePosition);
 
 	GET_HOOKEDFUTURE(HudUpdate);
@@ -192,6 +201,7 @@ void ClientDLL::Hook(const std::wstring& moduleName,
 	GET_FUTURE(UTIL_TraceRay);
 	GET_FUTURE(CGameMovement__CanUnDuckJump);
 	GET_HOOKEDFUTURE(CViewEffects__Fade);
+	GET_HOOKEDFUTURE(CViewEffects__Shake);
 	GET_FUTURE(CHudDamageIndicator__GetDamagePosition);
 
 	if (DoesGameLookLikeHLS())
@@ -483,6 +493,9 @@ void ClientDLL::Hook(const std::wstring& moduleName,
 
 	if (!ORIG_CViewEffects__Fade)
 		Warning("y_spt_disable_fade 1 not available\n");
+
+	if (!ORIG_CViewEffects__Shake)
+		Warning("y_spt_disable_shake 1 not available\n");
 
 	if (!ORIG_MainViewOrigin || !ORIG_UTIL_TraceRay)
 		Warning("y_spt_hud_oob 1 has no effect\n");

--- a/spt/OrangeBox/modules/ClientDLL.hpp
+++ b/spt/OrangeBox/modules/ClientDLL.hpp
@@ -49,6 +49,7 @@ typedef void(__cdecl* _UTIL_TraceRay)(const Ray_t& ray,
                                       trace_t* ptr);
 typedef bool(__fastcall* _CGameMovement__CanUnDuckJump)(void* thisptr, int edx, trace_t& ptr);
 typedef void(__fastcall* _CViewEffects__Fade)(void* thisptr, int edx, void* data);
+typedef void(__fastcall* _CViewEffects__Shake)(void* thisptr, int edx, void* data);
 typedef const Vector&(__cdecl* _MainViewOrigin)();
 
 struct afterframes_entry_t
@@ -98,6 +99,7 @@ public:
 	                                                      int whatToDraw);
 	static void __fastcall HOOKED_CViewRender__Render(void* thisptr, int edx, void* rect);
 	static void __fastcall HOOKED_CViewEffects__Fade(void* thisptr, int edx, void* data);
+	static void __fastcall HOOKED_CViewEffects__Shake(void* thisptr, int edx, void* data);
 	void __cdecl HOOKED_DoImageSpaceMotionBlur_Func(void* view, int x, int y, int w, int h);
 	bool __fastcall HOOKED_CheckJumpButton_Func(void* thisptr, int edx);
 	void __stdcall HOOKED_HudUpdate_Func(bool bActive);
@@ -189,6 +191,7 @@ protected:
 	_CViewRender__Render ORIG_CViewRender__Render;
 	_CGameMovement__CanUnDuckJump ORIG_CGameMovement__CanUnDuckJump;
 	_CViewEffects__Fade ORIG_CViewEffects__Fade;
+	_CViewEffects__Shake ORIG_CViewEffects__Shake;
 	_MainViewOrigin ORIG_MainViewOrigin;
 
 	uintptr_t* pgpGlobals;

--- a/spt/OrangeBox/patterns.hpp
+++ b/spt/OrangeBox/patterns.hpp
@@ -268,6 +268,7 @@ namespace patterns
 		    "51 56 6A 14 8B F1 E8 ?? ?? ?? ?? 8B 54 24 10 8B C8 0F B7 02 89 44 24 10 83 C4 04 89 4C 24 04 DB 44 24 0C",
 		    "5377866",
 		    "55 8B EC 51 56 57 6A 14 89 4D FC E8 ?? ?? ?? ?? 8B 7D 08 8B F0");
+		PATTERNS(CViewEffects__Shake, "4104-5135", "56 8B 74 24 ?? 8B 06 85 C0");
 		PATTERNS(
 		    CHudDamageIndicator__GetDamagePosition,
 		    "5135",


### PR DESCRIPTION
You may have a question: why is this cvar needed, can't you just use **shake_stop**?

**shake_stop** needs to be input manually with each new shake.

**y_spt_disable_shake** automatically disables all shake.