### PR TITLE
VAG crash fix

### DIFF
--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -170,6 +170,11 @@ ConVar y_spt_hud_ent_info(
     "Display entity info on HUD. Format is \"[ent index],[prop regex],[prop regex],...,[prop regex];[ent index],...,[prop regex]\".\n");
 ConVar y_spt_hud_left("y_spt_hud_left", "0", FCVAR_CHEAT, "When set to 1, displays SPT HUD on the left.\n");
 ConVar y_spt_hud_oob("y_spt_hud_oob", "0", FCVAR_CHEAT, "Is the player OoB?");
+ConVar y_spt_prevent_vag_crash(
+    "y_spt_prevent_vag_crash",
+    "0",
+    FCVAR_CHEAT | FCVAR_DONTRECORD,
+    "Prevents the game from crashing from too many recursive teleports (useful when searching for vertical angle glitches).\n");
 
 ConVar _y_spt_overlay("_y_spt_overlay",
                       "0",

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -12,6 +12,7 @@ extern ConVar y_spt_stucksave;
 extern ConVar y_spt_piwsave;
 extern ConVar y_spt_pause_demo_on_tick;
 extern ConVar y_spt_on_slide_pause_for;
+extern ConVar y_spt_prevent_vag_crash;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/OrangeBox/modules/ServerDLL.hpp
+++ b/spt/OrangeBox/modules/ServerDLL.hpp
@@ -116,6 +116,8 @@ public:
 	                                                 datamap_t* pCurMap);
 	static int __cdecl HOOKED_DispatchSpawn(void* pEntity);
 	static void HOOKED_MiddleOfSlidingFunction();
+	static void HOOKED_MiddleOfTeleportTouchingEntity();
+	static void HOOKED_EndOfTeleportTouchingEntity();
 	static const Vector& __fastcall HOOKED_CGameMovement__GetPlayerMaxs(void* thisptr, int edx);
 	static const Vector& __fastcall HOOKED_CGameMovement__GetPlayerMins(void* thisptr, int edx);
 	static void __cdecl HOOKED_SetPredictionRandomSeed(void* usercmd);
@@ -209,6 +211,8 @@ protected:
 	_TraceFirePortal ORIG_TraceFirePortal;
 	_SlidingAndOtherStuff ORIG_SlidingAndOtherStuff;
 	void* ORIG_MiddleOfSlidingFunction;
+	void* ORIG_MiddleOfTeleportTouchingEntity;
+	void* ORIG_EndOfTeleportTouchingEntity;
 	_SetPredictionRandomSeed ORIG_SetPredictionRandomSeed;
 
 	ptrdiff_t off1M_nOldButtons;

--- a/spt/OrangeBox/modules/ServerDLL.hpp
+++ b/spt/OrangeBox/modules/ServerDLL.hpp
@@ -143,6 +143,8 @@ public:
 	                                             bool bTest);
 	void __fastcall HOOKED_SlidingAndOtherStuff_Func(void* thisptr, int edx, void* a, void* b);
 	void HOOKED_MiddleOfSlidingFunction_Func();
+	void HOOKED_EndOfTeleportTouchingEntity_Func();
+	static void __fastcall HOOKED_MiddleOfTeleportTouchingEntity_Func(void* portalPtr, void* tpStackPointer);
 	bool CanTracePlayerBBox();
 	int GetCommandNumber();
 	void TracePlayerBBox(const Vector& start,
@@ -233,4 +235,6 @@ protected:
 
 	bool sliding;
 	bool wasSliding;
+
+	int recursiveTeleportCount;
 };

--- a/spt/OrangeBox/patterns.hpp
+++ b/spt/OrangeBox/patterns.hpp
@@ -459,7 +459,9 @@ namespace patterns
 		PATTERNS(CGameMovement__DecayPunchAngle,
 		         "5135",
 		         "83 EC 0C 56 8B F1 8B 56 ?? D9 82 ?? ?? ?? ?? 8D 8A ?? ?? ?? ??");
-		PATTERNS(MiddleOfTeleportTouchingEntity, "5135", "8B 80 24 27 00 00 8B CD 8B A9 24 27 00 00 89 44 24 3C");
+		PATTERNS(MiddleOfTeleportTouchingEntity,
+		         "5135",
+		         "8B 80 24 27 00 00 8B CD 8B A9 24 27 00 00 89 44 24 3C");
 		PATTERNS(EndOfTeleportTouchingEntity, "5135", "E8 E3 CC DB FF 8D 8C 24 B8 00 00 00 E8 17 45 F5 FF");
 	} // namespace server
 

--- a/spt/OrangeBox/patterns.hpp
+++ b/spt/OrangeBox/patterns.hpp
@@ -459,6 +459,8 @@ namespace patterns
 		PATTERNS(CGameMovement__DecayPunchAngle,
 		         "5135",
 		         "83 EC 0C 56 8B F1 8B 56 ?? D9 82 ?? ?? ?? ?? 8D 8A ?? ?? ?? ??");
+		PATTERNS(MiddleOfTeleportTouchingEntity, "5135", "8B 80 24 27 00 00 8B CD 8B A9 24 27 00 00 89 44 24 3C");
+		PATTERNS(EndOfTeleportTouchingEntity, "5135", "E8 E3 CC DB FF 8D 8C 24 B8 00 00 00 E8 17 45 F5 FF");
 	} // namespace server
 
 	namespace vguimatsurface


### PR DESCRIPTION
Added the `y_spt_prevent_vag_crash` var to prevent the "no free edicts" crash when trying a vertical angle glitch which makes searching for them slightly less painful. This also makes using a script for this kind of search (such as one through spt_ipc) much less annoying to use.

This kind of crash happens when a VAG teleports an entity slightly behind the entry portal after the 2nd teleport; which can cause a 4th teleport right back to where the VAG started. This would eventually cause a stack overflow, but since a physicsshadowclone gets created every time a teleport happens this way, the edicts all get used up without being freed for long enough.

To fix this I hooked the teleport function before and after the recursive call, and use a counter to keep track of the recursive depth. If the depth exceeds 3 (which is the max depth for a normal VAG), I nudge the teleported entity so that it ends up in front of the next portal it teleports to, breaking the cycle.