### PR TITLE
y_spt_disable_tone_map_reset

### DIFF
--- a/spt/OrangeBox/cvars.cpp
+++ b/spt/OrangeBox/cvars.cpp
@@ -25,6 +25,11 @@ ConVar y_spt_on_slide_pause_for("y_spt_on_slide_pause_for",
                                 "0",
                                 0,
                                 "Whenever sliding occurs in DMoMM, pause for this many ticks.");
+ConVar y_spt_disable_tone_map_reset(
+    "y_spt_disable_tone_map_reset",
+    "0",
+    0,
+    "Prevents the tone map getting reset (during each load), useful for keeping colors the same between demos");
 
 ConVar tas_strafe("tas_strafe", "0", FCVAR_TAS_RESET);
 ConVar tas_strafe_type(

--- a/spt/OrangeBox/cvars.hpp
+++ b/spt/OrangeBox/cvars.hpp
@@ -13,6 +13,7 @@ extern ConVar y_spt_piwsave;
 extern ConVar y_spt_pause_demo_on_tick;
 extern ConVar y_spt_on_slide_pause_for;
 extern ConVar y_spt_prevent_vag_crash;
+extern ConVar y_spt_disable_tone_map_reset;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/OrangeBox/modules/ClientDLL.cpp
+++ b/spt/OrangeBox/modules/ClientDLL.cpp
@@ -184,6 +184,7 @@ void ClientDLL::Hook(const std::wstring& moduleName,
 	DEF_FUTURE(CViewEffects__Fade);
 	DEF_FUTURE(CViewEffects__Shake);
 	DEF_FUTURE(CHudDamageIndicator__GetDamagePosition);
+	DEF_FUTURE(ResetToneMapping);
 
 	GET_HOOKEDFUTURE(HudUpdate);
 	GET_HOOKEDFUTURE(GetButtonBits);
@@ -203,6 +204,7 @@ void ClientDLL::Hook(const std::wstring& moduleName,
 	GET_HOOKEDFUTURE(CViewEffects__Fade);
 	GET_HOOKEDFUTURE(CViewEffects__Shake);
 	GET_FUTURE(CHudDamageIndicator__GetDamagePosition);
+	GET_HOOKEDFUTURE(ResetToneMapping);
 
 	if (DoesGameLookLikeHLS())
 	{
@@ -500,6 +502,9 @@ void ClientDLL::Hook(const std::wstring& moduleName,
 	if (!ORIG_MainViewOrigin || !ORIG_UTIL_TraceRay)
 		Warning("y_spt_hud_oob 1 has no effect\n");
 
+	if (!ORIG_ResetToneMapping)
+		Warning("y_spt_disable_tone_map_reset has no effect\n");
+
 	patternContainer.Hook();
 }
 
@@ -525,6 +530,7 @@ void ClientDLL::Clear()
 	ORIG_CViewRender__Render = nullptr;
 	ORIG_UTIL_TraceRay = nullptr;
 	ORIG_MainViewOrigin = nullptr;
+	ORIG_ResetToneMapping = nullptr;
 
 	pgpGlobals = nullptr;
 	off1M_nOldButtons = 0;
@@ -1179,4 +1185,10 @@ void ClientDLL::HOOKED_CViewRender__Render_Func(void* thisptr, int edx, void* re
 		renderingOverlay = false;
 	}
 #endif
+}
+
+void ClientDLL::HOOKED_ResetToneMapping(float value)
+{
+	if (!y_spt_disable_tone_map_reset.GetBool())
+		clientDLL.ORIG_ResetToneMapping(value);
 }

--- a/spt/OrangeBox/modules/ClientDLL.hpp
+++ b/spt/OrangeBox/modules/ClientDLL.hpp
@@ -51,6 +51,7 @@ typedef bool(__fastcall* _CGameMovement__CanUnDuckJump)(void* thisptr, int edx, 
 typedef void(__fastcall* _CViewEffects__Fade)(void* thisptr, int edx, void* data);
 typedef void(__fastcall* _CViewEffects__Shake)(void* thisptr, int edx, void* data);
 typedef const Vector&(__cdecl* _MainViewOrigin)();
+typedef void(__cdecl* _ResetToneMapping)(float value);
 
 struct afterframes_entry_t
 {
@@ -117,6 +118,7 @@ public:
 	                                                    int nClearFlags,
 	                                                    int whatToDraw);
 	void __fastcall HOOKED_CViewRender__Render_Func(void* thisptr, int edx, void* rect);
+	static void __cdecl HOOKED_ResetToneMapping(float value);
 
 	void DelayAfterframesQueue(int delay);
 	void AddIntoAfterframesQueue(const afterframes_entry_t& entry);
@@ -193,6 +195,7 @@ protected:
 	_CViewEffects__Fade ORIG_CViewEffects__Fade;
 	_CViewEffects__Shake ORIG_CViewEffects__Shake;
 	_MainViewOrigin ORIG_MainViewOrigin;
+	_ResetToneMapping ORIG_ResetToneMapping;
 
 	uintptr_t* pgpGlobals;
 	ptrdiff_t offM_pCommands;

--- a/spt/OrangeBox/patterns.hpp
+++ b/spt/OrangeBox/patterns.hpp
@@ -275,6 +275,12 @@ namespace patterns
 		    CHudDamageIndicator__GetDamagePosition,
 		    "5135",
 		    "83 EC 18 E8 ?? ?? ?? ?? e8 ?? ?? ?? ?? 8B 08 89 4C 24 0C 8B 50 04 6A 00 89 54 24 14 8B 40 08 6A 00 8D 4C 24 08 51 8D 54 24 18 52 89 44 24 24");
+		PATTERNS(
+		    ResetToneMapping,
+		    "5135",
+		    "8B 0D ?? ?? ?? ?? 8B 01 8B 90 7C 01 00 00 56 FF D2 8B F0 85 F6 74 09 8B 06 8B 50 08 8B CE FF D2 8B 06 D9 44 24 08",
+		    "1910503",
+		    "55 8B EC 8B 0D ?? ?? ?? ?? 8B 01 8B 90 88 01 00 00 56 FF D2 8B F0 85 F6 74 09 8B 06 8B 50 08 8B CE FF D2 8B 06 F3 0F 10 45 08");
 	} // namespace client
 
 	namespace server

--- a/spt/OrangeBox/patterns.hpp
+++ b/spt/OrangeBox/patterns.hpp
@@ -280,7 +280,9 @@ namespace patterns
 		    "5135",
 		    "8B 0D ?? ?? ?? ?? 8B 01 8B 90 7C 01 00 00 56 FF D2 8B F0 85 F6 74 09 8B 06 8B 50 08 8B CE FF D2 8B 06 D9 44 24 08",
 		    "1910503",
-		    "55 8B EC 8B 0D ?? ?? ?? ?? 8B 01 8B 90 88 01 00 00 56 FF D2 8B F0 85 F6 74 09 8B 06 8B 50 08 8B CE FF D2 8B 06 F3 0F 10 45 08");
+		    "55 8B EC 8B 0D ?? ?? ?? ?? 8B 01 8B 90 88 01 00 00 56 FF D2 8B F0 85 F6 74 09 8B 06 8B 50 08 8B CE FF D2 8B 06 F3 0F 10 45 08",
+		    "5377866",
+		    "55 8B EC 8B 0D ?? ?? ?? ?? 56 8B 01 FF 90 88 01 00 00 8B F0 85 F6 74 07 8B 06 8B CE FF 50 08 8B 06 D9 45 08");
 	} // namespace client
 
 	namespace server


### PR DESCRIPTION
Useful for rendering runs with several demos, allows the color to transition smoothly from one demo to the next.

`y_spt_disable_tone_map_reset 0` (default behavior):

![value at 0](https://user-images.githubusercontent.com/34390438/124687444-c0b67180-de89-11eb-8fdf-fdd9d77bf579.gif)

`y_spt_disable_tone_map_reset 1`:

![value at 1](https://user-images.githubusercontent.com/34390438/124687459-cad87000-de89-11eb-89ab-f4af7fa524a6.gif)
