### PR TITLE
Added ihud and tas_pause crash fix

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1379,6 +1379,7 @@
     <ClCompile Include="spt\features\graphics.cpp" />
     <ClCompile Include="spt\features\hops_hud.cpp" />
     <ClCompile Include="spt\features\hud.cpp" />
+    <ClCompile Include="spt\features\ihud.cpp" />
     <ClCompile Include="spt\features\ipc-spt.cpp" />
     <ClCompile Include="spt\features\isg.cpp" />
     <ClCompile Include="spt\features\nosleep.cpp" />
@@ -1596,6 +1597,7 @@
     <ClInclude Include="spt\features\demo.hpp" />
     <ClInclude Include="spt\features\generic.hpp" />
     <ClInclude Include="spt\features\hud.hpp" />
+    <ClInclude Include="spt\features\ihud.hpp" />
     <ClInclude Include="spt\features\overlay.hpp" />
     <ClInclude Include="spt\features\playerio.hpp" />
     <ClInclude Include="spt\features\rng.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -211,6 +211,9 @@
     <ClCompile Include="spt\features\hops_hud.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\ihud.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">
@@ -466,6 +469,9 @@
       <Filter>spt\features</Filter>
     </ClInclude>
     <ClInclude Include="spt\features\hud.hpp">
+      <Filter>spt\features</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\features\ihud.hpp">
       <Filter>spt\features</Filter>
     </ClInclude>
   </ItemGroup>

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -82,6 +82,17 @@ extern ConVar y_spt_hud_left;
 extern ConVar y_spt_hud_oob;
 extern ConVar y_spt_hud_isg;
 
+extern ConVar y_spt_ihud;
+extern ConVar y_spt_ihud_button_color;
+extern ConVar y_spt_ihud_shadow_color;
+extern ConVar y_spt_ihud_font_color;
+extern ConVar y_spt_ihud_shadow_font_color;
+extern ConVar y_spt_ihud_grid_size;
+extern ConVar y_spt_ihud_grid_padding;
+extern ConVar y_spt_ihud_font;
+extern ConVar y_spt_ihud_x;
+extern ConVar y_spt_ihud_y;
+
 extern ConVar _y_spt_overlay;
 extern ConVar _y_spt_overlay_type;
 extern ConVar _y_spt_overlay_portal;

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -1,0 +1,278 @@
+#include "stdafx.h"
+#if defined(SSDK2007)
+#include "ihud.hpp"
+
+#include "..\cvars.hpp"
+#include "playerio.hpp"
+#include "..\sptlib-wrapper.hpp"
+#include "Color.h"
+
+InputHud spt_ihud;
+
+ConVar y_spt_ihud("y_spt_ihud", "0", FCVAR_CHEAT, "Draws movement inputs of client.\n0 = Default,\n1 = tas.\n");
+ConVar y_spt_ihud_button_color("y_spt_ihud_button_color",
+                               "0 0 0 233",
+                               FCVAR_CHEAT,
+                               "RGBA button color of input HUD.\n");
+ConVar y_spt_ihud_shadow_color("y_spt_ihud_shadow_color",
+                               "0 0 0 66",
+                               FCVAR_CHEAT,
+                               "RGBA button shadow color of input HUD.\n");
+ConVar y_spt_ihud_font_color("y_spt_ihud_font_color",
+                             "255 255 255 233",
+                             FCVAR_CHEAT,
+                             "RGBA font color of input HUD.\n");
+ConVar y_spt_ihud_shadow_font_color("y_spt_ihud_shadow_font_color",
+                                    "255 255 255 66",
+                                    FCVAR_CHEAT,
+                                    "RGBA button shadow font color of input HUD.\n");
+ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", FCVAR_CHEAT, "Grid size of input HUD.\n");
+ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding", "2", FCVAR_CHEAT, "Padding between grids of input HUD.");
+ConVar y_spt_ihud_font("y_spt_ihud_font", "Trebuchet20", FCVAR_CHEAT, "Font of input HUD.");
+ConVar y_spt_ihud_x("y_spt_ihud_x", "2", FCVAR_CHEAT, "X offset of input HUD.\n");
+ConVar y_spt_ihud_y("y_spt_ihud_y", "2", FCVAR_CHEAT, "Y offset of input HUD.\n");
+
+bool InputHud::ShouldLoadFeature()
+{
+	return spt_hud.ShouldLoadFeature();
+}
+
+void InputHud::InitHooks()
+{
+	FIND_PATTERN(client, DecodeUserCmdFromBuffer);
+	HOOK_FUNCTION(client, DecodeUserCmdFromBuffer);
+}
+
+void InputHud::LoadFeature()
+{
+	if (loadingSuccessful)
+	{
+		ihudFont = spt_hud.scheme->GetFont(y_spt_ihud_font.GetString(), false);
+
+		bool result = AddHudCallback("ihud", std::bind(&InputHud::DrawInputHud, this), y_spt_ihud);
+		if (result)
+		{
+			InitConcommandBase(y_spt_ihud_button_color);
+			InitConcommandBase(y_spt_ihud_shadow_color);
+			InitConcommandBase(y_spt_ihud_font_color);
+			InitConcommandBase(y_spt_ihud_shadow_font_color);
+			InitConcommandBase(y_spt_ihud_grid_size);
+			InitConcommandBase(y_spt_ihud_grid_padding);
+			InitConcommandBase(y_spt_ihud_font);
+			InitConcommandBase(y_spt_ihud_x);
+			InitConcommandBase(y_spt_ihud_y);
+		}
+	}
+}
+
+void InputHud::PreHook()
+{
+	loadingSuccessful = !!(ORIG_DecodeUserCmdFromBuffer);
+}
+
+void InputHud::UnloadFeature() {}
+
+void InputHud::SetInputInfo(int button, Vector movement)
+{
+	if (awaitingFrameDraw)
+	{
+		buttonBits |= button;
+	}
+	else
+	{
+		buttonBits = button;
+	}
+	inputMovement = movement;
+	awaitingFrameDraw = true;
+}
+
+void InputHud::DrawInputHud()
+{
+	if (awaitingFrameDraw)
+	{
+		previousAng = currentAng;
+		float va[3];
+		EngineGetViewAngles(va);
+		currentAng = Vector(va[0], va[1], va[3]);
+		awaitingFrameDraw = false;
+	}
+	auto surface = spt_hud.surface;
+	auto scheme = spt_hud.scheme;
+	auto screen = spt_hud.screen;
+	ihudFont = scheme->GetFont(y_spt_ihud_font.GetString(), false);
+	const int IN_ATTACK = (1 << 0);
+	const int IN_JUMP = (1 << 1);
+	const int IN_DUCK = (1 << 2);
+	const int IN_FORWARD = (1 << 3);
+	const int IN_BACK = (1 << 4);
+	const int IN_USE = (1 << 5);
+	const int IN_MOVELEFT = (1 << 9);
+	const int IN_MOVERIGHT = (1 << 10);
+	const int IN_ATTACK2 = (1 << 11);
+
+	int xOffset = y_spt_ihud_x.GetInt();
+	int yOffset = y_spt_ihud_y.GetInt();
+	int gridSize = y_spt_ihud_grid_size.GetInt();
+	int padding = y_spt_ihud_grid_padding.GetInt();
+
+	Color buttonColor;
+	Color shadowColor;
+	Color buttonFontColor;
+	Color shadowFontColor;
+
+#define GET_COLOR(cmd, color) \
+	{ \
+		static int r = 0, g = 0, b = 0, a = 0; \
+		if (strcmp("", cmd.GetString()) != 0) \
+		{ \
+			sscanf(cmd.GetString(), "%d %d %d %d", &r, &g, &b, &a); \
+		} \
+		color = Color(r, g, b, a); \
+	}
+
+	GET_COLOR(y_spt_ihud_button_color, buttonColor);
+	GET_COLOR(y_spt_ihud_shadow_color, shadowColor);
+	GET_COLOR(y_spt_ihud_font_color, buttonFontColor);
+	GET_COLOR(y_spt_ihud_shadow_font_color, shadowFontColor);
+
+#define DRAW_BUTTON(button, col, row, size, colSize, rowSize, text) \
+	{ \
+		Color btnColor = (buttonBits & (button)) ? buttonColor : shadowColor; \
+		Color fontColor = (buttonBits & (button)) ? buttonFontColor : shadowFontColor; \
+		DrawRectAndCenterTxt(btnColor, \
+		                     xOffset + col * (size + padding), \
+		                     yOffset + row * (size + padding), \
+		                     xOffset + (col + colSize) * (size + padding) - padding, \
+		                     yOffset + (row + rowSize) * (size + padding) - padding, \
+		                     ihudFont, \
+		                     fontColor, \
+		                     surface, \
+		                     text); \
+	}
+
+	if (y_spt_ihud.GetInt() == 2)
+	{
+		gridSize /= 2;
+
+		// Angle
+		Vector ang = currentAng - previousAng;
+		while (ang.x < -180.0f)
+			ang.x += 360.0f;
+		if (ang.x > 180.0f)
+			ang.x -= 360.0f;
+		float len = ang.Length();
+		if (len > 0)
+		{
+			ang /= len;
+			ang *= pow(len / 180.0f, 0.2);
+			ang.y *= -1;
+		}
+
+		// Movement
+		Vector movement = inputMovement;
+		int movementSpeed = movement.Length();
+		int maxSpeed = movementSpeed > 150 ? 450 : 150; // For Portal TAS
+		movement /= movementSpeed > maxSpeed ? movementSpeed : maxSpeed;
+
+		// Draw
+		int r = 2 * gridSize;
+		int cX1 = (xOffset + xOffset + 5 * (gridSize + padding) - padding) / 2;
+		int cY1 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
+		int cX2 = (xOffset + 5 * (gridSize + padding) + xOffset + 10 * (gridSize + padding) - padding) / 2;
+		int cY2 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
+		int movX = cX1 + r * movement.x;
+		int movY = cY1 - r * movement.y;
+		int angX = cX2 + r * ang.y;
+		int angY = cY2 + r * ang.x;
+		surface->DrawSetColor(buttonColor);
+		surface->DrawFilledRect(xOffset,
+		                        yOffset,
+		                        xOffset + 5 * (gridSize + padding) - padding,
+		                        yOffset + 5 * (gridSize + padding) - padding);
+		surface->DrawFilledRect(xOffset + 5 * (gridSize + padding),
+		                        yOffset,
+		                        xOffset + 10 * (gridSize + padding) - padding,
+		                        yOffset + 5 * (gridSize + padding) - padding);
+
+		int th = surface->GetFontTall(ihudFont);
+		surface->DrawSetTextFont(ihudFont);
+		surface->DrawSetTextColor(buttonFontColor);
+		wchar_t* text = L"move analog";
+		surface->DrawSetTextPos(cX1 - r, cY1 - r - th);
+		surface->DrawPrintText(text, wcslen(text));
+		text = L"view analog";
+		surface->DrawSetTextPos(cX2 - r, cY2 - r - th);
+		surface->DrawPrintText(text, wcslen(text));
+
+		int joyStickSize = gridSize / 5;
+		surface->DrawSetColor(255, 200, 100, 100); // oragne
+		surface->DrawOutlinedCircle(cX1, cY1, r, 64);
+		surface->DrawOutlinedRect(cX1 - r, cY1 - r, cX1 + r, cY1 + r);
+		surface->DrawOutlinedCircle(movX, movY, joyStickSize, 16);
+		surface->DrawLine(cX1 - r, cY1, cX1 + r, cY1);
+		surface->DrawLine(cX1, cY1 - r, cX1, cY1 + r);
+		surface->DrawLine(cX1, cY1, movX, movY);
+		surface->DrawSetColor(100, 200, 255, 100); // blue
+		surface->DrawOutlinedCircle(cX2, cY2, r, 64);
+		surface->DrawOutlinedRect(cX2 - r, cY2 - r, cX2 + r, cY2 + r);
+		surface->DrawOutlinedCircle(angX, angY, joyStickSize, 16);
+		surface->DrawLine(cX2 - r, cY2, cX2 + r, cY2);
+		surface->DrawLine(cX2, cY2 - r, cX2, cY2 + r);
+		surface->DrawLine(cX2, cY2, angX, angY);
+
+		DRAW_BUTTON(IN_DUCK, 0, 5, gridSize, 2, 1, L"Duck");
+		DRAW_BUTTON(IN_USE, 2, 5, gridSize, 2, 1, L"Use");
+		DRAW_BUTTON(IN_JUMP, 4, 5, gridSize, 2, 1, L"Jump");
+		DRAW_BUTTON(IN_ATTACK, 6, 5, gridSize, 2, 1, L"Blue");
+		DRAW_BUTTON(IN_ATTACK2, 8, 5, gridSize, 2, 1, L"Orange");
+	}
+	else
+	{
+		DRAW_BUTTON(IN_FORWARD, 2, 0, gridSize, 1, 1, L"W");
+		DRAW_BUTTON(IN_USE, 3, 0, gridSize, 1, 1, L"E");
+		DRAW_BUTTON(IN_MOVELEFT, 1, 1, gridSize, 1, 1, L"A");
+		DRAW_BUTTON(IN_BACK, 2, 1, gridSize, 1, 1, L"S");
+		DRAW_BUTTON(IN_MOVERIGHT, 3, 1, gridSize, 1, 1, L"D");
+		DRAW_BUTTON(IN_DUCK, 0, 2, gridSize, 1, 1, L"Duck");
+		DRAW_BUTTON(IN_JUMP, 1, 2, gridSize, 3, 1, L"Jump");
+		DRAW_BUTTON(IN_ATTACK, 4, 2, gridSize, 1, 1, L"L");
+		DRAW_BUTTON(IN_ATTACK2, 5, 2, gridSize, 1, 1, L"R");
+	}
+}
+
+void InputHud::DrawRectAndCenterTxt(Color buttonColor,
+                                    int x0,
+                                    int y0,
+                                    int x1,
+                                    int y1,
+                                    vgui::HFont font,
+                                    Color textColor,
+                                    IMatSystemSurface* surface,
+                                    const wchar_t* text)
+{
+	surface->DrawSetColor(buttonColor);
+	surface->DrawFilledRect(x0, y0, x1, y1);
+
+	int tw, th;
+	surface->GetTextSize(font, text, tw, th);
+	int xc = x0 + ((x1 - x0) / 2);
+	int yc = y0 + ((y1 - y0) / 2);
+	surface->DrawSetTextFont(font);
+	surface->DrawSetTextColor(textColor);
+	surface->DrawSetTextPos(xc - (tw / 2), yc - (th / 2));
+	surface->DrawPrintText(text, wcslen(text));
+}
+
+void __fastcall InputHud::HOOKED_DecodeUserCmdFromBuffer(void* thisptr, int edx, bf_read& buf, int sequence_number)
+{
+	spt_ihud.ORIG_DecodeUserCmdFromBuffer(thisptr, edx, buf, sequence_number);
+
+	auto m_pCommands =
+	    *reinterpret_cast<uintptr_t*>(reinterpret_cast<uintptr_t>(thisptr) + spt_playerio.offM_pCommands);
+	auto pCmd = m_pCommands + spt_playerio.sizeofCUserCmd * (sequence_number % 90);
+	auto cmd = reinterpret_cast<CUserCmd*>(pCmd);
+	spt_ihud.SetInputInfo(cmd->buttons, Vector(cmd->sidemove, cmd->forwardmove, cmd->upmove));
+	pCmd = 0;
+}
+
+#endif

--- a/spt/features/ihud.hpp
+++ b/spt/features/ihud.hpp
@@ -37,6 +37,7 @@ private:
 	                                                      bf_read& buf,
 	                                                      int sequence_number);
 	_DecodeUserCmdFromBuffer ORIG_DecodeUserCmdFromBuffer = nullptr;
+	void CreateMove(uintptr_t pCmd);
 	void DrawRectAndCenterTxt(Color buttonColor,
 	                          int x0,
 	                          int y0,

--- a/spt/features/ihud.hpp
+++ b/spt/features/ihud.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#if defined(SSDK2007)
+#include "..\feature.hpp"
+#include "hud.hpp"
+#include "basehandle.h"
+
+#ifdef OE
+#include "..\game_shared\usercmd.h"
+#else
+#include "usercmd.h"
+#endif
+
+typedef void(__fastcall* _DecodeUserCmdFromBuffer)(void* thisptr, int edx, bf_read& buf, int sequence_number);
+
+// Input HUD
+class InputHud : public Feature
+{
+public:
+	void DrawInputHud();
+	void SetInputInfo(int button, Vector movement);
+
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void InitHooks() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void PreHook() override;
+
+	virtual void UnloadFeature() override;
+
+private:
+	static void __fastcall HOOKED_DecodeUserCmdFromBuffer(void* thisptr,
+	                                                      int edx,
+	                                                      bf_read& buf,
+	                                                      int sequence_number);
+	_DecodeUserCmdFromBuffer ORIG_DecodeUserCmdFromBuffer = nullptr;
+	void DrawRectAndCenterTxt(Color buttonColor,
+	                          int x0,
+	                          int y0,
+	                          int x1,
+	                          int y1,
+	                          vgui::HFont font,
+	                          Color textColor,
+	                          IMatSystemSurface* surface,
+	                          const wchar_t* text);
+	Vector inputMovement;
+	Vector currentAng;
+	Vector previousAng;
+	vgui::HFont ihudFont;
+	int buttonBits;
+
+	bool awaitingFrameDraw;
+
+	bool loadingSuccessful = false;
+};
+
+extern InputHud spt_ihud;
+
+#endif

--- a/spt/features/pause.cpp
+++ b/spt/features/pause.cpp
@@ -7,6 +7,8 @@
 
 ConVar y_spt_pause("y_spt_pause", "0", FCVAR_ARCHIVE);
 
+extern ConVar tas_pause;
+
 // y_spt_pause stuff
 class PauseFeature : public Feature
 {
@@ -132,6 +134,11 @@ void PauseFeature::LoadFeature()
 void PauseFeature::SV_ActivateServer(bool result)
 {
 	DevMsg("Engine call: SV_ActivateServer() => %s;\n", (result ? "true" : "false"));
+
+	if (tas_pause.GetBool())
+	{
+		tas_pause.SetValue(0);
+	}
 
 	if (spt_generic.ORIG_SetPaused && pM_bLoadgame && pGameServer)
 	{

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -13,12 +13,6 @@
 #include "..\overlay\portal_camera.hpp"
 #include "ihud.hpp"
 
-#ifdef OE
-#include "..\game_shared\usercmd.h"
-#else
-#include "usercmd.h"
-#endif
-
 #ifdef SSDK2007
 #include "mathlib\vmatrix.h"
 #endif
@@ -146,6 +140,8 @@ void PlayerIOFeature::PreHook()
 	if (ORIG_CreateMove)
 	{
 		int index = GetPatternIndex((void**)&ORIG_CreateMove);
+		
+		CreateMoveSignal.Works = true;
 
 		switch (index)
 		{
@@ -419,10 +415,7 @@ void __fastcall PlayerIOFeature::HOOKED_CreateMove_Func(void* thisptr,
 
 	ORIG_CreateMove(thisptr, edx, sequence_number, input_sample_frametime, active);
 
-#if defined(SSDK2007)
-	auto cmd = reinterpret_cast<CUserCmd*>(pCmd);
-	spt_ihud.SetInputInfo(cmd->buttons, Vector(cmd->sidemove, cmd->forwardmove, cmd->upmove));
-#endif
+	CreateMoveSignal(pCmd);
 
 	pCmd = 0;
 }

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -140,7 +140,7 @@ void PlayerIOFeature::PreHook()
 	if (ORIG_CreateMove)
 	{
 		int index = GetPatternIndex((void**)&ORIG_CreateMove);
-		
+
 		CreateMoveSignal.Works = true;
 
 		switch (index)

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -11,6 +11,13 @@
 #include "interfaces.hpp"
 #include "signals.hpp"
 #include "..\overlay\portal_camera.hpp"
+#include "ihud.hpp"
+
+#ifdef OE
+#include "..\game_shared\usercmd.h"
+#else
+#include "usercmd.h"
+#endif
 
 #ifdef SSDK2007
 #include "mathlib\vmatrix.h"
@@ -411,6 +418,9 @@ void __fastcall PlayerIOFeature::HOOKED_CreateMove_Func(void* thisptr,
 	pCmd = m_pCommands + sizeofCUserCmd * (sequence_number % 90);
 
 	ORIG_CreateMove(thisptr, edx, sequence_number, input_sample_frametime, active);
+
+	auto cmd = reinterpret_cast<CUserCmd*>(pCmd);
+	spt_ihud.SetInputInfo(cmd->buttons, Vector(cmd->sidemove, cmd->forwardmove, cmd->upmove));
 
 	pCmd = 0;
 }

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -419,8 +419,10 @@ void __fastcall PlayerIOFeature::HOOKED_CreateMove_Func(void* thisptr,
 
 	ORIG_CreateMove(thisptr, edx, sequence_number, input_sample_frametime, active);
 
+#if defined(SSDK2007)
 	auto cmd = reinterpret_cast<CUserCmd*>(pCmd);
 	spt_ihud.SetInputInfo(cmd->buttons, Vector(cmd->sidemove, cmd->forwardmove, cmd->upmove));
+#endif
 
 	pCmd = 0;
 }

--- a/spt/patterns.hpp
+++ b/spt/patterns.hpp
@@ -219,6 +219,10 @@ namespace patterns
 		    "BMS-Retail",
 		    "55 8B EC 83 EC 54 53 56 8B 75 08 B8 ?? ?? ?? ?? F7 EE 57 03 D6 8B F9 C1 FA 06 8B CE 8B C2 C1 E8 1F 03 C2 6B C0 5A");
 		PATTERNS(
+		    DecodeUserCmdFromBuffer,
+		    "5135",
+		    "83 ec 54 33 c0 d9 ee 89 44 24 40 d9 54 24 0c 89 44 24 44 d9 54 24 10 89 44 24 48 d9 54 24 14 89 44 24 50 d9 54 24 18 89 44 24 04");
+		PATTERNS(
 		    MiddleOfCAM_Think,
 		    "5135",
 		    "8B 54 24 74 8B 4C 24 78 83 EC 0C 8B C4 89 10 8B 94 24 88 00 00 00 89 48 04 89 50 08 E8",

--- a/spt/utils/signals.cpp
+++ b/spt/utils/signals.cpp
@@ -10,3 +10,4 @@ Gallant::Signal1<bool> OngroundSignal;
 Gallant::Signal0<void> TickSignal;
 Gallant::Signal3<void*, int, bool> SetPausedSignal;
 Gallant::Signal1<bool> SV_ActivateServerSignal;
+Gallant::Signal1<uintptr_t> CreateMoveSignal;

--- a/spt/utils/signals.hpp
+++ b/spt/utils/signals.hpp
@@ -11,3 +11,4 @@ extern Gallant::Signal1<bool> OngroundSignal;
 extern Gallant::Signal0<void> TickSignal;
 extern Gallant::Signal3<void*, int, bool> SetPausedSignal;
 extern Gallant::Signal1<bool> SV_ActivateServerSignal;
+extern Gallant::Signal1<uintptr_t> CreateMoveSignal;


### PR DESCRIPTION
New commands:
y_spt_ihud
y_spt_ihud_button_color
y_spt_ihud_font
y_spt_ihud_grid_padding
y_spt_ihud_grid_size
y_spt_ihud_shadow_color
y_spt_ihud_shadow_font_color
y_spt_ihud_x
y_spt_ihud_y

y_spt_ihud 1 for normal ihud
y_spt_ihud 2 for analog movement / view
![ihud](https://user-images.githubusercontent.com/72735402/147422373-6ea911f8-bc22-4ef5-b49e-bd1555af6325.png)

Prevent load crash while tas_pause.
(Auto set tas_pause to 0 when loading)