### PR TITLE
tas_restart_game

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1148,6 +1148,7 @@
     <ClCompile Include="spt\features\overlay.cpp" />
     <ClCompile Include="spt\features\pause.cpp" />
     <ClCompile Include="spt\features\playerio.cpp" />
+    <ClCompile Include="spt\features\restart.cpp" />
     <ClCompile Include="spt\features\rng.cpp" />
     <ClCompile Include="spt\features\shadow.cpp" />
     <ClCompile Include="spt\features\stucksave.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -220,6 +220,9 @@
     <ClCompile Include="spt\utils\datamap_wrapper.cpp">
       <Filter>spt\utils</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\restart.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/cvars.cpp
+++ b/spt/cvars.cpp
@@ -6,35 +6,6 @@
 
 static std::unordered_map<ConCommandBase*, void*> cmd_to_feature;
 
-// For OE CVar and ConCommand registering.
-#if defined(OE)
-class CPluginConVarAccessor : public IConCommandBaseAccessor
-{
-public:
-	virtual bool RegisterConCommandBase(ConCommandBase* pCommand)
-	{
-		if (cmd_to_feature.find(pCommand) == cmd_to_feature.end())
-		{
-			DevWarning("Command %s was unloaded, because it was not initialized!\n", pCommand->GetName());
-			return false;
-		}
-		pCommand->AddFlags(FCVAR_PLUGIN);
-
-		// Unlink from plugin only list
-		pCommand->SetNext(0);
-
-		// Link to engine's list instead
-		g_pCVar->RegisterConCommandBase(pCommand);
-		return true;
-	}
-};
-
-CPluginConVarAccessor g_ConVarAccessor;
-
-// OE: For correct linking in VS 2015.
-int(__cdecl* __vsnprintf)(char*, size_t, const char*, va_list) = _vsnprintf;
-#endif
-
 void Cvar_InitConCommandBase(ConCommandBase& concommand, void* owner)
 {
 	if (cmd_to_feature.find(&concommand) != cmd_to_feature.end())
@@ -47,42 +18,108 @@ void Cvar_InitConCommandBase(ConCommandBase& concommand, void* owner)
 	}
 }
 
-#if !defined(OE)
+#if defined(OE)
 void Cvar_RegisterSPTCvars()
 {
-	if (!g_pCVar)
+	if (!interfaces::g_pCVar)
 		return;
-	ConVar_Register(0);
-	int identifier = y_spt_pause.GetDLLIdentifier();
 
-	ConCommandBase* cmd = interfaces::g_pCVar->GetCommands();
-
-	// Loops through the console variables and commands, delete any that are initialized
-	while (cmd != NULL)
+	// Was unable implement similar diagnostics with which commands get unloaded in OE
+	// Using the OneTimeInit function completely broke the commands from being loaded the second time
+	for (auto command_pair : cmd_to_feature)
 	{
-		ConCommandBase* todelete = nullptr;
-		if (cmd->GetDLLIdentifier() == identifier)
-		{
-			if (cmd_to_feature.find(cmd) == cmd_to_feature.end())
-			{
-				DevWarning("Command %s was unloaded, because it was not initialized!\n",
-				           cmd->GetName());
-				todelete = cmd;
-			}
-		}
-		cmd = cmd->GetNext();
-		if (todelete)
-			g_pCVar->UnregisterConCommand(todelete);
+		command_pair.first->AddFlags(FCVAR_PLUGIN);
+		// Unlink from plugin only list
+		command_pair.first->SetNext(0);
+		interfaces::g_pCVar->RegisterConCommandBase(command_pair.first);
 	}
 }
-#endif
 
-#ifdef OE
+void Cvar_UnregisterSPTCvars()
+{
+	// The OE interface for ConVars leaves a lot to be desired...
+	// First deletes all plugin ConVars and then readds the ConVars outside of SPT
+	std::vector<ConCommandBase*> commandsToAdd;
+
+	ConCommandBase* command = interfaces::g_pCVar->GetCommands();
+
+	while (command)
+	{
+		// Detect which non-spt commands have this flag set, and add them back afterwards
+		if (command->IsBitSet(FCVAR_PLUGIN) && cmd_to_feature.find(command) == cmd_to_feature.end())
+		{
+			commandsToAdd.push_back(command);
+		}
+
+		command = const_cast<ConCommandBase*>(command->GetNext());
+	}
+
+	interfaces::g_pCVar->UnlinkVariables(FCVAR_PLUGIN);
+
+	for (ConCommandBase* command : commandsToAdd)
+	{
+		interfaces::g_pCVar->RegisterConCommandBase(command);
+	}
+
+	cmd_to_feature.clear();
+}
+
+#else
+static bool first_time_init = true;
+
 void Cvar_RegisterSPTCvars()
 {
-	if (g_pCVar)
+	if (!interfaces::g_pCVar)
+		return;
+
+	// First time init is more complicated but reports which cvars were unloaded
+	// Useful for development
+	if (first_time_init)
 	{
-		ConCommandBaseMgr::OneTimeInit(&g_ConVarAccessor);
+		ConVar_Register(0);
+		int identifier = y_spt_pause.GetDLLIdentifier();
+
+		ConCommandBase* cmd = interfaces::g_pCVar->GetCommands();
+
+		// Loops through the console variables and commands, delete any that are initialized
+		while (cmd != NULL)
+		{
+			ConCommandBase* todelete = nullptr;
+			if (cmd->GetDLLIdentifier() == identifier)
+			{
+				if (cmd_to_feature.find(cmd) == cmd_to_feature.end())
+				{
+					DevWarning("Command %s was unloaded, because it was not initialized!\n",
+					           cmd->GetName());
+					todelete = cmd;
+				}
+			}
+			cmd = cmd->GetNext();
+			if (todelete)
+				g_pCVar->UnregisterConCommand(todelete);
+		}
 	}
+	else
+	{
+		// The above implementation no longer works after restarts
+		// Adding the concommands breaks the linked list structure there is for the plugin convars
+		// And thus they don't get registered if you call ConVar_Register a second time
+		for (auto command_pair : cmd_to_feature)
+		{
+			interfaces::g_pCVar->RegisterConCommand(command_pair.first);
+		}
+	}
+
+	first_time_init = false;
+}
+
+void Cvar_UnregisterSPTCvars()
+{
+	for (auto command_pair : cmd_to_feature)
+	{
+		interfaces::g_pCVar->UnregisterConCommand(command_pair.first);
+	}
+
+	cmd_to_feature.clear();
 }
 #endif

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -5,6 +5,7 @@
 #define FCVAR_TAS_RESET (1 << 31)
 
 void Cvar_RegisterSPTCvars();
+void Cvar_UnregisterSPTCvars();
 void Cvar_InitConCommandBase(ConCommandBase& concommand, void* owner);
 
 extern ConVar y_spt_pause;

--- a/spt/feature.hpp
+++ b/spt/feature.hpp
@@ -117,7 +117,10 @@ public:
 	virtual void PreHook(){};
 	virtual void LoadFeature(){};
 	virtual void UnloadFeature(){};
+	virtual Feature* CreateNewInstance() = 0;
+	virtual void Move(Feature* instance) = 0;
 
+	static void ReloadFeatures();
 	static void LoadFeatures();
 	static void UnloadFeatures();
 
@@ -156,6 +159,21 @@ private:
 	static void InitModules();
 	static void Hook();
 	static void Unhook();
+};
+
+template<typename T>
+class FeatureWrapper : public Feature
+{
+public:
+	virtual Feature* CreateNewInstance()
+	{
+		return new T();
+	}
+
+	virtual void Move(Feature* instance)
+	{
+		*((T*)this) = std::move(*(T*)instance);
+	}
 };
 
 template<size_t PatternLength>

--- a/spt/features/afterframes.cpp
+++ b/spt/features/afterframes.cpp
@@ -8,6 +8,9 @@
 #include <sstream>
 
 AfterframesFeature spt_afterframes;
+static std::vector<afterframes_entry_t> afterframesQueue;
+static bool afterframesPaused = false;
+static int afterframesDelay = 0;
 
 ConVar _y_spt_afterframes_await_legacy("_y_spt_afterframes_await_legacy",
                                        "0",
@@ -45,10 +48,7 @@ bool AfterframesFeature::ShouldLoadFeature()
 	return true;
 }
 
-void AfterframesFeature::UnloadFeature()
-{
-	afterframesQueue.clear();
-}
+void AfterframesFeature::UnloadFeature() {}
 
 void AfterframesFeature::PreHook()
 {
@@ -180,9 +180,6 @@ void AfterframesFeature::LoadFeature()
 #endif
 
 		FrameSignal.Connect(this, &AfterframesFeature::OnFrame);
-		afterframesPaused = false;
-		afterframesDelay = 0;
-		afterframesQueue.clear();
 
 		if (SV_ActivateServerSignal.Works)
 		{

--- a/spt/features/afterframes.hpp
+++ b/spt/features/afterframes.hpp
@@ -36,9 +36,6 @@ private:
 	void SV_ActivateServer(bool result);
 	void FinishRestore(void* thisptr, int edx);
 	void SetPaused(void* thisptr, int edx, bool paused);
-	std::vector<afterframes_entry_t> afterframesQueue;
-	bool afterframesPaused = false;
-	int afterframesDelay = 0;
 };
 
 extern AfterframesFeature spt_afterframes;

--- a/spt/features/afterframes.hpp
+++ b/spt/features/afterframes.hpp
@@ -15,7 +15,7 @@ struct afterframes_entry_t
 };
 
 // This feature enables _y_spt_afterframes
-class AfterframesFeature : public Feature
+class AfterframesFeature : public FeatureWrapper<AfterframesFeature>
 {
 public:
 	void AddAfterFramesEntry(afterframes_entry_t entry);

--- a/spt/features/aim.hpp
+++ b/spt/features/aim.hpp
@@ -9,7 +9,7 @@ typedef struct
 	bool set = false;
 } angset_command_t;
 
-class AimFeature : public Feature
+class AimFeature : public FeatureWrapper<AimFeature>
 {
 public:
 	aim::ViewState viewState;

--- a/spt/features/autojump.hpp
+++ b/spt/features/autojump.hpp
@@ -14,7 +14,7 @@ typedef bool(__fastcall* _CheckJumpButton_client)(void* thisptr, int edx);
 typedef void(__fastcall* _FinishGravity)(void* thisptr, int edx);
 
 // y_spt_autojump
-class AutojumpFeature : public Feature
+class AutojumpFeature : public FeatureWrapper<AutojumpFeature>
 {
 public:
 	ptrdiff_t off1M_nOldButtons = 0;

--- a/spt/features/cvar.cpp
+++ b/spt/features/cvar.cpp
@@ -5,7 +5,7 @@
 #include "interfaces.hpp"
 #include <string>
 
-class CvarStuff : public Feature
+class CvarStuff : public FeatureWrapper<CvarStuff>
 {
 public:
 protected:

--- a/spt/features/demo.hpp
+++ b/spt/features/demo.hpp
@@ -7,7 +7,7 @@ typedef void(__fastcall* _SetSignonState)(void* thisptr, int edx, int state);
 typedef void(__cdecl* _Stop)();
 
 // Various demo features
-class DemoStuff : public Feature
+class DemoStuff : public FeatureWrapper<DemoStuff>
 {
 public:
 	void Demo_StopRecording();

--- a/spt/features/dmomm.cpp
+++ b/spt/features/dmomm.cpp
@@ -16,7 +16,7 @@ ConVar y_spt_on_slide_pause_for("y_spt_on_slide_pause_for",
                                 "Whenever sliding occurs in DMoMM, pause for this many ticks.");
 
 // DMoMM stuff
-class DMoMM : public Feature
+class DMoMM : public FeatureWrapper<DMoMM>
 {
 public:
 protected:

--- a/spt/features/ent_props.hpp
+++ b/spt/features/ent_props.hpp
@@ -47,7 +47,7 @@ struct PlayerField
 };
 
 // Initializes ent utils stuff
-class EntUtils : public Feature
+class EntUtils : public FeatureWrapper<EntUtils>
 {
 public:
 	virtual bool ShouldLoadFeature()

--- a/spt/features/fov.cpp
+++ b/spt/features/fov.cpp
@@ -8,7 +8,7 @@ typedef void(__fastcall* _CViewRender__OnRenderStart)(void* thisptr, int edx);
 ConVar _y_spt_force_fov("_y_spt_force_fov", "0", 0, "Force FOV to some value.");
 
 // FOV related features
-class FOVFeatures : public Feature
+class FOVFeatures : public FeatureWrapper<FOVFeatures>
 {
 public:
 protected:

--- a/spt/features/generic.hpp
+++ b/spt/features/generic.hpp
@@ -18,7 +18,7 @@ typedef void*(__cdecl* _GetClientModeNormal)();
 typedef void(__fastcall* _AdjustAngles)(void* thisptr, int edx, float frametime);
 
 // For hooks used by many features
-class GenericFeature : public Feature
+class GenericFeature : public FeatureWrapper<GenericFeature>
 {
 public:
 	_HudUpdate ORIG_HudUpdate = nullptr;

--- a/spt/features/graphics.cpp
+++ b/spt/features/graphics.cpp
@@ -8,7 +8,7 @@
 
 ConVar y_spt_drawseams("y_spt_drawseams", "0", FCVAR_CHEAT, "Draws seamshot stuff.\n");
 
-class GraphicsFeature : public Feature
+class GraphicsFeature : public FeatureWrapper<GraphicsFeature>
 {
 public:
 protected:

--- a/spt/features/hops_hud.cpp
+++ b/spt/features/hops_hud.cpp
@@ -16,7 +16,7 @@ ConVar y_spt_hud_hops_x("y_spt_hud_hops_x", "-85", FCVAR_CHEAT, "Hops HUD x offs
 ConVar y_spt_hud_hops_y("y_spt_hud_hops_y", "100", FCVAR_CHEAT, "Hops HUD y offset");
 
 // Hops HUD
-class HopsHud : public Feature
+class HopsHud : public FeatureWrapper<HopsHud>
 {
 public:
 	void OnGround(bool onground);

--- a/spt/features/hud.hpp
+++ b/spt/features/hud.hpp
@@ -30,7 +30,7 @@ struct HudCallback
 };
 
 // HUD stuff
-class HUDFeature : public Feature
+class HUDFeature : public FeatureWrapper<HUDFeature>
 {
 public:
 	bool AddHudCallback(HudCallback callback);

--- a/spt/features/ihud.hpp
+++ b/spt/features/ihud.hpp
@@ -14,7 +14,7 @@
 typedef void(__fastcall* _DecodeUserCmdFromBuffer)(void* thisptr, int edx, bf_read& buf, int sequence_number);
 
 // Input HUD
-class InputHud : public Feature
+class InputHud : public FeatureWrapper<InputHud>
 {
 public:
 	void DrawInputHud();

--- a/spt/features/ipc-spt.cpp
+++ b/spt/features/ipc-spt.cpp
@@ -18,7 +18,7 @@ namespace ipc
 	void ShutdownIPC();
 	void Send(const nlohmann::json& msg);
 
-	class IPCFeature : public Feature
+	class IPCFeature : public FeatureWrapper<IPCFeature>
 	{
 	public:
 	protected:

--- a/spt/features/isg.cpp
+++ b/spt/features/isg.cpp
@@ -13,7 +13,7 @@
 ConVar y_spt_hud_isg("y_spt_hud_isg", "0", FCVAR_CHEAT, "Is the ISG flag set?\n");
 
 // This feature enables the ISG setting and HUD features
-class ISGFeature : public Feature
+class ISGFeature : public FeatureWrapper<ISGFeature>
 {
 public:
 	bool* isgFlagPtr = nullptr;

--- a/spt/features/nosleep.cpp
+++ b/spt/features/nosleep.cpp
@@ -6,7 +6,7 @@ typedef void(__fastcall* _CInputSystem__SleepUntilInput)(void* thisptr, int edx,
 ConVar y_spt_focus_nosleep("y_spt_focus_nosleep", "0", 0, "Improves FPS while alt-tabbed.");
 
 // Gives the option to disable sleeping to improve FPS while alt-tabbed
-class NoSleepFeature : public Feature
+class NoSleepFeature : public FeatureWrapper<NoSleepFeature>
 {
 public:
 protected:

--- a/spt/features/overlay.hpp
+++ b/spt/features/overlay.hpp
@@ -6,7 +6,7 @@ typedef void(
 typedef void(__fastcall* _CViewRender__Render)(void* thisptr, int edx, void* rect);
 
 // Overlay hook stuff, could combine with overlay renderer as well
-class Overlay : public Feature
+class Overlay : public FeatureWrapper<Overlay>
 {
 public:
 	bool renderingOverlay = false;

--- a/spt/features/pause.cpp
+++ b/spt/features/pause.cpp
@@ -10,7 +10,7 @@ ConVar y_spt_pause("y_spt_pause", "0", FCVAR_ARCHIVE);
 extern ConVar tas_pause;
 
 // y_spt_pause stuff
-class PauseFeature : public Feature
+class PauseFeature : public FeatureWrapper<PauseFeature>
 {
 public:
 protected:

--- a/spt/features/playerio.hpp
+++ b/spt/features/playerio.hpp
@@ -18,7 +18,7 @@ typedef int(__fastcall* _GetButtonBits)(void* thisptr, int edx, int bResetState)
 typedef void*(__cdecl* _GetLocalPlayer)();
 
 // This feature reads player stuff from memory and writes player stuff into memory
-class PlayerIOFeature : public Feature
+class PlayerIOFeature : public FeatureWrapper<PlayerIOFeature>
 {
 private:
 	void __fastcall HOOKED_CreateMove_Func(void* thisptr,

--- a/spt/features/restart.cpp
+++ b/spt/features/restart.cpp
@@ -1,0 +1,48 @@
+#include "stdafx.h"
+#include <Windows.h>
+#include "..\feature.hpp"
+#include "..\spt-serverplugin.hpp"
+#include "..\sptlib-wrapper.hpp"
+#include "SPTLib\Hooks.hpp"
+
+// Does game restarts
+class RestartFeature : public FeatureWrapper<RestartFeature>
+{
+public:
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void LoadFeature() override;
+};
+
+static RestartFeature spt_restart;
+static HMODULE spt_module = 0;
+
+CON_COMMAND(tas_restart_game, "Restarts the game")
+{
+	bool gotHandle = GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)&spt_module, &spt_module);
+	if (gotHandle)
+	{
+		EngineConCmd("_restart");
+	}
+}
+
+bool RestartFeature::ShouldLoadFeature()
+{
+#if defined(OE) || defined(SSDK2013)
+	return true;
+#else
+	return false;
+#endif
+}
+
+void RestartFeature::LoadFeature()
+{
+	if (spt_module != 0)
+	{
+		FreeLibrary(spt_module); // clear old reference from restart
+		spt_module = 0;
+	}
+
+	InitCommand(tas_restart_game);
+}

--- a/spt/features/rng.hpp
+++ b/spt/features/rng.hpp
@@ -4,7 +4,7 @@
 typedef void(__cdecl* _SetPredictionRandomSeed)(void* usercmd);
 
 // RNG prediction
-class RNGStuff : public Feature
+class RNGStuff : public FeatureWrapper<RNGStuff>
 {
 public:
 	int GetPredictionRandomSeed(int commandOffset);

--- a/spt/features/shadow.cpp
+++ b/spt/features/shadow.cpp
@@ -6,7 +6,7 @@
 typedef int(__fastcall* _GetShadowPosition)(void* thisptr, int edx, Vector* worldPosition, QAngle* angles);
 
 // This feature allows access to the Havok hitbox location (aka physics shadow)
-class ShadowPosition : public Feature
+class ShadowPosition : public FeatureWrapper<ShadowPosition>
 {
 public:
 	static int __fastcall HOOKED_GetShadowPosition(void* thisptr, int edx, Vector* worldPosition, QAngle* angles);

--- a/spt/features/stucksave.cpp
+++ b/spt/features/stucksave.cpp
@@ -18,7 +18,7 @@ ConVar y_spt_piwsave("y_spt_piwsave", "", FCVAR_TAS_RESET, "Automatically saves 
 typedef int(__fastcall* _CheckStuck)(void* thisptr, int edx);
 
 // Implements saving when the player gets stuck, enabled with y_spt_stucksave
-class Stucksave : public Feature
+class Stucksave : public FeatureWrapper<Stucksave>
 {
 public:
 protected:

--- a/spt/features/tas.hpp
+++ b/spt/features/tas.hpp
@@ -2,7 +2,7 @@
 #include "..\feature.hpp"
 
 // Enables TAS strafing and view related functionality
-class TASFeature : public Feature
+class TASFeature : public FeatureWrapper<TASFeature>
 {
 public:
 	void Strafe(float* va, bool yawChanged);

--- a/spt/features/taslogging.cpp
+++ b/spt/features/taslogging.cpp
@@ -10,7 +10,7 @@ typedef void(__fastcall* _ProcessMovement)(void* thisptr, int edx, void* pPlayer
 ConVar tas_log("tas_log", "0", 0, "If enabled, dumps a whole bunch of different stuff into the console.");
 
 // Some logging stuff that can be turned on with tas_log 1
-class TASLogging : public Feature
+class TASLogging : public FeatureWrapper<TASLogging>
 {
 public:
 protected:

--- a/spt/features/taspause.cpp
+++ b/spt/features/taspause.cpp
@@ -5,7 +5,7 @@
 typedef void(__cdecl* _Host_AccumulateTime)(float dt);
 ConVar tas_pause("tas_pause", "0", 0, "Does a pause where you can look around when the game is paused.\n");
 
-class TASPause : public Feature
+class TASPause : public FeatureWrapper<TASPause>
 {
 public:
 protected:

--- a/spt/features/template.cpp.txt
+++ b/spt/features/template.cpp.txt
@@ -2,7 +2,7 @@
 #include "..\feature.hpp"
 
 // Feature description
-class TemplateFeature : public Feature
+class TemplateFeature : public FeatureWrapper<TemplateFeature>
 {
 public:
 protected:

--- a/spt/features/test.cpp
+++ b/spt/features/test.cpp
@@ -3,7 +3,7 @@
 #include "signals.hpp"
 #include "..\scripts\tester.hpp"
 
-class TestFeature : public Feature
+class TestFeature : public FeatureWrapper<TestFeature>
 {
 public:
 protected:

--- a/spt/features/tickrate.hpp
+++ b/spt/features/tickrate.hpp
@@ -2,7 +2,7 @@
 #include "..\feature.hpp"
 
 // For getting tickrate stuff
-class TickrateMod : public Feature
+class TickrateMod : public FeatureWrapper<TickrateMod>
 {
 public:
 	float GetTickrate();

--- a/spt/features/timer.cpp
+++ b/spt/features/timer.cpp
@@ -5,7 +5,7 @@
 
 #include "convar.h"
 
-class Timer : public Feature
+class Timer : public FeatureWrapper<Timer>
 {
 public:
 	void StartTimer()

--- a/spt/features/tracing.hpp
+++ b/spt/features/tracing.hpp
@@ -61,7 +61,7 @@ typedef const Vector&(__fastcall* _CGameMovement__GetPlayerMins)(void* thisptr, 
 typedef bool(__fastcall* _CEngineTrace__PointOutsideWorld)(void* thisptr, int edx, const Vector& pt);
 
 // Tracing related functionality
-class Tracing : public Feature
+class Tracing : public FeatureWrapper<Tracing>
 {
 public:
 	_UTIL_TraceRay ORIG_UTIL_TraceRay = nullptr;

--- a/spt/features/vag.cpp
+++ b/spt/features/vag.cpp
@@ -15,7 +15,7 @@ ConVar y_spt_prevent_vag_crash(
     "Prevents the game from crashing from too many recursive teleports (useful when searching for vertical angle glitches).\n");
 
 // y_spt_prevent_vag_crash
-class VAG : public Feature
+class VAG : public FeatureWrapper<VAG>
 {
 public:
 protected:

--- a/spt/features/visual_fixes.cpp
+++ b/spt/features/visual_fixes.cpp
@@ -18,7 +18,7 @@ ConVar y_spt_disable_tone_map_reset(
     "Prevents the tone map getting reset (during each load), useful for keeping colors the same between demos.");
 
 // Misc visual fixes
-class VisualFixes : public Feature
+class VisualFixes : public FeatureWrapper<VisualFixes>
 {
 public:
 protected:

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -278,14 +278,12 @@ void CSourcePauseTool::Unload(void)
 		return;
 	}
 
-#if !defined(OE)
-	ConVar_Unregister();
-#endif
-
+	Cvar_UnregisterSPTCvars();
 	DisconnectTier1Libraries();
 	DisconnectTier3Libraries();
 	Feature::UnloadFeatures();
 	Hooks::Free();
+	pluginLoaded = false;
 }
 
 const char* CSourcePauseTool::GetPluginDescription(void)


### PR DESCRIPTION
How it works:
tas_restart_game increments the spt*.dll reference count by requesting a handle to it and then executes the _restart command. SPT still gets unloaded like usual, but the dll itself stays in memory and some state can be persisted over restarts. Most state should not be preserved (like pointers to random bits of memory) and hence all features get hackily constructed again upon the plugin getting loaded again. If something should be persisted across restarts, it needs to be stored outside of the feature system. Did an initial test with afterframes and it now persists across restarts. 

Intended usage is to put `plugin_load spt` into your autoexec, so the plugin automatically loads when the game starts, no automatic reloading happens from the plugin side after it runs tas_restart_game. Went with this implementation instead of requiring people to use the BXT Injector or something else to load spt, admittedly requiring the autoexec thing might be slightly confusing but not requiring that would be vastly more complicated to implement.

The _restart command itself is broken on 2007 source and BMS, hence those engine versions are not supported. Tested to work on 4044 OE and steampipe Portal.