### PR TITLE
Saveglitch collision visualization

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1147,9 +1147,11 @@
     <ClCompile Include="spt\features\nosleep.cpp" />
     <ClCompile Include="spt\features\overlay.cpp" />
     <ClCompile Include="spt\features\pause.cpp" />
+    <ClCompile Include="spt\features\physvis.cpp" />
     <ClCompile Include="spt\features\playerio.cpp" />
     <ClCompile Include="spt\features\restart.cpp" />
     <ClCompile Include="spt\features\rng.cpp" />
+    <ClCompile Include="spt\features\sg-collide-vis.cpp" />
     <ClCompile Include="spt\features\shadow.cpp" />
     <ClCompile Include="spt\features\stucksave.cpp" />
     <ClCompile Include="spt\features\tas.cpp" />
@@ -1346,6 +1348,7 @@
     <ClInclude Include="spt\features\hud.hpp" />
     <ClInclude Include="spt\features\ihud.hpp" />
     <ClInclude Include="spt\features\overlay.hpp" />
+    <ClInclude Include="spt\features\physvis.hpp" />
     <ClInclude Include="spt\features\playerio.hpp" />
     <ClInclude Include="spt\features\rng.hpp" />
     <ClInclude Include="spt\features\shadow.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -223,6 +223,12 @@
     <ClCompile Include="spt\features\restart.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\physvis.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
+    <ClCompile Include="spt\features\sg-collide-vis.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">
@@ -490,6 +496,9 @@
       <Filter>spt\utils</Filter>
     </ClInclude>
     <ClInclude Include="spt\features\ent_props.hpp">
+      <Filter>spt\features</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\features\physvis.hpp">
       <Filter>spt\features</Filter>
     </ClInclude>
   </ItemGroup>

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -20,6 +20,11 @@ extern ConVar y_spt_on_slide_pause_for;
 extern ConVar y_spt_prevent_vag_crash;
 extern ConVar y_spt_disable_tone_map_reset;
 extern ConVar y_spt_drawseams;
+extern ConVar y_spt_draw_portal_env;
+extern ConVar y_spt_draw_portal_env_type;
+extern ConVar y_spt_draw_portal_env_ents;
+extern ConVar y_spt_draw_portal_env_remote;
+extern ConVar y_spt_draw_portal_env_wireframe;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -19,7 +19,7 @@ extern ConVar y_spt_pause_demo_on_tick;
 extern ConVar y_spt_on_slide_pause_for;
 extern ConVar y_spt_prevent_vag_crash;
 extern ConVar y_spt_disable_tone_map_reset;
-extern ConVar y_spt_drawseams;
+extern ConVar y_spt_draw_seams;
 extern ConVar y_spt_draw_portal_env;
 extern ConVar y_spt_draw_portal_env_type;
 extern ConVar y_spt_draw_portal_env_ents;

--- a/spt/features/generic.cpp
+++ b/spt/features/generic.cpp
@@ -39,8 +39,20 @@ void GenericFeature::LoadFeature()
 {
 	if (ORIG_CHudDamageIndicator__GetDamagePosition)
 	{
-		int offset = *reinterpret_cast<int*>(ORIG_CHudDamageIndicator__GetDamagePosition + 4);
-		ORIG_MainViewOrigin = (_MainViewOrigin)(offset + ORIG_CHudDamageIndicator__GetDamagePosition + 8);
+		int ptnNumber = GetPatternIndex((void**)&ORIG_CHudDamageIndicator__GetDamagePosition);
+		switch (ptnNumber)
+		{
+		case 0:
+			ORIG_MainViewOrigin =
+			    (_MainViewOrigin)(*reinterpret_cast<int*>(ORIG_CHudDamageIndicator__GetDamagePosition + 4)
+			                      + ORIG_CHudDamageIndicator__GetDamagePosition + 8);
+			break;
+		case 1:
+			ORIG_MainViewOrigin =
+			    (_MainViewOrigin)(*reinterpret_cast<int*>(ORIG_CHudDamageIndicator__GetDamagePosition + 10)
+			                      + ORIG_CHudDamageIndicator__GetDamagePosition + 14);
+			break;
+		}
 		DevMsg("[client.dll] Found MainViewOrigin at %p\n", ORIG_MainViewOrigin);
 	}
 

--- a/spt/features/graphics.cpp
+++ b/spt/features/graphics.cpp
@@ -6,7 +6,7 @@
 #include "..\feature.hpp"
 #include "..\vgui\lines.hpp"
 
-ConVar y_spt_drawseams("y_spt_drawseams", "0", FCVAR_CHEAT, "Draws seamshot stuff.\n");
+ConVar y_spt_draw_seams("y_spt_draw_seams", "0", FCVAR_CHEAT, "Draws seamshot stuff.\n");
 
 class GraphicsFeature : public FeatureWrapper<GraphicsFeature>
 {
@@ -33,7 +33,7 @@ void GraphicsFeature::LoadFeature()
 	if (spt_tracing.ORIG_TraceFirePortal && spt_tracing.ORIG_GetActiveWeapon && interfaces::debugOverlay
 	    && AdjustAngles.Works)
 	{
-		InitConcommandBase(y_spt_drawseams);
+		InitConcommandBase(y_spt_draw_seams);
 		AdjustAngles.Connect(vgui::DrawLines);
 	}
 }

--- a/spt/features/isg.cpp
+++ b/spt/features/isg.cpp
@@ -8,7 +8,7 @@
 
 #include "convar.hpp"
 
-#if defined(SSDK2007)
+#if defined(SSDK2007) || defined(SSDK2013)
 
 ConVar y_spt_hud_isg("y_spt_hud_isg", "0", FCVAR_CHEAT, "Is the ISG flag set?\n");
 
@@ -69,8 +69,10 @@ void ISGFeature::LoadFeature()
 	{
 		InitCommand(y_spt_set_isg);
 
+#ifdef SSDK2007
 		AddHudCallback(
 		    "isg", []() { spt_hud.DrawTopHudElement(L"isg: %d", IsISGActive()); }, y_spt_hud_isg);
+#endif
 	}
 }
 

--- a/spt/features/physvis.cpp
+++ b/spt/features/physvis.cpp
@@ -1,0 +1,162 @@
+#include "stdafx.h"
+#include "physvis.hpp"
+#include "interfaces.hpp"
+#include "materialsystem\imaterialsystem.h"
+
+const matrix3x4_t matrix3x4_identity(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0);
+
+PhysVisFeature spt_physvis;
+
+bool PhysVisFeature::AddPhysVisCallback(PhysVisCallback callback)
+{
+	if (!loadingSuccessful)
+		return false;
+	callbacks.push_back(callback);
+	std::sort(callbacks.begin(), callbacks.end(), [](PhysVisCallback& lhs, PhysVisCallback& rhs) {
+		return lhs.sortKey < rhs.sortKey;
+	});
+	return true;
+}
+
+bool PhysVisFeature::ShouldLoadFeature()
+{
+#if defined(SSDK2007) || defined(SSDK2013)
+	return interfaces::materialSystem;
+#else
+	return false;
+#endif
+}
+
+void PhysVisFeature::InitHooks()
+{
+	FIND_PATTERN(vphysics, CPhysicsObject__GetPosition);
+	FIND_PATTERN(engine, DebugDrawPhysCollide);
+	HOOK_FUNCTION(vphysics, CPhysicsCollision__CreateDebugMesh);
+	HOOK_FUNCTION(vphysics, CPhysicsCollision__DestroyDebugMesh);
+	HOOK_FUNCTION(client, CRendering3dView__DrawTranslucentRenderables);
+}
+
+void PhysVisFeature::LoadFeature() {}
+
+void PhysVisFeature::UnloadFeature() {}
+
+void PhysVisFeature::PreHook()
+{
+	loadingSuccessful = ORIG_CPhysicsObject__GetPosition && ORIG_DebugDrawPhysCollide
+	                    && ORIG_CPhysicsCollision__CreateDebugMesh && ORIG_CPhysicsCollision__DestroyDebugMesh
+	                    && ORIG_CRendering3dView__DrawTranslucentRenderables;
+}
+
+int __fastcall PhysVisFeature::HOOKED_CPhysicsCollision__CreateDebugMesh(const IPhysicsCollision* thisptr,
+                                                                         int dummy,
+                                                                         const CPhysCollide* pCollideModel,
+                                                                         Vector** outVerts)
+{
+	auto& state = spt_physvis.renderState;
+	int numVerts;
+	if (state.verts)
+	{
+		numVerts = state.numVerts;
+		*outVerts = state.verts;
+	}
+	else
+	{
+		numVerts = spt_physvis.ORIG_CPhysicsCollision__CreateDebugMesh(thisptr, dummy, pCollideModel, outVerts);
+	}
+	if (state.curDrawInfo && state.curDrawInfo->EditMeshFunc)
+		numVerts = state.curDrawInfo->EditMeshFunc(*outVerts, numVerts, state.curMat);
+
+	return numVerts;
+}
+
+void __fastcall PhysVisFeature::HOOKED_CPhysicsCollision__DestroyDebugMesh(const IPhysicsCollision* thisptr,
+                                                                           int dummy,
+                                                                           int vertCount,
+                                                                           Vector* outVerts)
+{
+	if (!spt_physvis.renderState.verts)
+		g_pMemAlloc->Free(outVerts); // only free if we're not drawing a custom mesh
+}
+
+void __fastcall PhysVisFeature::HOOKED_CRendering3dView__DrawTranslucentRenderables(void* thisptr,
+                                                                                    int edx,
+                                                                                    bool bInSkybox,
+                                                                                    bool bShadowDepth)
+{
+	spt_physvis.ORIG_CRendering3dView__DrawTranslucentRenderables(thisptr, edx, bInSkybox, bShadowDepth);
+	// this seems to be the best spot in the pipeline to render meshes, otherwise stuff gets drawn on top of them
+	spt_physvis.renderState.renderingCallbacks = true;
+	for (auto& callback : spt_physvis.callbacks)
+		callback.render();
+	spt_physvis.renderState.renderingCallbacks = false;
+}
+
+void PhysVisFeature::DrawPhysCollideWrapper(const CPhysCollide* pCollide,
+                                            const PhysVisDrawInfo& info,
+                                            const matrix3x4_t* m)
+{
+	spt_physvis.renderState.curMat = m;
+	spt_physvis.renderState.curDrawInfo = &info;
+	auto& actualMat = m ? *m : matrix3x4_identity;
+	color32 color = info.color;
+	switch (info.wireframeMode)
+	{
+	case OnlyFaces:
+	case FacesAndWire:
+	{
+		const char* faceMatName = "debug/debugtranslucentvertexcolor";
+		IMaterial* material = interfaces::materialSystem->FindMaterial(faceMatName, TEXTURE_GROUP_OTHER);
+		spt_physvis.ORIG_DebugDrawPhysCollide(pCollide, material, actualMat, color, false);
+		if (info.wireframeMode == OnlyFaces)
+			break;
+		color = {0, 0, 0, 250}; // fall through and use a black wireframe
+	}
+	case OnlyWire:
+		spt_physvis.ORIG_DebugDrawPhysCollide(pCollide, nullptr, actualMat, color, false);
+	}
+	spt_physvis.renderState.curDrawInfo = nullptr;
+	spt_physvis.renderState.curMat = nullptr;
+}
+
+void PhysVisFeature::DrawCPhysCollide(const CPhysCollide* pCollide, const PhysVisDrawInfo& info, const matrix3x4_t* mat)
+{
+	if (!spt_physvis.renderState.renderingCallbacks || !pCollide)
+		return;
+	DrawPhysCollideWrapper(pCollide, info, mat);
+}
+
+void PhysVisFeature::DrawCPhysicsObject(const CPhysicsObject* pPhysicsObject, const PhysVisDrawInfo& info)
+{
+	if (!spt_physvis.renderState.renderingCallbacks || !pPhysicsObject)
+		return;
+	Vector pos;
+	QAngle ang;
+	matrix3x4_t mat;
+	spt_physvis.ORIG_CPhysicsObject__GetPosition(pPhysicsObject, 0, &pos, &ang);
+	AngleMatrix(ang, pos, mat);
+	DrawCPhysCollide(*((CPhysCollide**)pPhysicsObject + 3), info, &mat);
+}
+
+void PhysVisFeature::DrawCBaseEntity(const CBaseEntity* pEnt, const PhysVisDrawInfo& info)
+{
+	if (!spt_physvis.renderState.renderingCallbacks || !pEnt)
+		return;
+#if defined(SSDK2007)
+	DrawCPhysicsObject(*((void**)pEnt + 106), info);
+#elif defined(SSDK2013)
+	DrawCPhysicsObject(*((void**)pEnt + 120), info);
+#endif
+}
+
+void PhysVisFeature::DrawCustomMesh(Vector* verts, int numVerts, const PhysVisDrawInfo& info, const matrix3x4_t* mat)
+{
+	if (!spt_physvis.renderState.renderingCallbacks || !verts)
+		return;
+	auto& state = spt_physvis.renderState;
+	state.verts = verts;
+	state.numVerts = numVerts;
+	state.curDrawInfo = &info;
+	DrawPhysCollideWrapper(nullptr, info, mat);
+	state.curDrawInfo = nullptr;
+	state.verts = nullptr;
+}

--- a/spt/features/physvis.hpp
+++ b/spt/features/physvis.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "..\feature.hpp"
+#include "engine\iserverplugin.h"
+#include "tier3\tier3.h"
+#include "cdll_int.h"
+
+extern const matrix3x4_t matrix3x4_identity;
+
+#ifdef OE
+typedef void IPhysicsCollision; // just for OE to compile
+#endif
+typedef void CPhysicsObject;
+
+typedef int(__fastcall* _CPhysicsCollision__CreateDebugMesh)(const IPhysicsCollision* thisptr,
+                                                             int dummy,
+                                                             const CPhysCollide* pCollideModel,
+                                                             Vector** outVerts);
+
+typedef void(__fastcall* _CPhysicsCollision__DestroyDebugMesh)(const IPhysicsCollision* thisptr,
+                                                               int dummy,
+                                                               int vertCount,
+                                                               Vector* outVerts);
+
+typedef void(__fastcall* _CPhysicsObject__GetPosition)(const void* thisptr,
+                                                       int dummy,
+                                                       Vector* worldPosition,
+                                                       QAngle* angles);
+
+typedef void(__cdecl* _DebugDrawPhysCollide)(const CPhysCollide* pCollide,
+                                             IMaterial* pMaterial,
+                                             const matrix3x4_t& transform,
+                                             const color32& color,
+                                             bool drawAxes);
+
+typedef void(__fastcall* _CRendering3dView__DrawTranslucentRenderables)(void* thisptr,
+                                                                        int edx,
+                                                                        bool bInSkybox,
+                                                                        bool bShadowDepth);
+
+/* 
+* NOTE: the matrix will be applied to the verts in ORIG_DebugDrawPhysCollide AFTER this function is called, it
+* should not be used for transforming the verts. A null matrix means that the identity mat will be used. The
+* vertex array will be allocated by the game's allocator, so if you're creating a new one make sure to free the
+* old one and allocate the new one yourself using g_pMemAlloc; the one used will be freed by the game after the
+* mesh is rendered.
+*/
+typedef int (*_EditMeshFunc)(Vector*& verts, int numVerts, const matrix3x4_t* mat);
+
+typedef struct
+{
+	std::function<void()> render;
+	std::string sortKey;
+} PhysVisCallback;
+
+enum WireframeMode
+{
+	OnlyFaces,
+	OnlyWire,
+	FacesAndWire // color is used for faces, black wireframe
+};
+
+struct PhysVisDrawInfo
+{
+	WireframeMode wireframeMode;
+	color32 color;
+	// set this if you're editing the mesh created by CreateDebugMesh (or your own custom mesh func)
+	_EditMeshFunc EditMeshFunc = nullptr;
+};
+
+/*
+* This is akin to an advanced version of the debug overlay - the primary purpose of this is
+* for drawing individual meshes. It hooks the same system that is used by vcollide_wireframe.
+* It's not as fast as the main engine rendering system, but it's damn well fast enough for
+* many needs. Note that meshes are unlit, render order matters, and rendering too many or using
+* large meshes will crash the game (especially when looking through portals or going OOB).
+*/
+class PhysVisFeature : public FeatureWrapper<PhysVisFeature>
+{
+public:
+	/*
+	* The callbacks get called every frame. The sort key determines the order that the callbacks
+	* are rendered in, "higher" keys (e.g. 'z') are rendered last and therefore on top.
+	*/
+	bool AddPhysVisCallback(PhysVisCallback callback);
+	virtual bool ShouldLoadFeature() override;
+
+	_CPhysicsCollision__CreateDebugMesh ORIG_CPhysicsCollision__CreateDebugMesh = nullptr;
+	_CPhysicsCollision__CreateDebugMesh ORIG_CPhysicsCollision__DestroyDebugMesh = nullptr;
+	_CPhysicsObject__GetPosition ORIG_CPhysicsObject__GetPosition = nullptr;
+
+	// These functions can only be called from a PhysVisCallback. The first 3 allow the game to
+	// allocate and free the verts array automatically.
+
+	static void DrawCPhysCollide(const CPhysCollide* pCollide,
+	                             const PhysVisDrawInfo& info,
+	                             const matrix3x4_t* mat = nullptr);
+
+	static void DrawCPhysicsObject(const CPhysicsObject* pPhysicsObject, const PhysVisDrawInfo& info);
+
+	static void DrawCBaseEntity(const CBaseEntity* pEnt, const PhysVisDrawInfo& info);
+
+	// this one does not free the verts array
+
+	static void DrawCustomMesh(Vector* verts,
+	                           int numVerts,
+	                           const PhysVisDrawInfo& info,
+	                           const matrix3x4_t* mat = nullptr);
+
+protected:
+	virtual void InitHooks() override;
+	virtual void LoadFeature() override;
+	virtual void UnloadFeature() override;
+	virtual void PreHook() override;
+
+private:
+	static int __fastcall HOOKED_CPhysicsCollision__CreateDebugMesh(const IPhysicsCollision* thisptr,
+	                                                                int dummy,
+	                                                                const CPhysCollide* pCollideModel,
+	                                                                Vector** outVerts);
+
+	static void __fastcall HOOKED_CPhysicsCollision__DestroyDebugMesh(const IPhysicsCollision* thisptr,
+	                                                                  int dummy,
+	                                                                  int vertCount,
+	                                                                  Vector* outVerts);
+
+	static void __fastcall HOOKED_CRendering3dView__DrawTranslucentRenderables(void* thisptr,
+	                                                                           int edx,
+	                                                                           bool bInSkybox,
+	                                                                           bool bShadowDepth);
+
+	_DebugDrawPhysCollide ORIG_DebugDrawPhysCollide = nullptr;
+	_CRendering3dView__DrawTranslucentRenderables ORIG_CRendering3dView__DrawTranslucentRenderables = nullptr;
+
+	static void DrawPhysCollideWrapper(const CPhysCollide* pCollide,
+	                                   const PhysVisDrawInfo& info,
+	                                   const matrix3x4_t* m);
+
+	std::vector<PhysVisCallback> callbacks;
+
+	struct
+	{
+		bool renderingCallbacks = false;
+		const PhysVisDrawInfo* curDrawInfo = nullptr;
+		const matrix3x4_t* curMat = nullptr;
+		// if drawing a custom mesh
+		Vector* verts = nullptr;
+		int numVerts;
+	} renderState;
+
+	bool loadingSuccessful = false;
+};
+
+extern PhysVisFeature spt_physvis;

--- a/spt/features/sg-collide-vis.cpp
+++ b/spt/features/sg-collide-vis.cpp
@@ -1,0 +1,203 @@
+#include "stdafx.h"
+#include "..\feature.hpp"
+#include "physvis.hpp"
+#include "generic.hpp"
+#include "game_detection.hpp"
+#include "..\overlay\portal_camera.hpp"
+#include "property_getter.hpp"
+#include "interfaces.hpp"
+#include "..\cvars.hpp"
+
+ConVar y_spt_draw_portal_env("y_spt_draw_portal_env",
+                             "0",
+                             FCVAR_CHEAT | FCVAR_DONTRECORD,
+                             "Draw the geometry in a portal's physics environment");
+
+ConVar y_spt_draw_portal_env_type(
+    "y_spt_draw_portal_env_type",
+    "auto",
+    FCVAR_CHEAT | FCVAR_DONTRECORD,
+    "Usage: y_spt_draw_portal_env_type collide|auto|blue|orange|<index>; draw world collision and static props in a portal environment\n"
+    "   - collide: draw what the player has collision with\n"
+    "   - auto: prioritize what the player has collision with, otherwise use last drawn portal index\n"
+    "   - blue/orange: look for specific portal color\n"
+    "   - index: specify portal entity index");
+
+ConVar y_spt_draw_portal_env_ents("y_spt_draw_portal_env_ents",
+                                  "0",
+                                  FCVAR_CHEAT | FCVAR_DONTRECORD,
+                                  "Draw entities owned by portal and shadow clones from remote portal");
+
+ConVar y_spt_draw_portal_env_remote("y_spt_draw_portal_env_remote",
+                                    "0",
+                                    FCVAR_CHEAT | FCVAR_DONTRECORD,
+                                    "Draw geometry from remote portal");
+
+ConVar y_spt_draw_portal_env_wireframe("y_spt_draw_portal_env_wireframe",
+                                       "1",
+                                       FCVAR_CHEAT | FCVAR_DONTRECORD,
+                                       "Draw wireframe for static geometry");
+
+#if defined(SSDK2007) || defined(SSDK2013) // :)
+
+/* 
+* This is an _EditMeshFunc. Since we're drawing directly on top of world geo there's a lot of
+* z-fighting. This mostly prevents that by pushing each face outwards by some epsilon that depends
+* on the camera's distance to the mesh (the further away we are, the more the mesh should be extruded).
+*/
+int ExtrudeMesh(Vector*& verts, int numVerts, const matrix3x4_t* mat)
+{
+	const Vector camPos = spt_generic.GetCameraOrigin();
+	// determine furthest vert from camera
+	float maxDistSqr = 0;
+	for (int i = 0; i < numVerts; i++)
+	{
+		float distSqr;
+		if (mat)
+		{
+			// outVerts doesn't have the transform applied yet
+			Vector out;
+			VectorTransform(verts[i].Base(), *mat, out.Base());
+			distSqr = camPos.DistToSqr(out);
+		}
+		else
+		{
+			distSqr = camPos.DistToSqr(verts[i]);
+		}
+		maxDistSqr = MAX(maxDistSqr, distSqr);
+	}
+	// extrude the mesh by this epsilon - seems to work alright in most cases
+	float normEps = MAX(pow(maxDistSqr, 0.6f) / 50000, 0.0001f);
+	for (int i = 0; i < numVerts; i += 3)
+	{
+		Vector norm = (verts[i] - verts[i + 1]).Cross(verts[i + 2] - verts[i]);
+		norm.NormalizeInPlace();
+		norm *= normEps;
+		verts[i] += norm;
+		verts[i + 1] += norm;
+		verts[i + 2] += norm;
+	}
+	return numVerts;
+}
+
+static int lastPortalIndex = -1;
+
+IServerEntity* GetSgDrawPortal()
+{
+	if (!y_spt_draw_portal_env.GetBool() || !interfaces::engine_server->PEntityOfEntIndex(0))
+		return nullptr;
+
+	const char* typeStr = y_spt_draw_portal_env_type.GetString();
+	bool want_auto = !strcmp(typeStr, "auto");
+	bool want_collide = !strcmp(typeStr, "collide");
+	typeStr = want_collide ? "auto" : typeStr; // 'collide' here is what 'auto' means in 'getPortal'
+
+	// 'auto' here should prioritize player's env
+	IClientEntity* pEnt = getPortal(typeStr, false); // blue/orange/index/collide/auto in bubble
+	int portalIdx = pEnt ? pEnt->entindex() : -1;
+
+	if (portalIdx == -1 && want_auto)
+	{
+		// try the last index we used
+		if (invalidPortal(utils::GetClientEntity(lastPortalIndex - 1)))
+			lastPortalIndex = -1;
+		else
+			portalIdx = lastPortalIndex;
+		// let's try blue and orange
+		if (portalIdx == -1)
+		{
+			pEnt = getPortal("blue", false);
+			if (!pEnt)
+				pEnt = getPortal("orange", false);
+			if (pEnt)
+				portalIdx = pEnt->entindex();
+		}
+	}
+	lastPortalIndex = portalIdx;
+	auto serverPortal = interfaces::engine_server->PEntityOfEntIndex(portalIdx);
+	return serverPortal ? serverPortal->GetIServerEntity() : nullptr;
+}
+
+void DrawSgCollision()
+{
+	auto iServerEnt = GetSgDrawPortal();
+	if (!iServerEnt)
+		return;
+	auto portal = iServerEnt->GetBaseEntity();
+
+	// portal simulator
+#ifdef SSDK2007
+	uint32_t* sim = (uint32_t*)portal + 327;
+#else
+	uint32_t* sim = (uint32_t*)portal + 341;
+#endif
+
+	WireframeMode mode = y_spt_draw_portal_env_wireframe.GetBool() ? FacesAndWire : OnlyFaces;
+
+	// portal hole - not directly used for collision (green wireframe)
+	PhysVisFeature::DrawCPhysCollide(*(CPhysCollide**)(sim + 70), {OnlyWire, {20, 255, 20, 255}});
+	// world brushes - wall geo in front of portal (red)
+	PhysVisFeature::DrawCPhysCollide(*(CPhysCollide**)(sim + 76), {mode, {255, 20, 20, 70}, ExtrudeMesh});
+	// local wall tube - edge of portal (green)
+	PhysVisFeature::DrawCPhysCollide(*(CPhysCollide**)(sim + 94), {mode, {0, 255, 0, 200}});
+	// local wall brushes - wall geo behind the portal (blue)
+	PhysVisFeature::DrawCPhysCollide(*(CPhysCollide**)(sim + 101), {mode, {40, 40, 255, 60}, ExtrudeMesh});
+	// static props (piss colored)
+	const CUtlVector<char[28]>& staticProps = *(CUtlVector<char[28]>*)(sim + 83);
+	for (int i = 0; i < staticProps.Count(); i++)
+	{
+		const color32 c = {255, 255, 40, 50};
+		PhysVisFeature::DrawCPhysCollide(*((CPhysCollide**)staticProps[i] + 2), {mode, c, ExtrudeMesh});
+	}
+	if (y_spt_draw_portal_env_remote.GetBool())
+	{
+		// remote brushes (light pink); extruding here since this frequently overlaps with local world geo
+		PhysVisFeature::DrawCPhysicsObject(*(void**)(sim + 103), {mode, {255, 150, 150, 15}, ExtrudeMesh});
+		// remote static props (light yellow)
+		const CUtlVector<void*>& remoteStaticProps = *(CUtlVector<void*>*)(sim + 104);
+		for (int i = 0; i < remoteStaticProps.Count(); i++)
+			PhysVisFeature::DrawCPhysicsObject(remoteStaticProps[i], {mode, {255, 255, 150, 15}});
+	}
+	if (y_spt_draw_portal_env_ents.GetBool())
+	{
+		// owned entities (pink wireframe)
+		const CUtlVector<CBaseEntity*>& ownedEnts = *(CUtlVector<CBaseEntity*>*)(sim + 2171);
+		for (int i = 0; i < ownedEnts.Count(); i++)
+			PhysVisFeature::DrawCBaseEntity(ownedEnts[i], {OnlyWire, {255, 100, 255, 255}});
+		// shadow clones (white wireframe); ownedEnts also has shadow clones so these will draw over them
+		const CUtlVector<CBaseEntity*>& shadowClones = *(CUtlVector<CBaseEntity*>*)(sim + 2166);
+		for (int i = 0; i < shadowClones.Count(); i++)
+			PhysVisFeature::DrawCBaseEntity(shadowClones[i], {OnlyWire, {255, 255, 255, 255}});
+	}
+}
+
+class SgCollideVisFeature : public FeatureWrapper<SgCollideVisFeature>
+{
+public:
+protected:
+	virtual bool ShouldLoadFeature() override
+	{
+		return spt_physvis.ShouldLoadFeature() && spt_generic.ShouldLoadFeature()
+		       && utils::DoesGameLookLikePortal();
+	}
+
+	virtual void InitHooks() override{};
+
+	virtual void LoadFeature() override
+	{
+		if (spt_physvis.AddPhysVisCallback({DrawSgCollision, "f"}))
+		{
+			InitConcommandBase(y_spt_draw_portal_env);
+			InitConcommandBase(y_spt_draw_portal_env_type);
+			InitConcommandBase(y_spt_draw_portal_env_ents);
+			InitConcommandBase(y_spt_draw_portal_env_remote);
+			InitConcommandBase(y_spt_draw_portal_env_wireframe);
+		}
+	};
+
+	virtual void UnloadFeature() override{};
+};
+
+static SgCollideVisFeature spt_sgCollision;
+
+#endif

--- a/spt/overlay/portal_camera.cpp
+++ b/spt/overlay/portal_camera.cpp
@@ -20,8 +20,6 @@
 
 const int INDEX_MASK = MAX_EDICTS - 1;
 
-IClientEntity* getPortal(const char* arg, bool verbose);
-
 // From /game/shared/portal/prop_portal_shared.cpp
 void UpdatePortalTransformationMatrix(const matrix3x4_t& localToWorld,
                                       const matrix3x4_t& remoteToWorld,

--- a/spt/overlay/portal_camera.hpp
+++ b/spt/overlay/portal_camera.hpp
@@ -6,6 +6,7 @@
 #include "icliententity.h"
 #include "tier2\tier2.h"
 
+IClientEntity* getPortal(const char* arg, bool verbose);
 bool invalidPortal(IClientEntity* portal);
 IClientEntity* GetEnvironmentPortal();
 void calculateAGPosition(Vector& new_player_origin, QAngle& new_player_angles);

--- a/spt/patterns.hpp
+++ b/spt/patterns.hpp
@@ -109,6 +109,11 @@ namespace patterns
 		         "83 3D ?? ?? ?? ?? 01 75 ?? 8B 0D ?? ?? ?? ?? 8B 01 8B ?? ?? FF D2 84 C0 75 ?? C7",
 		         "1910503",
 		         "83 3D ?? ?? ?? ?? 01 75 ?? 8B 0D ?? ?? ?? ?? 8B 01 8B ?? ?? FF D2 84 C0 75 ?? 68");
+		PATTERNS(DebugDrawPhysCollide,
+		         "5135",
+		         "81 EC 38 02 00 00 53 55 33 DB 39 9C 24 48 02 00 00 56 57 75 24",
+		         "1910503",
+		         "55 8B EC 81 EC 3C 02 00 00 53 33 DB 56 57 39 5D 0C 75 20");
 	} // namespace engine
 
 	namespace client
@@ -299,7 +304,9 @@ namespace patterns
 		PATTERNS(
 		    CHudDamageIndicator__GetDamagePosition,
 		    "5135",
-		    "83 EC 18 E8 ?? ?? ?? ?? e8 ?? ?? ?? ?? 8B 08 89 4C 24 0C 8B 50 04 6A 00 89 54 24 14 8B 40 08 6A 00 8D 4C 24 08 51 8D 54 24 18 52 89 44 24 24");
+		    "83 EC 18 E8 ?? ?? ?? ?? E8 ?? ?? ?? ?? 8B 08 89 4C 24 0C 8B 50 04 6A 00 89 54 24 14 8B 40 08 6A 00 8D 4C 24 08 51 8D 54 24 18 52 89 44 24 24",
+		    "1910503",
+		    "55 8B EC 83 EC 18 56 8B F1 E8 ?? ?? ?? ?? E8 ?? ?? ?? ?? F3 0F 7E 00 6A 00 6A 00 8D 4D F4 66 0F D6 45 E8");
 		PATTERNS(
 		    ResetToneMapping,
 		    "5135",
@@ -312,6 +319,11 @@ namespace patterns
 		    "55 8B EC 8B 0D ?? ?? ?? ?? 56 8B 01 FF 90 ?? ?? ?? ?? 8B F0 85 F6 74 ?? 8B 06 8B CE FF 50 ?? 8B 06 D9 45 ?? 51 8B CE",
 		    "te120",
 		    "55 8B EC 8B 0D ?? ?? ?? ?? 8B 01 8B 90 ?? ?? ?? ?? 56 FF D2 8B F0 85 F6 74 ?? 8B 06 8B 50 ?? 8B CE FF D2 8B 06");
+		PATTERNS(CRendering3dView__DrawTranslucentRenderables,
+		         "5135",
+		         "55 8B EC 83 EC 34 53 8B D9 8B 83 94 00 00 00 8B 13 56 8D B3 94 00 00 00",
+		         "1910503",
+		         "55 8B EC 81 EC 9C 00 00 00 53 56 8B F1 8B 86 E8 00 00 00 8B 16 57 8D BE E8 00 00 00");
 	} // namespace client
 
 	namespace server
@@ -538,6 +550,21 @@ namespace patterns
 		    "55 8B EC 81 EC ?? ?? ?? ?? 8B 41 08 8B 40 08 8B 50",
 		    "BMS-Retail",
 		    "55 8B EC 81 EC ?? ?? ?? ?? A1 ?? ?? ?? ?? 33 C5 89 45 FC 8B 41 ?? 56 8B 75 ?? 57 8B 40 ?? 8B 7D ?? 8B 50");
+		PATTERNS(CPhysicsCollision__CreateDebugMesh,
+		         "5135",
+		         "83 EC 10 8B 4C 24 14 8B 01 8B 40 08 55 56 57 33 ED 8D 54 24 10 52",
+		         "1910503",
+		         "55 8B EC 83 EC 14 8B 4D 08 8B 01 8B 40 08 53 56 57 33 DB 8D 55 EC");
+		PATTERNS(CPhysicsCollision__DestroyDebugMesh,
+		         "5135",
+		         "8B 44 24 08 50 E8 ?? ?? ?? ?? 59 C2 08 00",
+		         "1910503",
+		         "55 8B EC 8B 45 0C 50 E8 ?? ?? ?? ?? 83 C4 04 5D C2 08 00");
+		PATTERNS(CPhysicsObject__GetPosition,
+		         "5135",
+		         "8B 49 08 81 EC 80 00 00 00 8D 04 24 50 E8 ?? ?? ?? ?? 8B 84 24 84 00 00 00 85 C0",
+		         "1910503",
+		         "55 8B EC 8B 49 08 81 EC 80 00 00 00 8D 45 80 50 E8 ?? ?? ?? ?? 8B 45 08 85 C0");
 	} // namespace vphysics
 
 } // namespace patterns

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -52,6 +52,7 @@ namespace interfaces
 	IMatSystemSurface* surface = nullptr;
 	vgui::ISchemeManager* scheme = nullptr;
 	IVDebugOverlay* debugOverlay = nullptr;
+	IMaterialSystem* materialSystem = nullptr;
 	ICvar* g_pCVar = nullptr;
 	void* gm = nullptr;
 	IClientEntityList* entList;
@@ -150,6 +151,7 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 	interfaces::g_pCVar = g_pCVar;
 	interfaces::engine_server = (IVEngineServer*)interfaceFactory(INTERFACEVERSION_VENGINESERVER, NULL);
 	interfaces::debugOverlay = (IVDebugOverlay*)interfaceFactory(VDEBUG_OVERLAY_INTERFACE_VERSION, NULL);
+	interfaces::materialSystem = (IMaterialSystem*)interfaceFactory(MATERIAL_SYSTEM_INTERFACE_VERSION, NULL);
 
 	auto clientFactory = Sys_GetFactory("client");
 	interfaces::entList = (IClientEntityList*)clientFactory(VCLIENTENTITYLIST_INTERFACE_VERSION, NULL);
@@ -235,6 +237,9 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 		DevWarning("SPT: Failed to get the debug overlay interface.\n");
 		Warning("Seam visualization has no effect.\n");
 	}
+
+	if (!interfaces::materialSystem)
+		DevWarning("SPT: Failed to get the material system interface.\n");
 
 	if (!interfaces::entList)
 		DevWarning("Unable to retrieve entitylist interface.\n");

--- a/spt/utils/interfaces.hpp
+++ b/spt/utils/interfaces.hpp
@@ -17,6 +17,7 @@ namespace interfaces
 	extern IMatSystemSurface* surface;
 	extern vgui::ISchemeManager* scheme;
 	extern IVDebugOverlay* debugOverlay;
+	extern IMaterialSystem* materialSystem;
 	extern ICvar* g_pCVar;
 	extern void* gm;
 	extern IClientEntityList* entList;

--- a/spt/vgui/lines.cpp
+++ b/spt/vgui/lines.cpp
@@ -114,7 +114,7 @@ namespace vgui
 		if (!interfaces::debugOverlay || !utils::playerEntityAvailable())
 			return;
 
-		if (y_spt_drawseams.GetBool())
+		if (y_spt_draw_seams.GetBool())
 			DrawSeams(interfaces::debugOverlay);
 	}
 } // namespace vgui


### PR DESCRIPTION
### Changes
- Added physvis and sg-collide-vis features
- Added the following commands:
  - `y_spt_draw_portal_env 0|1`
  - `y_spt_draw_portal_env_ents 0|1`
  - `y_spt_draw_portal_env_remote 0|1`
  - `y_spt_draw_portal_env_type auto|collide|blue|orange|index`
  - `y_spt_draw_portal_env_wireframe 0|1`
- Added pattern for `CHudDamageIndicator__GetDamagePosition` and offset for `ORIG_MainViewOrigin` for version 1910503 (portal/hl2 steampipe)
- Fix isg feature not being enabled for version 1910503

### Saveglitch collision visualization
![Screenshot_4](https://user-images.githubusercontent.com/34390438/149612261-36ed216c-bd84-4c17-a20b-231854a818a5.png)

This is implemented largely using the system in the physvis feature.

### Physvis feature
This feature contains hooks/patterns for calling `DebugDrawPhysCollide`, which is the rendering function used by `vcollide_wireframe`. I implemented this in a very similar way to the hud feature - there is a vector of callbacks which are sorted by a given priority. From those callbacks you can call the following functions:
- DrawCPhysCollide
- DrawCPhysicsObject
- DrawCBaseEntity
- DrawCustomMesh

The first 3 can be used for drawing objects which have CPhysCollides (check out the sg-collision-vis feature). The last one allows you to pass in a custom array of verts (where each 3 consecutive verts form a triangle face), as well as a matrix which will be applied to the mesh. All meshes drawing have a simple unlit and/or wireframe material applied. Here's an example:
![mememan gif](https://user-images.githubusercontent.com/34390438/149611599-b2789303-0625-42a7-85ad-4011ff154357.gif)

Unfortunately I've hardcoded meme man to be the only mesh that you can use (/s).