### PR TITLE
Improve y_spt_find_portals

### DIFF
--- a/spt/overlay/portal_camera.cpp
+++ b/spt/overlay/portal_camera.cpp
@@ -18,8 +18,6 @@
 #include "interfaces.hpp"
 #include "..\features\ent_props.hpp"
 
-const int INDEX_MASK = MAX_EDICTS - 1;
-
 // From /game/shared/portal/prop_portal_shared.cpp
 void UpdatePortalTransformationMatrix(const matrix3x4_t& localToWorld,
                                       const matrix3x4_t& remoteToWorld,

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -31,10 +31,6 @@
 #include "cbase.h"
 #endif
 
-#ifndef OE
-const int INDEX_MASK = MAX_EDICTS - 1;
-#endif
-
 namespace utils
 {
 #ifndef OE

--- a/spt/utils/ent_utils.hpp
+++ b/spt/utils/ent_utils.hpp
@@ -8,6 +8,10 @@
 #include "iserverunknown.h"
 #include "trace.h"
 
+#ifndef OE
+const int INDEX_MASK = MAX_EDICTS - 1;
+#endif
+
 namespace utils
 {
 #ifndef OE


### PR DESCRIPTION
In-game, `y_spt_find_portals` is used when there are multiple portals and the overlay vars cannot determine the right portal to use. The only info that `y_spt_find_portals` prints is the portal position, which is just balls. This is especially balls with evanlin's VAG trace commands, so I've added some extra info and changed it to use client-side ents (and print client-side ent indices as well).
![unknown](https://user-images.githubusercontent.com/34390438/150220888-a73c13bd-0bb7-4d38-bb17-0efcf8f153cb.png)
![unknown](https://user-images.githubusercontent.com/34390438/150220896-050579dc-3bd1-4964-9d5e-bb7417a9d672.png)