### PR TITLE
Fixed overlay aspect ratio not adapting to the game screen

### DIFF
--- a/spt/features/overlay.cpp
+++ b/spt/features/overlay.cpp
@@ -59,6 +59,7 @@ void Overlay::InitHooks()
 {
 	HOOK_FUNCTION(client, CViewRender__Render);
 	HOOK_FUNCTION(client, CViewRender__RenderView);
+	FIND_PATTERN(engine, GetScreenAspect);
 }
 
 void Overlay::LoadFeature()
@@ -85,6 +86,16 @@ void Overlay::LoadFeature()
 }
 
 void Overlay::UnloadFeature() {}
+
+float Overlay::GetScreenAspectRatio()
+{
+	// The VEngineClient013 interface isn't compatible between 3420 and 5135,
+	// so we hook this function instead of using the SDK
+	// TODO: implement a custom interface to be used with the IVEngineClientWrapper and/or move to spt_generic if more features need this
+	if (spt_overlay.ORIG_GetScreenAspect)
+		return spt_overlay.ORIG_GetScreenAspect();
+	return 16.0f / 9.0f; // assume 16:9 as a default
+}
 
 void Overlay::DrawCrosshair()
 {

--- a/spt/features/overlay.hpp
+++ b/spt/features/overlay.hpp
@@ -4,6 +4,7 @@
 typedef void(
     __fastcall* _CViewRender__RenderView)(void* thisptr, int edx, void* cameraView, int nClearFlags, int whatToDraw);
 typedef void(__fastcall* _CViewRender__Render)(void* thisptr, int edx, void* rect);
+typedef float(__cdecl* _GetScreenAspect)();
 
 // Overlay hook stuff, could combine with overlay renderer as well
 class Overlay : public FeatureWrapper<Overlay>
@@ -11,6 +12,8 @@ class Overlay : public FeatureWrapper<Overlay>
 public:
 	bool renderingOverlay = false;
 	void* screenRect = nullptr;
+
+	float GetScreenAspectRatio();
 
 protected:
 	virtual bool ShouldLoadFeature() override;
@@ -25,6 +28,7 @@ private:
 	void DrawCrosshair();
 	_CViewRender__RenderView ORIG_CViewRender__RenderView = nullptr;
 	_CViewRender__Render ORIG_CViewRender__Render = nullptr;
+	_GetScreenAspect ORIG_GetScreenAspect = nullptr;
 
 	static void __fastcall HOOKED_CViewRender__RenderView(void* thisptr,
 	                                                      int edx,

--- a/spt/overlay/overlay-renderer.cpp
+++ b/spt/overlay/overlay-renderer.cpp
@@ -1,14 +1,14 @@
 #include "stdafx.h"
 
-#ifndef OE
+#ifdef SSDK2007
 #include "..\spt-serverplugin.hpp"
 #include "..\cvars.hpp"
+#include "..\features\overlay.hpp"
 #include "SDK\hl_movedata.h"
 #include "overlay-renderer.hpp"
 #include "overlays.hpp"
 
 OverlayRenderer g_OverlayRenderer;
-const float ASPECT_RATIO = 16.0f / 9.0f;
 const int VIEW_CLEAR = 1;
 const int VIEWMODEL_MASK = ~RENDERVIEW_DRAWVIEWMODEL;
 
@@ -83,20 +83,20 @@ void OverlayRenderer::modifyView(CViewSetup* view, bool overlay)
 		if (!shouldFlipScreens())
 		{
 			int width = _y_spt_overlay_width.GetFloat();
-			int height = static_cast<int>(width / ASPECT_RATIO);
+			int height = static_cast<int>(width / spt_overlay.GetScreenAspectRatio());
 			view->width = width;
 			view->height = height;
 		}
 
 		view->fov = getFOV();
-		view->m_flAspectRatio = ASPECT_RATIO;
+		view->m_flAspectRatio = spt_overlay.GetScreenAspectRatio();
 	}
 }
 
 Rect_t OverlayRenderer::getRect()
 {
 	int width = _y_spt_overlay_width.GetFloat();
-	int height = static_cast<int>(width / ASPECT_RATIO);
+	int height = static_cast<int>(width / spt_overlay.GetScreenAspectRatio());
 
 	Rect_t rect;
 	rect.x = 0;
@@ -109,7 +109,7 @@ Rect_t OverlayRenderer::getRect()
 
 float OverlayRenderer::getFOV()
 {
-	const float ratioRatio = ASPECT_RATIO / (4.0f / 3.0f);
+	const float ratioRatio = spt_overlay.GetScreenAspectRatio() / (4.0f / 3.0f);
 	float fovRad = DEG2RAD(_y_spt_overlay_fov.GetFloat());
 	float fov = 2 * RAD2DEG(std::atan(std::tan(fovRad / 2) * ratioRatio));
 

--- a/spt/patterns.hpp
+++ b/spt/patterns.hpp
@@ -114,6 +114,7 @@ namespace patterns
 		         "81 EC 38 02 00 00 53 55 33 DB 39 9C 24 48 02 00 00 56 57 75 24",
 		         "1910503",
 		         "55 8B EC 81 EC 3C 02 00 00 53 33 DB 56 57 39 5D 0C 75 20");
+		PATTERNS(GetScreenAspect, "5135", "83 EC 0C A1 ?? ?? ?? ?? F3");
 	} // namespace engine
 
 	namespace client


### PR DESCRIPTION
The overlay renderer doesn't adjust itself properly to the game's aspect ratio (only noticeable once _y_spt_overlay_swap is used). This fixes that by using the engine's GetScreenAspect function

Example in 21:9 aspect ratio, toggling _y_spt_overlay_swap
Before:
![before](https://user-images.githubusercontent.com/22877883/150294439-7900b75d-a828-48b9-8dca-08b6e73df511.gif)

After:
![after](https://user-images.githubusercontent.com/22877883/150294490-e8238fe6-18f0-4655-b80e-3da1b62b83ac.gif)
