### PR TITLE
no-transform overlay

### DIFF
--- a/spt/features/overlay.cpp
+++ b/spt/features/overlay.cpp
@@ -6,11 +6,15 @@ ConVar _y_spt_overlay("_y_spt_overlay",
                       "0",
                       FCVAR_CHEAT,
                       "Enables the overlay camera in the top left of the screen.\n");
-ConVar _y_spt_overlay_type(
-    "_y_spt_overlay_type",
-    "0",
-    FCVAR_CHEAT,
-    "Overlay type. 0 = save glitch body, 1 = angle glitch simulation, 2 = rear view mirror, 3 = havok view mirror.\n");
+ConVar _y_spt_overlay_type("_y_spt_overlay_type",
+                           "0",
+                           FCVAR_CHEAT,
+                           "Overlay type:\n"
+                           "  0 = save glitch body\n"
+                           "  1 = angle glitch simulation\n"
+                           "  2 = rear view mirror\n"
+                           "  3 = havok view mirror\n"
+                           "  4 = no camera transform (even when behind SG portal)\n");
 ConVar _y_spt_overlay_portal(
     "_y_spt_overlay_portal",
     "auto",

--- a/spt/overlay/overlay-renderer.cpp
+++ b/spt/overlay/overlay-renderer.cpp
@@ -67,8 +67,11 @@ void OverlayRenderer::modifyView(CViewSetup* view, bool overlay)
 		case 2:
 			data = rearViewMirrorOverlay();
 			break;
-		default:
+		case 3:
 			data = havokViewMirrorOverlay();
+			break;
+		default:
+			data = noTransformOverlay();
 			break;
 		}
 

--- a/spt/overlay/overlays.cpp
+++ b/spt/overlay/overlays.cpp
@@ -11,16 +11,8 @@
 
 CameraInformation rearViewMirrorOverlay()
 {
-	CameraInformation info;
-
-	auto pos = utils::GetPlayerEyePosition();
-	auto angles = utils::GetPlayerEyeAngles();
-
-	info.x = pos.x;
-	info.y = pos.y;
-	info.z = pos.z;
-	info.pitch = angles[PITCH];
-	info.yaw = utils::NormalizeDeg(angles[YAW] + 180);
+	CameraInformation info = noTransformOverlay();
+	info.yaw = utils::NormalizeDeg(info.yaw + 180);
 	return info;
 }
 
@@ -75,4 +67,19 @@ CameraInformation agOverlay()
 
 	return info;
 }
+
+CameraInformation noTransformOverlay()
+{
+	CameraInformation info;
+
+	auto pos = utils::GetPlayerEyePosition();
+	auto angles = utils::GetPlayerEyeAngles();
+	info.x = pos.x;
+	info.y = pos.y;
+	info.z = pos.z;
+	info.pitch = angles[PITCH];
+	info.yaw = utils::NormalizeDeg(angles[YAW]);
+	return info;
+}
+
 #endif

--- a/spt/overlay/overlays.hpp
+++ b/spt/overlay/overlays.hpp
@@ -6,4 +6,6 @@ CameraInformation rearViewMirrorOverlay();
 CameraInformation havokViewMirrorOverlay();
 CameraInformation sgOverlay();
 CameraInformation agOverlay();
+CameraInformation noTransformOverlay();
+
 #endif


### PR DESCRIPTION
Added an overlay that does not transform the camera (I meant to push this along with sg collision stuff but forgot).
Why?
Well, when you're behind your saveglitch portal _and_ in contact with the portal hole, you have collision with geometry from the remote portal, _**but**_ your camera is also transformed to the other portal meaning that it can be difficult to figure out exactly where/what you have collision with.

For this video I saveglitched on blue and have enabled the following commands:
- `y_spt_draw_portal_env 1`
- `y_spt_draw_portal_env_remote 1`
- `_y_spt_overlay 1`
- `_y_spt_overlay_swap 1`
- `_y_spt_overlay_type 69420`

So the top left shows what you normally see, and in the main screen you can see where the player is and exactly what geometry you have collision with. Notice that as soon as I stop touching the portal hole, the normal view snaps to the actual player location and you lose collision with the remote geometry.

https://user-images.githubusercontent.com/34390438/151457715-64d20976-38cd-464a-a911-18f56e3b01ea.mp4

(Also, it makes sense for the overlay to do nothing by default.)
