### PR TITLE
Added VAG searcher and VAG trace

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1162,6 +1162,8 @@
     <ClCompile Include="spt\features\timer.cpp" />
     <ClCompile Include="spt\features\tracing.cpp" />
     <ClCompile Include="spt\features\vag.cpp" />
+    <ClCompile Include="spt\features\vag_searcher.cpp" />
+    <ClCompile Include="spt\features\vag_trace.cpp" />
     <ClCompile Include="spt\features\visual_fixes.cpp" />
     <ClCompile Include="spt\ipc\ipc.cpp" />
     <ClCompile Include="sptlib\sptlib.cpp">
@@ -1355,6 +1357,7 @@
     <ClInclude Include="spt\features\tas.hpp" />
     <ClInclude Include="spt\features\tickrate.hpp" />
     <ClInclude Include="spt\features\tracing.hpp" />
+    <ClInclude Include="spt\features\vag_searcher.hpp" />
     <ClInclude Include="spt\ipc\ipc.hpp" />
     <ClInclude Include="spt\overlay\overlay-renderer.hpp" />
     <ClInclude Include="spt\overlay\overlays.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -229,6 +229,12 @@
     <ClCompile Include="spt\features\sg-collide-vis.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\vag_searcher.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
+    <ClCompile Include="spt\features\vag_trace.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">
@@ -499,6 +505,9 @@
       <Filter>spt\features</Filter>
     </ClInclude>
     <ClInclude Include="spt\features\physvis.hpp">
+      <Filter>spt\features</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\features\vag_searcher.hpp">
       <Filter>spt\features</Filter>
     </ClInclude>
   </ItemGroup>

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -25,6 +25,9 @@ extern ConVar y_spt_draw_portal_env_type;
 extern ConVar y_spt_draw_portal_env_ents;
 extern ConVar y_spt_draw_portal_env_remote;
 extern ConVar y_spt_draw_portal_env_wireframe;
+extern ConVar y_spt_vag_search_portal;
+extern ConVar y_spt_vag_trace;
+extern ConVar y_spt_vag_target;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -28,6 +28,7 @@ extern ConVar y_spt_draw_portal_env_wireframe;
 extern ConVar y_spt_vag_search_portal;
 extern ConVar y_spt_vag_trace;
 extern ConVar y_spt_vag_target;
+extern ConVar y_spt_vag_trace_portal;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -41,7 +41,6 @@ bool InputHud::ShouldLoadFeature()
 
 void InputHud::InitHooks()
 {
-	FIND_PATTERN(client, DecodeUserCmdFromBuffer);
 	HOOK_FUNCTION(client, DecodeUserCmdFromBuffer);
 }
 
@@ -49,22 +48,22 @@ void InputHud::LoadFeature()
 {
 	if (!loadingSuccessful)
 		return;
-	CreateMoveSignal.Connect(this, &InputHud::CreateMove);
-		ihudFont = spt_hud.scheme->GetFont(y_spt_ihud_font.GetString(), false);
+	if (CreateMoveSignal.Works)
+		CreateMoveSignal.Connect(this, &InputHud::CreateMove);
+	ihudFont = spt_hud.scheme->GetFont(y_spt_ihud_font.GetString(), false);
 
-		bool result = AddHudCallback("ihud", std::bind(&InputHud::DrawInputHud, this), y_spt_ihud);
-		if (result)
-		{
-			InitConcommandBase(y_spt_ihud_button_color);
-			InitConcommandBase(y_spt_ihud_shadow_color);
-			InitConcommandBase(y_spt_ihud_font_color);
-			InitConcommandBase(y_spt_ihud_shadow_font_color);
-			InitConcommandBase(y_spt_ihud_grid_size);
-			InitConcommandBase(y_spt_ihud_grid_padding);
-			InitConcommandBase(y_spt_ihud_font);
-			InitConcommandBase(y_spt_ihud_x);
-			InitConcommandBase(y_spt_ihud_y);
-		}
+	bool result = AddHudCallback("ihud", std::bind(&InputHud::DrawInputHud, this), y_spt_ihud);
+	if (result)
+	{
+		InitConcommandBase(y_spt_ihud_button_color);
+		InitConcommandBase(y_spt_ihud_shadow_color);
+		InitConcommandBase(y_spt_ihud_font_color);
+		InitConcommandBase(y_spt_ihud_shadow_font_color);
+		InitConcommandBase(y_spt_ihud_grid_size);
+		InitConcommandBase(y_spt_ihud_grid_padding);
+		InitConcommandBase(y_spt_ihud_font);
+		InitConcommandBase(y_spt_ihud_x);
+		InitConcommandBase(y_spt_ihud_y);
 	}
 }
 

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -50,20 +50,21 @@ void InputHud::LoadFeature()
 	if (!loadingSuccessful)
 		return;
 	CreateMoveSignal.Connect(this, &InputHud::CreateMove);
-	ihudFont = spt_hud.scheme->GetFont(y_spt_ihud_font.GetString(), false);
+		ihudFont = spt_hud.scheme->GetFont(y_spt_ihud_font.GetString(), false);
 
-	bool result = AddHudCallback("ihud", std::bind(&InputHud::DrawInputHud, this), y_spt_ihud);
-	if (result)
-	{
-		InitConcommandBase(y_spt_ihud_button_color);
-		InitConcommandBase(y_spt_ihud_shadow_color);
-		InitConcommandBase(y_spt_ihud_font_color);
-		InitConcommandBase(y_spt_ihud_shadow_font_color);
-		InitConcommandBase(y_spt_ihud_grid_size);
-		InitConcommandBase(y_spt_ihud_grid_padding);
-		InitConcommandBase(y_spt_ihud_font);
-		InitConcommandBase(y_spt_ihud_x);
-		InitConcommandBase(y_spt_ihud_y);
+		bool result = AddHudCallback("ihud", std::bind(&InputHud::DrawInputHud, this), y_spt_ihud);
+		if (result)
+		{
+			InitConcommandBase(y_spt_ihud_button_color);
+			InitConcommandBase(y_spt_ihud_shadow_color);
+			InitConcommandBase(y_spt_ihud_font_color);
+			InitConcommandBase(y_spt_ihud_shadow_font_color);
+			InitConcommandBase(y_spt_ihud_grid_size);
+			InitConcommandBase(y_spt_ihud_grid_padding);
+			InitConcommandBase(y_spt_ihud_font);
+			InitConcommandBase(y_spt_ihud_x);
+			InitConcommandBase(y_spt_ihud_y);
+		}
 	}
 }
 

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -196,6 +196,8 @@ void __fastcall PlayerIOFeature::HOOKED_CreateMove_Func(void* thisptr,
 
 	ORIG_CreateMove(thisptr, edx, sequence_number, input_sample_frametime, active);
 
+	CreateMoveSignal(pCmd);
+	
 	pCmd = 0;
 }
 

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -197,7 +197,7 @@ void __fastcall PlayerIOFeature::HOOKED_CreateMove_Func(void* thisptr,
 	ORIG_CreateMove(thisptr, edx, sequence_number, input_sample_frametime, active);
 
 	CreateMoveSignal(pCmd);
-	
+
 	pCmd = 0;
 }
 

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -196,8 +196,6 @@ void __fastcall PlayerIOFeature::HOOKED_CreateMove_Func(void* thisptr,
 
 	ORIG_CreateMove(thisptr, edx, sequence_number, input_sample_frametime, active);
 
-	CreateMoveSignal(pCmd);
-
 	pCmd = 0;
 }
 

--- a/spt/features/vag.cpp
+++ b/spt/features/vag.cpp
@@ -5,7 +5,7 @@
 #include "..\feature.hpp"
 #include "..\utils\game_detection.hpp"
 #include "..\cvars.hpp"
-#include "vag_searcher.hpp"
+#include "signals.hpp"
 
 #include "dbg.h"
 
@@ -57,6 +57,7 @@ void VAG::LoadFeature()
 	if (ORIG_MiddleOfTeleportTouchingEntity && ORIG_EndOfTeleportTouchingEntity)
 	{
 		InitConcommandBase(y_spt_prevent_vag_crash);
+		VagCrashSignal.Works = true;
 	}
 	recursiveTeleportCount = 0;
 }
@@ -129,7 +130,7 @@ void __fastcall VAG::HOOKED_MiddleOfTeleportTouchingEntity_Func(void* portalPtr,
 		entPos->x -= portalNorm->x;
 		entPos->y -= portalNorm->y;
 		entPos->z -= portalNorm->z;
-		spt_vag_searcher.VagCrashTriggered();
+		VagCrashSignal();
 	}
 }
 

--- a/spt/features/vag.cpp
+++ b/spt/features/vag.cpp
@@ -5,6 +5,7 @@
 #include "..\feature.hpp"
 #include "..\utils\game_detection.hpp"
 #include "..\cvars.hpp"
+#include "vag_searcher.hpp"
 
 #include "dbg.h"
 
@@ -128,6 +129,7 @@ void __fastcall VAG::HOOKED_MiddleOfTeleportTouchingEntity_Func(void* portalPtr,
 		entPos->x -= portalNorm->x;
 		entPos->y -= portalNorm->y;
 		entPos->z -= portalNorm->z;
+		spt_vag_searcher.VagCrashTriggered();
 	}
 }
 

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -13,10 +13,11 @@
 
 VagSearcher spt_vag_searcher;
 
-ConVar y_spt_vag_search_portal("y_spt_vag_search_portal",
-                               "overlay",
-                               FCVAR_CHEAT,
-                               "Chooses the portal for the VAG search. Valid options are overlay/blue/orange/portal index. This is the portal you enter.\n");
+ConVar y_spt_vag_search_portal(
+    "y_spt_vag_search_portal",
+    "overlay",
+    FCVAR_CHEAT,
+    "Chooses the portal for the VAG search. Valid options are overlay/blue/orange/portal index. This is the portal you enter.\n");
 
 CON_COMMAND(y_spt_vag_search, "Search VAG")
 {
@@ -27,7 +28,7 @@ void VagSearcher::StartSearch()
 {
 	if (IsIterating())
 		return;
-	
+
 	if (strcmp(y_spt_vag_search_portal.GetString(), "overlay") == 0)
 	{
 		enter_portal = getPortal(_y_spt_overlay_portal.GetString(), false);
@@ -36,30 +37,30 @@ void VagSearcher::StartSearch()
 	{
 		enter_portal = getPortal(y_spt_vag_search_portal.GetString(), false);
 	}
-	
+
 	if (!enter_portal)
 	{
 		Msg("Entry portal not found, maybe try using index.\n");
 		return;
 	}
-		
+
 	exit_portal = GetLinkedPortal(enter_portal);
 	if (!exit_portal)
 	{
 		Msg("Exit portal not found, maybe try using index.\n");
 		return;
 	}
-		
+
 	entry_index = enter_portal->entindex();
 	exit_index = exit_portal->entindex();
-	
+
 	if (utils::GetProperty<int>(entry_index - 1, "m_bActivated") == 0
 	    || utils::GetProperty<int>(exit_index - 1, "m_bActivated") == 0)
 	{
 		Msg("Portal not activated.\n");
 		return;
 	}
-	
+
 	StartIterations();
 }
 
@@ -98,7 +99,7 @@ void VagSearcher::StartIterations()
 		Msg("Auto enable y_spt_prevent_vag_crash.\n");
 		y_spt_prevent_vag_crash.SetValue(1);
 	}
-    
+
 	entry_origin = utils::GetPortalPosition(enter_portal);
 	auto angle = utils::GetPortalAngles(enter_portal);
 	// angles_to_vec
@@ -222,7 +223,8 @@ VagSearcher::VagSearchResult VagSearcher::RunIteration()
 	return ITERATING;
 }
 
-void VagSearcher::OnTick() {
+void VagSearcher::OnTick()
+{
 	if (IsIterating())
 	{
 		if (cooldown)

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
-#if defined(SSDK2007)
+#if defined(SSDK2007) || defined(SSDK2013)
 #include "vag_searcher.hpp"
+
 #include "interfaces.hpp"
 #include "property_getter.hpp"
 #include "ent_utils.hpp"
@@ -76,6 +77,10 @@ void VagSearcher::LoadFeature()
 	if (TickSignal.Works)
 	{
 		TickSignal.Connect(this, &VagSearcher::OnTick);
+	}
+	if (VagCrashSignal.Works)
+	{
+		VagCrashSignal.Connect(this, &VagSearcher::VagCrashTriggered);
 	}
 }
 

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -1,0 +1,235 @@
+#include "stdafx.h"
+#if defined(SSDK2007)
+#include "vag_searcher.hpp"
+#include "interfaces.hpp"
+#include "property_getter.hpp"
+#include "ent_utils.hpp"
+#include "..\utils\game_detection.hpp"
+#include "playerio.hpp"
+#include "signals.hpp"
+#include "..\sptlib-wrapper.hpp"
+#include "..\cvars.hpp"
+
+VagSearcher spt_vag_searcher;
+
+ConVar y_spt_vag_search_portal("y_spt_vag_search_portal",
+                               "overlay",
+                               FCVAR_CHEAT,
+                               "Chooses the portal for the VAG search. Valid options are overlay/blue/orange/portal index. This is the portal you enter.\n");
+
+CON_COMMAND(y_spt_vag_search, "Search VAG")
+{
+	spt_vag_searcher.StartSearch();
+}
+
+void VagSearcher::StartSearch()
+{
+	if (IsIterating())
+		return;
+	
+	if (strcmp(y_spt_vag_search_portal.GetString(), "overlay") == 0)
+	{
+		enter_portal = getPortal(_y_spt_overlay_portal.GetString(), false);
+	}
+	else
+	{
+		enter_portal = getPortal(y_spt_vag_search_portal.GetString(), false);
+	}
+	
+	if (!enter_portal)
+	{
+		Msg("Entry portal not found, maybe try using index.\n");
+		return;
+	}
+		
+	exit_portal = GetLinkedPortal(enter_portal);
+	if (!exit_portal)
+	{
+		Msg("Exit portal not found, maybe try using index.\n");
+		return;
+	}
+		
+	entry_index = enter_portal->entindex();
+	exit_index = exit_portal->entindex();
+	
+	if (utils::GetProperty<int>(entry_index - 1, "m_bActivated") == 0
+	    || utils::GetProperty<int>(exit_index - 1, "m_bActivated") == 0)
+	{
+		Msg("Portal not activated.\n");
+		return;
+	}
+	
+	StartIterations();
+}
+
+bool VagSearcher::ShouldLoadFeature()
+{
+	return utils::DoesGameLookLikePortal();
+}
+
+void VagSearcher::InitHooks() {}
+
+void VagSearcher::LoadFeature()
+{
+	InitCommand(y_spt_vag_search);
+	InitConcommandBase(y_spt_vag_search_portal);
+	if (TickSignal.Works)
+	{
+		TickSignal.Connect(this, &VagSearcher::OnTick);
+	}
+}
+
+void VagSearcher::UnloadFeature() {}
+
+void VagSearcher::VagCrashTriggered()
+{
+	crash = true;
+}
+
+void VagSearcher::StartIterations()
+{
+	if (!y_spt_prevent_vag_crash.GetBool())
+	{
+		Msg("Auto enable y_spt_prevent_vag_crash.\n");
+		y_spt_prevent_vag_crash.SetValue(1);
+	}
+    
+	entry_origin = utils::GetPortalPosition(enter_portal);
+	auto angle = utils::GetPortalAngles(enter_portal);
+	// angles_to_vec
+	angle *= (M_PI_F / 180);
+	entry_norm = Vector(std::cos(angle[1]) * std::cos(angle[0]),
+	                    std::sin(angle[1]) * std::cos(angle[0]),
+	                    std::sin(-angle[0]));
+	exit_origin = utils::GetPortalPosition(exit_portal);
+	is_crouched = (utils::GetProperty<int>(0, "m_fFlags") & 2) != 0;
+	// change z pos so player center is where the portal center is
+	player_half_height = is_crouched ? 18 : 36;
+	player_setpos = entry_origin;
+	player_setpos.z -= player_half_height;
+
+	// save only component of the portal normal with the largest magnitude, we'll be moving along in that axis
+	no_idx = 0;
+	auto max_value = std::abs(entry_norm[0]);
+	for (int i = 1; i < 3; i++)
+	{
+		if (std::abs(entry_norm[i]) > max_value)
+		{
+			max_value = std::abs(entry_norm[i]);
+			no_idx = i;
+		}
+	}
+
+	first_result = NONE;
+	iteration = max_iteration;
+
+	// start first iteration
+	DevMsg("Iteration %d\n", max_iteration - iteration + 1);
+	crash = false;
+	setpos_cmd = "setpos " + std::to_string(player_setpos.x) + " " + std::to_string(player_setpos.y) + " "
+	             + std::to_string(player_setpos.z);
+	DevMsg("Trying: %s\n", setpos_cmd.c_str());
+	EngineConCmd(setpos_cmd.c_str());
+	// the player position is wacky - it doesn't seem to be valid right away
+	cooldown = cooldown_ticks;
+}
+
+VagSearcher::VagSearchResult VagSearcher::RunIteration()
+{
+	if (crash)
+	{
+		Msg("This VAG would normally cause a crash, not possible here.\n");
+		crash = false;
+		return WOULD_CAUSE_CRASH;
+	}
+	auto new_player_pos = utils::GetProperty<Vector>(0, "m_vecOrigin");
+	new_player_pos.z += player_half_height;
+
+	// idk how to use this
+	auto player_portal_idx = utils::GetProperty<int>(0, "m_hPortalEnvironment") & 0xfff;
+
+	DevMsg("Player pos: %f %f %f\n", new_player_pos.x, new_player_pos.y, new_player_pos.z);
+	if (player_portal_idx == entry_index)
+	{
+		current_result = NEXT_TO_ENTRY;
+	}
+	else if (player_portal_idx == exit_index)
+	{
+		current_result = NEXT_TO_EXIT;
+	}
+	else if ((new_player_pos - entry_origin).IsLengthLessThan(1.0f))
+	{
+		// behind portal but didn't teleport
+		current_result = BEHIND_ENTRY_PLANE;
+	}
+	else
+	{
+		Msg("VAG probably worked: %s\n", setpos_cmd.c_str());
+		return SUCCESS;
+	}
+
+	if (first_result == NONE && current_result != BEHIND_ENTRY_PLANE)
+	{
+		first_result = current_result;
+	}
+
+	if (current_result == NEXT_TO_ENTRY)
+	{
+		if (first_result == NEXT_TO_EXIT)
+		{
+			Msg("No VAG found\n");
+			return FAIL;
+		}
+		DevMsg("Trying setpos closer to portal,\n");
+		player_setpos[no_idx] = std::nextafterf(player_setpos[no_idx], entry_norm[no_idx] * -INFINITY);
+	}
+	else if (current_result == NEXT_TO_EXIT)
+	{
+		if (first_result == NEXT_TO_ENTRY)
+		{
+			Msg("No VAG found,\n");
+			return FAIL;
+		}
+		DevMsg("Trying setpos further from portal.\n");
+		player_setpos[no_idx] = std::nextafterf(player_setpos[no_idx], entry_norm[no_idx] * INFINITY);
+	}
+	else
+	{
+		DevMsg("Behind portal plane, trying setpos further from portal.\n");
+		player_setpos[no_idx] = std::nextafterf(player_setpos[no_idx], entry_norm[no_idx] * INFINITY);
+	}
+
+	iteration--;
+	if (iteration <= 0)
+	{
+		Msg("Maximum iterations reached.\n");
+		return MAX_ITERATIONS;
+	}
+
+	// next iteration
+	DevMsg("Iteration %d\n", max_iteration - iteration + 1);
+	crash = false;
+	setpos_cmd = "setpos " + std::to_string(player_setpos.x) + " " + std::to_string(player_setpos.y) + " "
+	             + std::to_string(player_setpos.z);
+	DevMsg("Trying: %s\n", setpos_cmd.c_str());
+	EngineConCmd(setpos_cmd.c_str());
+	cooldown = cooldown_ticks;
+	return ITERATING;
+}
+
+void VagSearcher::OnTick() {
+	if (IsIterating())
+	{
+		if (cooldown)
+		{
+			cooldown--;
+		}
+		else if (RunIteration() != ITERATING)
+		{
+			Msg("Finished in %d iteration(s).\n", max_iteration - iteration + 1);
+			iteration = 0;
+		}
+	}
+}
+
+#endif

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -102,11 +102,8 @@ void VagSearcher::StartIterations()
 
 	entry_origin = utils::GetPortalPosition(enter_portal);
 	auto angle = utils::GetPortalAngles(enter_portal);
-	// angles_to_vec
-	angle *= (M_PI_F / 180);
-	entry_norm = Vector(std::cos(angle[1]) * std::cos(angle[0]),
-	                    std::sin(angle[1]) * std::cos(angle[0]),
-	                    std::sin(-angle[0]));
+	AngleVectors(angle, &entry_norm);
+
 	exit_origin = utils::GetPortalPosition(exit_portal);
 	is_crouched = (utils::GetProperty<int>(0, "m_fFlags") & 2) != 0;
 	// change z pos so player center is where the portal center is
@@ -151,7 +148,6 @@ VagSearcher::VagSearchResult VagSearcher::RunIteration()
 	auto new_player_pos = utils::GetProperty<Vector>(0, "m_vecOrigin");
 	new_player_pos.z += player_half_height;
 
-	// idk how to use this
 	auto player_portal_idx = utils::GetProperty<int>(0, "m_hPortalEnvironment") & 0xfff;
 
 	DevMsg("Player pos: %f %f %f\n", new_player_pos.x, new_player_pos.y, new_player_pos.z);

--- a/spt/features/vag_searcher.hpp
+++ b/spt/features/vag_searcher.hpp
@@ -1,0 +1,71 @@
+#pragma once
+#if defined(SSDK2007)
+#include "..\feature.hpp"
+#include "icliententity.h"
+
+extern IClientEntity* getPortal(const char* arg, bool verbose);
+extern IClientEntity* GetLinkedPortal(IClientEntity* portal);
+
+// VAG tester
+class VagSearcher : public Feature
+{
+public:
+	void StartSearch();
+	void VagCrashTriggered();
+	bool IsIterating()
+	{
+		return iteration != 0;
+	}
+	enum VagSearchResult
+	{
+		ITERATING,
+		SUCCESS,
+		FAIL,
+		MAX_ITERATIONS,
+		WOULD_CAUSE_CRASH
+	};
+	enum SearchResult
+	{
+		NONE,
+		NEXT_TO_ENTRY,
+		NEXT_TO_EXIT,
+		BEHIND_ENTRY_PLANE
+	};
+	void StartIterations();
+	VagSearchResult RunIteration();
+	void OnTick();
+
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void InitHooks() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void UnloadFeature() override;
+
+private:
+	const int cooldown_ticks = 2;
+	int cooldown;
+	const int max_iteration = 35;
+	int iteration = 0;
+	bool crash;
+	IClientEntity* enter_portal = NULL;
+	IClientEntity* exit_portal = NULL;
+	int entry_index;
+	int exit_index;
+	Vector entry_origin;
+	Vector entry_norm;
+	Vector exit_origin;
+	bool is_crouched;
+	int player_half_height;
+	Vector player_setpos;
+	int no_idx;
+	SearchResult first_result = NONE;
+	SearchResult current_result;
+	std::string setpos_cmd;
+};
+
+extern VagSearcher spt_vag_searcher;
+
+#endif

--- a/spt/features/vag_searcher.hpp
+++ b/spt/features/vag_searcher.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(SSDK2007)
+#if defined(SSDK2007) || defined(SSDK2013)
 #include "..\feature.hpp"
 #include "icliententity.h"
 
@@ -7,7 +7,7 @@ extern IClientEntity* getPortal(const char* arg, bool verbose);
 extern IClientEntity* GetLinkedPortal(IClientEntity* portal);
 
 // VAG tester
-class VagSearcher : public Feature
+class VagSearcher : public FeatureWrapper<VagSearcher>
 {
 public:
 	void StartSearch();
@@ -45,9 +45,9 @@ protected:
 	virtual void UnloadFeature() override;
 
 private:
-	const int cooldown_ticks = 2;
+	int cooldown_ticks = 2;
 	int cooldown;
-	const int max_iteration = 35;
+	int max_iteration = 35;
 	int iteration = 0;
 	bool crash;
 	IClientEntity* enter_portal = NULL;

--- a/spt/features/vag_trace.cpp
+++ b/spt/features/vag_trace.cpp
@@ -211,10 +211,22 @@ Vector VagTrace::ReverseAG(Vector enter_origin, QAngle enter_angles, QAngle exit
 		invdet = 1 / det;
 	}
 
-	VMatrix enter_mat(enter[0][0], enter[0][1], enter[0][2], 0,
-	                  enter[1][0], enter[1][1], enter[1][2], 0,
-	                  enter[2][0], enter[2][1], enter[2][2], 0,
-	                  0, 0, 0, 1);
+	VMatrix enter_mat(enter[0][0],
+	                  enter[0][1],
+	                  enter[0][2],
+	                  0,
+	                  enter[1][0],
+	                  enter[1][1],
+	                  enter[1][2],
+	                  0,
+	                  enter[2][0],
+	                  enter[2][1],
+	                  enter[2][2],
+	                  0,
+	                  0,
+	                  0,
+	                  0,
+	                  1);
 	VMatrix inv;
 	enter_mat.InverseGeneral(inv);
 	Vector inv_enter[3] = {{inv[0][0], inv[0][1], inv[0][2]},
@@ -244,10 +256,22 @@ Vector VagTrace::ReverseAG(Vector enter_origin, QAngle enter_angles, QAngle exit
 		invdet = 1 / det;
 	}
 
-	VMatrix exit_mat(exit[0][0], exit[0][1], exit[0][2], 0,
-	                 exit[1][0], exit[1][1], exit[1][2], 0,
-	                 exit[2][0], exit[2][1], exit[2][2], 0,
-	                 0, 0, 0, 1);
+	VMatrix exit_mat(exit[0][0],
+	                 exit[0][1],
+	                 exit[0][2],
+	                 0,
+	                 exit[1][0],
+	                 exit[1][1],
+	                 exit[1][2],
+	                 0,
+	                 exit[2][0],
+	                 exit[2][1],
+	                 exit[2][2],
+	                 0,
+	                 0,
+	                 0,
+	                 0,
+	                 1);
 	exit_mat.InverseGeneral(inv);
 	Vector inv_exit_angles[3] = {{inv[0][0], inv[0][1], inv[0][2]},
 	                             {inv[1][0], inv[1][1], inv[1][2]},

--- a/spt/features/vag_trace.cpp
+++ b/spt/features/vag_trace.cpp
@@ -67,7 +67,7 @@ void VagTrace::DrawTrace()
 		                                        100,
 		                                        lifeTime);
 	}
-	
+
 	auto enter_portal = getPortal(_y_spt_overlay_portal.GetString(), false);
 	if (!enter_portal)
 		return;
@@ -91,7 +91,7 @@ void VagTrace::DrawTrace()
 		                     0,
 		                     true,
 		                     lifeTime);
-		
+
 		if (abs(abs(exit_angles.x) - 90) < 0.04 && abs(exit_angles.z) < 0.04)
 		{
 			// Is floor/ceiling portal
@@ -113,7 +113,7 @@ void VagTrace::DrawTrace()
 		                         {0.0f, -90.0f, 0.0f},
 		                         {0.0f, 180.0f, 0.0f}};
 		Vector wall_normal[4] = {{1.0f, 0.0f, 0.0f},
-		                         {0.0f, 1.0f, 0.0f}, 
+		                         {0.0f, 1.0f, 0.0f},
 		                         {0.0f, -1.0f, 0.0f},
 		                         {-1.0f, 0.0f, 0.0f}};
 		for (int i = 0; i < 4; i++)

--- a/spt/features/vag_trace.cpp
+++ b/spt/features/vag_trace.cpp
@@ -1,0 +1,273 @@
+#include "stdafx.h"
+
+#if defined(SSDK2007)
+#include "..\feature.hpp"
+#include "icliententity.h"
+#include "..\utils\game_detection.hpp"
+#include "ent_utils.hpp"
+#include "interfaces.hpp"
+#include "..\cvars.hpp"
+#include "tickrate.hpp"
+#include "signals.hpp"
+#include "playerio.hpp"
+
+extern IClientEntity* getPortal(const char* arg, bool verbose);
+extern IClientEntity* GetLinkedPortal(IClientEntity* portal);
+
+ConVar y_spt_vag_trace("y_spt_vag_trace", "0", FCVAR_CHEAT, "Draws VAG trace.\n");
+ConVar y_spt_vag_target("y_spt_vag_target", "0", FCVAR_CHEAT, "Draws VAG target trace.\n");
+
+// VAG finding tool
+class VagTrace : public Feature
+{
+public:
+	void DrawTrace();
+
+	Vector CalculateAG(Vector enter_origin, QAngle enter_angles, Vector exit_origin, QAngle exit_angles);
+
+	void SetTarget(Vector target);
+
+	Vector ReverseAG(Vector enter_origin, QAngle enter_angles, QAngle exit_angles);
+
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void UnloadFeature() override;
+
+private:
+	Vector target = {0.0f, 0.0f, 0.0f};
+};
+
+VagTrace spt_vag_trace;
+
+CON_COMMAND(y_spt_vag_target_set, "Set VAG target\n")
+{
+	spt_vag_trace.SetTarget(spt_playerio.GetPlayerEyePos());
+}
+
+void VagTrace::DrawTrace()
+{
+	bool vag_trace = y_spt_vag_trace.GetBool();
+	bool vag_target = y_spt_vag_target.GetBool();
+	if (!vag_trace && !vag_target)
+		return;
+
+	float lifeTime = spt_tickrate.GetTickrate() * 2;
+	if (vag_target)
+	{
+		interfaces::debugOverlay->AddBoxOverlay(target,
+		                                        Vector(-20, -20, -20),
+		                                        Vector(20, 20, 20),
+		                                        QAngle(0, 0, 0),
+		                                        255,
+		                                        255,
+		                                        0,
+		                                        100,
+		                                        lifeTime);
+	}
+	
+	auto enter_portal = getPortal(_y_spt_overlay_portal.GetString(), false);
+	if (!enter_portal)
+		return;
+	auto exit_portal = GetLinkedPortal(enter_portal);
+	if (!exit_portal)
+		return;
+
+	auto enter_origin = utils::GetPortalPosition(enter_portal);
+	auto enter_angles = utils::GetPortalAngles(enter_portal);
+	auto exit_origin = utils::GetPortalPosition(exit_portal);
+	auto exit_angles = utils::GetPortalAngles(exit_portal);
+
+	if (y_spt_vag_trace.GetBool())
+	{
+		interfaces::debugOverlay->AddLineOverlay(enter_origin, exit_origin, 0, 0, 255, true, lifeTime);
+		interfaces::debugOverlay
+		    ->AddLineOverlay(CalculateAG(enter_origin, enter_angles, exit_origin, exit_angles),
+		                     enter_origin,
+		                     0,
+		                     255,
+		                     0,
+		                     true,
+		                     lifeTime);
+		
+		if (abs(abs(exit_angles.x) - 90) < 0.04 && abs(exit_angles.z) < 0.04)
+		{
+			// Is floor/ceiling portal
+			QAngle angle = exit_angles;
+			angle.y = 179.0f;
+			Vector prev = CalculateAG(enter_origin, enter_angles, exit_origin, angle);
+			for (angle.y = -180.0f; angle.y < 180.0f; angle.y += 1.0f)
+			{
+				Vector curr = CalculateAG(enter_origin, enter_angles, exit_origin, angle);
+				interfaces::debugOverlay->AddLineOverlay(curr, prev, 255, 255, 255, false, lifeTime);
+				prev = curr;
+			}
+		}
+	}
+	if (y_spt_vag_target.GetBool())
+	{
+		QAngle wall_angles[4] = {{0.0f, 0.0f, 0.0f},
+		                         {0.0f, 90.0f, 0.0f},
+		                         {0.0f, -90.0f, 0.0f},
+		                         {0.0f, 180.0f, 0.0f}};
+		Vector wall_normal[4] = {{1.0f, 0.0f, 0.0f},
+		                         {0.0f, 1.0f, 0.0f}, 
+		                         {0.0f, -1.0f, 0.0f},
+		                         {-1.0f, 0.0f, 0.0f}};
+		for (int i = 0; i < 4; i++)
+		{
+			Vector exit = ReverseAG(enter_origin, enter_angles, wall_angles[i]);
+			interfaces::debugOverlay->AddBoxOverlay2(exit,
+			                                         Vector(-1, -32, -54),
+			                                         Vector(1, 32, 54),
+			                                         wall_angles[i],
+			                                         Color(255, 0, 0, 64),
+			                                         Color(255, 0, 0, 255),
+			                                         lifeTime);
+			interfaces::debugOverlay
+			    ->AddLineOverlay(exit, exit + wall_normal[i] * 20, 255, 0, 0, true, lifeTime);
+		}
+
+		QAngle angle(90.0f, 179.0f, 0.0f);
+		Vector prev = ReverseAG(enter_origin, enter_angles, angle);
+		for (angle.y = -180.0f; angle.y < 180.0f; angle.y += 1.0f)
+		{
+			Vector curr = ReverseAG(enter_origin, enter_angles, angle);
+			interfaces::debugOverlay->AddLineOverlay(curr, prev, 255, 0, 255, false, lifeTime);
+			prev = curr;
+		}
+
+		angle = QAngle(-90.0f, 179.0f, 0.0f);
+		prev = ReverseAG(enter_origin, enter_angles, angle);
+		for (angle.y = -180.0f; angle.y < 180.0f; angle.y += 1.0f)
+		{
+			Vector curr = ReverseAG(enter_origin, enter_angles, angle);
+			interfaces::debugOverlay->AddLineOverlay(curr, prev, 0, 255, 255, false, lifeTime);
+			prev = curr;
+		}
+	}
+}
+
+Vector VagTrace::CalculateAG(Vector enter_origin, QAngle enter_angles, Vector exit_origin, QAngle exit_angles)
+{
+	Vector exitForward, exitRight, exitUp;
+	Vector enterForward, enterRight, enterUp;
+	AngleVectors(enter_angles, &enterForward, &enterRight, &enterUp);
+	AngleVectors(exit_angles, &exitForward, &exitRight, &exitUp);
+
+	auto delta = enter_origin - exit_origin;
+
+	Vector exit_portal_coords;
+	exit_portal_coords.x = delta.Dot(exitForward);
+	exit_portal_coords.y = delta.Dot(exitRight);
+	exit_portal_coords.z = delta.Dot(exitUp);
+
+	Vector transition(0, 0, 0);
+	transition -= exit_portal_coords.x * enterForward;
+	transition -= exit_portal_coords.y * enterRight;
+	transition += exit_portal_coords.z * enterUp;
+
+	return enter_origin + transition;
+}
+
+void VagTrace::SetTarget(Vector target)
+{
+	this->target = target;
+}
+
+Vector VagTrace::ReverseAG(Vector enter_origin, QAngle enter_angles, QAngle exit_angles)
+{
+	Vector transition = target - enter_origin;
+	Vector enter[3];
+	AngleVectors(enter_angles, &enter[0], &enter[1], &enter[2]);
+	enter[0] *= -1;
+	enter[1] *= -1;
+
+	float det = enter[0][0] * (enter[1][1] * enter[2][2] - enter[2][1] * enter[1][2])
+	            - enter[0][1] * (enter[1][0] * enter[2][2] - enter[1][2] * enter[2][0])
+	            + enter[0][2] * (enter[1][0] * enter[2][1] - enter[1][1] * enter[2][0]);
+	float invdet;
+	if (det == 0)
+	{
+		invdet = 1;
+	}
+	else
+	{
+		invdet = 1 / det;
+	}
+
+	Vector inv_enter[3];
+	inv_enter[0][0] = (enter[1][1] * enter[2][2] - enter[2][1] * enter[1][2]) * invdet;
+	inv_enter[0][1] = (enter[0][2] * enter[2][1] - enter[0][1] * enter[2][2]) * invdet;
+	inv_enter[0][2] = (enter[0][1] * enter[1][2] - enter[0][2] * enter[1][1]) * invdet;
+	inv_enter[1][0] = (enter[1][2] * enter[2][0] - enter[1][0] * enter[2][2]) * invdet;
+	inv_enter[1][1] = (enter[0][0] * enter[2][2] - enter[0][2] * enter[2][0]) * invdet;
+	inv_enter[1][2] = (enter[1][0] * enter[0][2] - enter[0][0] * enter[1][2]) * invdet;
+	inv_enter[2][0] = (enter[1][0] * enter[2][1] - enter[2][0] * enter[1][1]) * invdet;
+	inv_enter[2][1] = (enter[2][0] * enter[0][1] - enter[0][0] * enter[2][1]) * invdet;
+	inv_enter[2][2] = (enter[0][0] * enter[1][1] - enter[1][0] * enter[0][1]) * invdet;
+
+	Vector exit_portal_coords;
+	exit_portal_coords.x =
+	    transition.x * inv_enter[0][0] + transition.y * inv_enter[1][0] + transition.z * inv_enter[2][0];
+	exit_portal_coords.y =
+	    transition.x * inv_enter[0][1] + transition.y * inv_enter[1][1] + transition.z * inv_enter[2][1];
+	exit_portal_coords.z =
+	    transition.x * inv_enter[0][2] + transition.y * inv_enter[1][2] + transition.z * inv_enter[2][2];
+
+	Vector exit[3];
+	AngleVectors(exit_angles, &exit[0], &exit[1], &exit[2]);
+
+	det = exit[0][0] * (exit[1][1] * exit[2][2] - exit[2][1] * exit[1][2])
+	      - exit[0][1] * (exit[1][0] * exit[2][2] - exit[1][2] * exit[2][0])
+	      + exit[0][2] * (exit[1][0] * exit[2][1] - exit[1][1] * exit[2][0]);
+	if (det == 0)
+	{
+		invdet = 1;
+	}
+	else
+	{
+		invdet = 1 / det;
+	}
+
+	Vector inv_exit_angles[3];
+	inv_exit_angles[0][0] = (exit[1][1] * exit[2][2] - exit[2][1] * exit[1][2]) * invdet;
+	inv_exit_angles[0][1] = (exit[0][2] * exit[2][1] - exit[0][1] * exit[2][2]) * invdet;
+	inv_exit_angles[0][2] = (exit[0][1] * exit[1][2] - exit[0][2] * exit[1][1]) * invdet;
+	inv_exit_angles[1][0] = (exit[1][2] * exit[2][0] - exit[1][0] * exit[2][2]) * invdet;
+	inv_exit_angles[1][1] = (exit[0][0] * exit[2][2] - exit[0][2] * exit[2][0]) * invdet;
+	inv_exit_angles[1][2] = (exit[1][0] * exit[0][2] - exit[0][0] * exit[1][2]) * invdet;
+	inv_exit_angles[2][0] = (exit[1][0] * exit[2][1] - exit[2][0] * exit[1][1]) * invdet;
+	inv_exit_angles[2][1] = (exit[2][0] * exit[0][1] - exit[0][0] * exit[2][1]) * invdet;
+	inv_exit_angles[2][2] = (exit[0][0] * exit[1][1] - exit[1][0] * exit[0][1]) * invdet;
+
+	Vector delta;
+
+	delta.x = inv_exit_angles[0].Dot(exit_portal_coords);
+	delta.y = inv_exit_angles[1].Dot(exit_portal_coords);
+	delta.z = inv_exit_angles[2].Dot(exit_portal_coords);
+
+	return -(delta - enter_origin);
+}
+
+bool VagTrace::ShouldLoadFeature()
+{
+	return utils::DoesGameLookLikePortal();
+}
+
+void VagTrace::LoadFeature()
+{
+	if (interfaces::debugOverlay && TickSignal.Works)
+	{
+		TickSignal.Connect(this, &VagTrace::DrawTrace);
+		InitCommand(y_spt_vag_target_set);
+		InitConcommandBase(y_spt_vag_trace);
+		InitConcommandBase(y_spt_vag_target);
+	}
+}
+
+void VagTrace::UnloadFeature() {}
+
+#endif

--- a/spt/features/vag_trace.cpp
+++ b/spt/features/vag_trace.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#if defined(SSDK2007)
+#if defined(SSDK2007) || defined(SSDK2013)
 #include "..\feature.hpp"
 #include "icliententity.h"
 #include "..\utils\game_detection.hpp"
@@ -18,7 +18,7 @@ ConVar y_spt_vag_trace("y_spt_vag_trace", "0", FCVAR_CHEAT, "Draws VAG trace.\n"
 ConVar y_spt_vag_target("y_spt_vag_target", "0", FCVAR_CHEAT, "Draws VAG target trace.\n");
 
 // VAG finding tool
-class VagTrace : public Feature
+class VagTrace : public FeatureWrapper<VagTrace>
 {
 public:
 	void DrawTrace();
@@ -172,9 +172,9 @@ Vector VagTrace::CalculateAG(Vector enter_origin, QAngle enter_angles, Vector ex
 	return enter_origin + transition;
 }
 
-void VagTrace::SetTarget(Vector target)
+void VagTrace::SetTarget(Vector target_pos)
 {
-	this->target = target;
+	this->target = target_pos;
 }
 
 Vector VagTrace::ReverseAG(Vector enter_origin, QAngle enter_angles, QAngle exit_angles)

--- a/spt/overlay/portal_camera.cpp
+++ b/spt/overlay/portal_camera.cpp
@@ -281,6 +281,10 @@ IClientEntity* getPortal(const char* arg, bool verbose)
 			portal = utils::GetClientEntity(portal_index);
 		}
 	}
+	else
+	{
+		portal = utils::GetClientEntity(portal_index);
+	}
 
 	return portal;
 }

--- a/spt/utils/signals.cpp
+++ b/spt/utils/signals.cpp
@@ -11,3 +11,4 @@ Gallant::Signal0<void> TickSignal;
 Gallant::Signal3<void*, int, bool> SetPausedSignal;
 Gallant::Signal1<bool> SV_ActivateServerSignal;
 Gallant::Signal1<uintptr_t> CreateMoveSignal;
+Gallant::Signal0<void> VagCrashSignal;

--- a/spt/utils/signals.hpp
+++ b/spt/utils/signals.hpp
@@ -12,3 +12,4 @@ extern Gallant::Signal0<void> TickSignal;
 extern Gallant::Signal3<void*, int, bool> SetPausedSignal;
 extern Gallant::Signal1<bool> SV_ActivateServerSignal;
 extern Gallant::Signal1<uintptr_t> CreateMoveSignal;
+extern Gallant::Signal0<void> VagCrashSignal;


### PR DESCRIPTION
Added Uncrafted's VAG searcher and some VAG trace.

VAG Trace:

1.  Set entry portal
2.  Set target position (the yellow box)
3.  Calculate Exit portal position
    - Red: 4 walls
    - Purple circle: Ceiling
    - Cyan circle: Floor
    - White circle: Different exit portal rotation
    - Green line: Entry to VAG position
    - Blue line: Entry to exit

![testchmb_a_110007](https://user-images.githubusercontent.com/72735402/157124415-8c18b193-b928-4ebe-a050-172b93e78296.jpg)

New commands:
`y_spt_vag_search`
Do VAG search (need sv_cheats 1 for setpos) (auto enable y_spt_prevent_vag_crash)

`y_spt_vag_target_set`
Set VAG target

cvar:
`y_spt_vag_search_portal <overlay|blue|orange|portal index>`
For y_spt_vag_search

`y_spt_vag_trace <0|1>`
Draws VAG trace. (use overlay portal as entry portal)

`y_spt_vag_target <0|1>`
Draws VAG target trace. (use overlay portal as entry portal)


Fix:
Removed FIND_PATTERN when hooking DecodeUserCmdFromBuffer
Make _y_spt_overlay_portal works using portal index