### PR TITLE
Added more customizable ihud features.

### DIFF
--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -93,13 +93,8 @@ extern ConVar y_spt_hud_oob;
 extern ConVar y_spt_hud_isg;
 
 extern ConVar y_spt_ihud;
-extern ConVar y_spt_ihud_button_color;
-extern ConVar y_spt_ihud_shadow_color;
-extern ConVar y_spt_ihud_font_color;
-extern ConVar y_spt_ihud_shadow_font_color;
 extern ConVar y_spt_ihud_grid_size;
 extern ConVar y_spt_ihud_grid_padding;
-extern ConVar y_spt_ihud_font;
 extern ConVar y_spt_ihud_x;
 extern ConVar y_spt_ihud_y;
 

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -275,7 +275,7 @@ void InputHud::SetInputInfo(int button, Vector movement)
 bool InputHud::ModifySetting(const char* element, const char* param, const char* value)
 {
 	InputHud::Button* target;
-	if (std::strncmp(element, "anlges", 16) == 0)
+	if (std::strncmp(element, "angles", 16) == 0)
 	{
 		target = &anglesSetting;
 	}

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -32,7 +32,7 @@ CON_COMMAND(
 	const char* param = args.Arg(2);
 	const char* value = args.Arg(3);
 
-	if (std::strncmp(element, "all", 16) == 0)
+	if (std::strcmp(element, "all") == 0)
 	{
 		for (const auto& kv : spt_ihud.buttonSetting)
 		{
@@ -42,8 +42,8 @@ CON_COMMAND(
 				return;
 			}
 		}
-		if (std::strncmp(param, "text", 16) != 0 && std::strncmp(param, "width", 16) != 0
-		    && std::strncmp(param, "height", 16) != 0 && std::strncmp(param, "texthighlight", 16) != 0)
+		if (std::strcmp(param, "text") != 0 && std::strcmp(param, "width") != 0
+		    && std::strcmp(param, "height") != 0 && std::strcmp(param, "texthighlight") != 0)
 		{
 			spt_ihud.ModifySetting("angles", param, value);
 		}
@@ -61,7 +61,7 @@ CON_COMMAND(y_spt_ihud_preset, "Load ihud preset.\nValid options: normal, normal
 		Msg("Usage: y_spt_ihud_preset <preset>\nPresets: normal, normal_mouse, tas.\n");
 	}
 	const char* preset = args.Arg(1);
-	if (std::strncmp(preset, "normal", 16) == 0)
+	if (std::strcmp(preset, "normal") == 0)
 	{
 		spt_ihud.tasPreset = false;
 		InputHud::Button* button = &spt_ihud.buttonSetting["forward"];
@@ -121,7 +121,7 @@ CON_COMMAND(y_spt_ihud_preset, "Load ihud preset.\nValid options: normal, normal
 
 		spt_ihud.anglesSetting.enabled = false;
 	}
-	else if (std::strncmp(preset, "normal_mouse", 16) == 0)
+	else if (std::strcmp(preset, "normal_mouse") == 0)
 	{
 		spt_ihud.tasPreset = false;
 		InputHud::Button* button = &spt_ihud.buttonSetting["forward"];
@@ -183,7 +183,7 @@ CON_COMMAND(y_spt_ihud_preset, "Load ihud preset.\nValid options: normal, normal
 		spt_ihud.anglesSetting.x = 1;
 		spt_ihud.anglesSetting.y = 4;
 	}
-	else if (std::strncmp(preset, "tas", 16) == 0)
+	else if (std::strcmp(preset, "tas") == 0)
 	{
 		spt_ihud.tasPreset = true;
 	}
@@ -281,7 +281,7 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 {
 	InputHud::Button* target;
 	bool angle = false;
-	if (std::strncmp(element, "angles", 16) == 0)
+	if (std::strcmp(element, "angles") == 0)
 	{
 		angle = true;
 		target = &anglesSetting;
@@ -295,11 +295,11 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 		return false;
 	}
 
-	if (std::strncmp(param, "enabled", 16) == 0)
+	if (std::strcmp(param, "enabled") == 0)
 	{
 		target->enabled = std::atoi(value);
 	}
-	else if (std::strncmp(param, "text", 16) == 0)
+	else if (std::strcmp(param, "text") == 0)
 	{
 		if (angle)
 		{
@@ -311,19 +311,19 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 		std::wstring wstr(str.begin(), str.end());
 		target->text = wstr;
 	}
-	else if (std::strncmp(param, "font", 16) == 0)
+	else if (std::strcmp(param, "font") == 0)
 	{
 		target->font = spt_hud.scheme->GetFont(value, false);
 	}
-	else if (std::strncmp(param, "x", 16) == 0)
+	else if (std::strcmp(param, "x") == 0)
 	{
 		target->x = std::atoi(value);
 	}
-	else if (std::strncmp(param, "y", 16) == 0)
+	else if (std::strcmp(param, "y") == 0)
 	{
 		target->y = std::atoi(value);
 	}
-	else if (std::strncmp(param, "width", 16) == 0)
+	else if (std::strcmp(param, "width") == 0)
 	{
 		if (angle)
 		{
@@ -332,7 +332,7 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 		}
 		target->width = std::atoi(value);
 	}
-	else if (std::strncmp(param, "height", 16) == 0)
+	else if (std::strcmp(param, "height") == 0)
 	{
 		if (angle)
 		{
@@ -341,19 +341,19 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 		}
 		target->hight = std::atoi(value);
 	}
-	else if (std::strncmp(param, "background", 16) == 0)
+	else if (std::strcmp(param, "background") == 0)
 	{
 		target->background = StringToColor(value);
 	}
-	else if (std::strncmp(param, "highlight", 16) == 0)
+	else if (std::strcmp(param, "highlight") == 0)
 	{
 		target->highlight = StringToColor(value);
 	}
-	else if (std::strncmp(param, "textcolor", 16) == 0)
+	else if (std::strcmp(param, "textcolor") == 0)
 	{
 		target->textcolor = StringToColor(value);
 	}
-	else if (std::strncmp(param, "texthighlight", 16) == 0)
+	else if (std::strcmp(param, "texthighlight") == 0)
 	{
 		if (angle)
 		{

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -42,6 +42,11 @@ CON_COMMAND(
 				return;
 			}
 		}
+		if (std::strncmp(param, "text", 16) != 0 && std::strncmp(param, "width", 16) != 0
+		    && std::strncmp(param, "height", 16) != 0 && std::strncmp(param, "texthighlight", 16) != 0)
+		{
+			spt_ihud.ModifySetting("angles", param, value);
+		}
 	}
 	else if (!spt_ihud.ModifySetting(element, param, value))
 	{
@@ -275,8 +280,10 @@ void InputHud::SetInputInfo(int button, Vector movement)
 bool InputHud::ModifySetting(const char* element, const char* param, const char* value)
 {
 	InputHud::Button* target;
+	bool angle = false;
 	if (std::strncmp(element, "angles", 16) == 0)
 	{
+		angle = true;
 		target = &anglesSetting;
 	}
 	else if (buttonSetting.find(element) != buttonSetting.end())
@@ -294,6 +301,11 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 	}
 	else if (std::strncmp(param, "text", 16) == 0)
 	{
+		if (angle)
+		{
+			Msg("angles font has no effect\n");
+			return true;
+		}
 		// only works for ASCII
 		std::string str(value);
 		std::wstring wstr(str.begin(), str.end());
@@ -313,10 +325,20 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 	}
 	else if (std::strncmp(param, "width", 16) == 0)
 	{
+		if (angle)
+		{
+			Msg("angles width has no effect\n");
+			return true;
+		}
 		target->width = std::atoi(value);
 	}
 	else if (std::strncmp(param, "height", 16) == 0)
 	{
+		if (angle)
+		{
+			Msg("angles height has no effect\n");
+			return true;
+		}
 		target->hight = std::atoi(value);
 	}
 	else if (std::strncmp(param, "background", 16) == 0)
@@ -333,6 +355,11 @@ bool InputHud::ModifySetting(const char* element, const char* param, const char*
 	}
 	else if (std::strncmp(param, "texthighlight", 16) == 0)
 	{
+		if (angle)
+		{
+			Msg("angles texthighlight has no effect\n");
+			return true;
+		}
 		target->texthighlight = StringToColor(value);
 	}
 	else

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -18,7 +18,7 @@ ConVar y_spt_ihud_y("y_spt_ihud_y", "2", 0, "Y offset of input HUD.\n");
 
 CON_COMMAND(
     y_spt_ihud_modify,
-    "y_spt_ihud_modify <element|all> <param> <value> - modifies parameters in given element.\nParams: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.\n")
+    "y_spt_ihud_modify <element|all> <param> <value> - Modifies parameters in given element.\nParams: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.\n")
 {
 	if (args.ArgC() != 4)
 	{
@@ -408,13 +408,15 @@ void InputHud::DrawInputHud()
 
 	if (y_spt_ihud.GetBool())
 	{
-		Vector ang = currentAng - previousAng;
+		Vector ang;
 		if (tasPreset || anglesSetting.enabled)
 		{
+			ang = {previousAng.y - currentAng.y, previousAng.x - currentAng.x, 0};
 			while (ang.x < -180.0f)
 				ang.x += 360.0f;
 			if (ang.x > 180.0f)
 				ang.x -= 360.0f;
+
 			float len = ang.Length();
 			if (len > 0)
 			{
@@ -442,8 +444,8 @@ void InputHud::DrawInputHud()
 			int cY2 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
 			int movX = cX1 + r * movement.x;
 			int movY = cY1 - r * movement.y;
-			int angX = cX2 + r * ang.y;
-			int angY = cY2 + r * ang.x;
+			int angX = cX2 + r * ang.x;
+			int angY = cY2 + r * ang.y;
 			surface->DrawSetColor(anglesSetting.background);
 			surface->DrawFilledRect(xOffset,
 			                        yOffset,
@@ -534,8 +536,8 @@ void InputHud::DrawInputHud()
 				int r = gridSize;
 				int cX = xOffset + (anglesSetting.y + 1) * (gridSize + padding) - padding / 2;
 				int cY = yOffset + (anglesSetting.x + 1) * (gridSize + padding) - padding / 2;
-				int angX = cX + r * ang.y;
-				int angY = cY + r * ang.x;
+				int angX = cX + r * ang.x;
+				int angY = cY + r * ang.y;
 				surface->DrawSetColor(anglesSetting.background);
 				surface->DrawFilledRect(xOffset + anglesSetting.y * (gridSize + padding),
 				                        yOffset + anglesSetting.x * (gridSize + padding),

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -10,11 +10,11 @@
 
 InputHud spt_ihud;
 
-ConVar y_spt_ihud("y_spt_ihud", "0", FCVAR_CHEAT, "Draws movement inputs of client.\n");
-ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", FCVAR_CHEAT, "Grid size of input HUD.\n");
-ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding", "2", FCVAR_CHEAT, "Padding between grids of input HUD.");
-ConVar y_spt_ihud_x("y_spt_ihud_x", "2", FCVAR_CHEAT, "X offset of input HUD.\n");
-ConVar y_spt_ihud_y("y_spt_ihud_y", "2", FCVAR_CHEAT, "Y offset of input HUD.\n");
+ConVar y_spt_ihud("y_spt_ihud", "0", 0, "Draws movement inputs of client.\n");
+ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", 0, "Grid size of input HUD.\n");
+ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding", "2", 0, "Padding between grids of input HUD.");
+ConVar y_spt_ihud_x("y_spt_ihud_x", "2", 0, "X offset of input HUD.\n");
+ConVar y_spt_ihud_y("y_spt_ihud_y", "2", 0, "Y offset of input HUD.\n");
 
 CON_COMMAND(
     y_spt_ihud_modify,

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -408,12 +408,9 @@ void InputHud::DrawInputHud()
 
 	if (y_spt_ihud.GetBool())
 	{
-		if (tasPreset)
+		Vector ang = currentAng - previousAng;
+		if (tasPreset || anglesSetting.enabled)
 		{
-			gridSize /= 2;
-
-			// Angle
-			Vector ang = currentAng - previousAng;
 			while (ang.x < -180.0f)
 				ang.x += 360.0f;
 			if (ang.x > 180.0f)
@@ -425,6 +422,10 @@ void InputHud::DrawInputHud()
 				ang *= pow(len / 180.0f, 0.2);
 				ang.y *= -1;
 			}
+		}
+		if (tasPreset)
+		{
+			gridSize /= 2;
 
 			// Movement
 			Vector movement = inputMovement;
@@ -530,19 +531,6 @@ void InputHud::DrawInputHud()
 			// mouse
 			if (anglesSetting.enabled)
 			{
-				Vector ang = currentAng - previousAng;
-				while (ang.x < -180.0f)
-					ang.x += 360.0f;
-				if (ang.x > 180.0f)
-					ang.x -= 360.0f;
-				float len = ang.Length();
-				if (len > 0)
-				{
-					ang /= len;
-					ang *= pow(len / 180.0f, 0.2);
-					ang.y *= -1;
-				}
-
 				int r = gridSize;
 				int cX = xOffset + (anglesSetting.y + 1) * (gridSize + padding) - padding / 2;
 				int cY = yOffset + (anglesSetting.x + 1) * (gridSize + padding) - padding / 2;

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -7,32 +7,186 @@
 #include "signals.hpp"
 #include "property_getter.hpp"
 #include "..\sptlib-wrapper.hpp"
-#include "Color.h"
 
 InputHud spt_ihud;
 
-ConVar y_spt_ihud("y_spt_ihud", "0", FCVAR_CHEAT, "Draws movement inputs of client.\n0 = Default,\n1 = tas.\n");
-ConVar y_spt_ihud_button_color("y_spt_ihud_button_color",
-                               "0 0 0 233",
-                               FCVAR_CHEAT,
-                               "RGBA button color of input HUD.\n");
-ConVar y_spt_ihud_shadow_color("y_spt_ihud_shadow_color",
-                               "0 0 0 66",
-                               FCVAR_CHEAT,
-                               "RGBA button shadow color of input HUD.\n");
-ConVar y_spt_ihud_font_color("y_spt_ihud_font_color",
-                             "255 255 255 233",
-                             FCVAR_CHEAT,
-                             "RGBA font color of input HUD.\n");
-ConVar y_spt_ihud_shadow_font_color("y_spt_ihud_shadow_font_color",
-                                    "255 255 255 66",
-                                    FCVAR_CHEAT,
-                                    "RGBA button shadow font color of input HUD.\n");
+ConVar y_spt_ihud("y_spt_ihud", "0", FCVAR_CHEAT, "Draws movement inputs of client.\n");
 ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", FCVAR_CHEAT, "Grid size of input HUD.\n");
 ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding", "2", FCVAR_CHEAT, "Padding between grids of input HUD.");
-ConVar y_spt_ihud_font("y_spt_ihud_font", "Trebuchet20", FCVAR_CHEAT, "Font of input HUD.");
 ConVar y_spt_ihud_x("y_spt_ihud_x", "2", FCVAR_CHEAT, "X offset of input HUD.\n");
 ConVar y_spt_ihud_y("y_spt_ihud_y", "2", FCVAR_CHEAT, "Y offset of input HUD.\n");
+
+CON_COMMAND(
+    y_spt_ihud_modify,
+    "y_spt_ihud_modify <element|all> <param> <value> - modifies parameters in given element.\nParams: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.\n")
+{
+	if (args.ArgC() != 4)
+	{
+		Msg("Usage: y_spt_ihud_modify <element|all> <param> <value>\n");
+		return;
+	}
+	const char* errorMsg =
+	    "Invalid arguments.\nElements: all, angles, forward, back, moveright, moveleft, use, duck, jump, attack, attack2\nParams: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.\n";
+
+	const char* element = args.Arg(1);
+	const char* param = args.Arg(2);
+	const char* value = args.Arg(3);
+
+	if (std::strncmp(element, "all", 16) == 0)
+	{
+		for (const auto& kv : spt_ihud.buttonSetting)
+		{
+			if (!spt_ihud.ModifySetting(kv.first.c_str(), param, value))
+			{
+				Msg(errorMsg);
+				return;
+			}
+		}
+	}
+	else if (!spt_ihud.ModifySetting(element, param, value))
+	{
+		Msg(errorMsg);
+	}
+}
+
+CON_COMMAND(y_spt_ihud_preset, "Load ihud preset.\nValid options: normal, normal_mouse, tas.\n")
+{
+	if (args.ArgC() != 2)
+	{
+		Msg("Usage: y_spt_ihud_preset <preset>\nPresets: normal, normal_mouse, tas.\n");
+	}
+	const char* preset = args.Arg(1);
+	if (std::strncmp(preset, "normal", 16) == 0)
+	{
+		spt_ihud.tasPreset = false;
+		InputHud::Button* button = &spt_ihud.buttonSetting["forward"];
+		button->enabled = true;
+		button->x = 0;
+		button->y = 2;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["use"];
+		button->enabled = true;
+		button->x = 0;
+		button->y = 3;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["moveleft"];
+		button->enabled = true;
+		button->x = 1;
+		button->y = 1;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["back"];
+		button->enabled = true;
+		button->x = 1;
+		button->y = 2;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["moveright"];
+		button->enabled = true;
+		button->x = 1;
+		button->y = 3;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["duck"];
+		button->enabled = true;
+		button->x = 2;
+		button->y = 0;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["jump"];
+		button->enabled = true;
+		button->x = 2;
+		button->y = 1;
+		button->width = 3;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["attack"];
+		button->enabled = true;
+		button->x = 2;
+		button->y = 4;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["attack2"];
+		button->enabled = true;
+		button->x = 2;
+		button->y = 5;
+		button->width = 1;
+		button->hight = 1;
+
+		spt_ihud.anglesSetting.enabled = false;
+	}
+	else if (std::strncmp(preset, "normal_mouse", 16) == 0)
+	{
+		spt_ihud.tasPreset = false;
+		InputHud::Button* button = &spt_ihud.buttonSetting["forward"];
+		button->enabled = true;
+		button->x = 0;
+		button->y = 1;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["use"];
+		button->enabled = true;
+		button->x = 0;
+		button->y = 2;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["moveleft"];
+		button->enabled = true;
+		button->x = 1;
+		button->y = 0;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["back"];
+		button->enabled = true;
+		button->x = 1;
+		button->y = 1;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["moveright"];
+		button->enabled = true;
+		button->x = 1;
+		button->y = 2;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["duck"];
+		button->enabled = true;
+		button->x = 2;
+		button->y = 0;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["jump"];
+		button->enabled = true;
+		button->x = 2;
+		button->y = 1;
+		button->width = 2;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["attack"];
+		button->enabled = true;
+		button->x = 0;
+		button->y = 4;
+		button->width = 1;
+		button->hight = 1;
+		button = &spt_ihud.buttonSetting["attack2"];
+		button->enabled = true;
+		button->x = 0;
+		button->y = 5;
+		button->width = 1;
+		button->hight = 1;
+
+		spt_ihud.anglesSetting.enabled = true;
+		spt_ihud.anglesSetting.x = 1;
+		spt_ihud.anglesSetting.y = 4;
+	}
+	else if (std::strncmp(preset, "tas", 16) == 0)
+	{
+		spt_ihud.tasPreset = true;
+	}
+	else
+	{
+		Msg("Invalid preset.\nPresets: normal, normal_mouse, tas.\n");
+	}
+}
 
 bool InputHud::ShouldLoadFeature()
 {
@@ -50,21 +204,51 @@ void InputHud::LoadFeature()
 		return;
 	if (CreateMoveSignal.Works)
 		CreateMoveSignal.Connect(this, &InputHud::CreateMove);
-	ihudFont = spt_hud.scheme->GetFont(y_spt_ihud_font.GetString(), false);
 
 	bool result = AddHudCallback("ihud", std::bind(&InputHud::DrawInputHud, this), y_spt_ihud);
 	if (result)
 	{
-		InitConcommandBase(y_spt_ihud_button_color);
-		InitConcommandBase(y_spt_ihud_shadow_color);
-		InitConcommandBase(y_spt_ihud_font_color);
-		InitConcommandBase(y_spt_ihud_shadow_font_color);
+		InitCommand(y_spt_ihud_modify);
+		InitCommand(y_spt_ihud_preset);
 		InitConcommandBase(y_spt_ihud_grid_size);
 		InitConcommandBase(y_spt_ihud_grid_padding);
-		InitConcommandBase(y_spt_ihud_font);
 		InitConcommandBase(y_spt_ihud_x);
 		InitConcommandBase(y_spt_ihud_y);
 	}
+	vgui::HFont font = spt_hud.scheme->GetFont("Trebuchet20", false);
+	Color background = {0, 0, 0, 233};
+	Color highlight = {255, 255, 255, 66};
+	Color textcolor = {255, 255, 255, 66};
+	Color texthighlight = {0, 0, 0, 233};
+
+	const int IN_ATTACK = (1 << 0);
+	const int IN_JUMP = (1 << 1);
+	const int IN_DUCK = (1 << 2);
+	const int IN_FORWARD = (1 << 3);
+	const int IN_BACK = (1 << 4);
+	const int IN_USE = (1 << 5);
+	const int IN_MOVELEFT = (1 << 9);
+	const int IN_MOVERIGHT = (1 << 10);
+	const int IN_ATTACK2 = (1 << 11);
+
+	buttonSetting["forward"] =
+	    {true, L"W", font, 0, 2, 1, 1, background, highlight, textcolor, texthighlight, IN_FORWARD};
+	buttonSetting["use"] = {true, L"E", font, 0, 3, 1, 1, background, highlight, textcolor, texthighlight, IN_USE};
+	buttonSetting["moveleft"] =
+	    {true, L"A", font, 1, 1, 1, 1, background, highlight, textcolor, texthighlight, IN_MOVELEFT};
+	buttonSetting["back"] =
+	    {true, L"S", font, 1, 2, 1, 1, background, highlight, textcolor, texthighlight, IN_BACK};
+	buttonSetting["moveright"] =
+	    {true, L"D", font, 1, 3, 1, 1, background, highlight, textcolor, texthighlight, IN_MOVERIGHT};
+	buttonSetting["duck"] =
+	    {true, L"Duck", font, 2, 0, 1, 1, background, highlight, textcolor, texthighlight, IN_DUCK};
+	buttonSetting["jump"] =
+	    {true, L"Jump", font, 2, 1, 3, 1, background, highlight, textcolor, texthighlight, IN_JUMP};
+	buttonSetting["attack"] =
+	    {true, L"L", font, 2, 4, 1, 1, background, highlight, textcolor, texthighlight, IN_ATTACK};
+	buttonSetting["attack2"] =
+	    {true, L"R", font, 2, 5, 1, 1, background, highlight, textcolor, texthighlight, IN_ATTACK2};
+	anglesSetting = {false, L"", font, 1, 4, 0, 0, background, highlight, textcolor, texthighlight, 0};
 }
 
 void InputHud::PreHook()
@@ -88,6 +272,96 @@ void InputHud::SetInputInfo(int button, Vector movement)
 	awaitingFrameDraw = true;
 }
 
+bool InputHud::ModifySetting(const char* element, const char* param, const char* value)
+{
+	InputHud::Button* target;
+	if (std::strncmp(element, "anlges", 16) == 0)
+	{
+		target = &anglesSetting;
+	}
+	else if (buttonSetting.find(element) != buttonSetting.end())
+	{
+		target = &buttonSetting[element];
+	}
+	else
+	{
+		return false;
+	}
+
+	if (std::strncmp(param, "enabled", 16) == 0)
+	{
+		target->enabled = std::atoi(value);
+	}
+	else if (std::strncmp(param, "text", 16) == 0)
+	{
+		// only works for ASCII
+		std::string str(value);
+		std::wstring wstr(str.begin(), str.end());
+		target->text = wstr;
+	}
+	else if (std::strncmp(param, "font", 16) == 0)
+	{
+		target->font = spt_hud.scheme->GetFont(value, false);
+	}
+	else if (std::strncmp(param, "x", 16) == 0)
+	{
+		target->x = std::atoi(value);
+	}
+	else if (std::strncmp(param, "y", 16) == 0)
+	{
+		target->y = std::atoi(value);
+	}
+	else if (std::strncmp(param, "width", 16) == 0)
+	{
+		target->width = std::atoi(value);
+	}
+	else if (std::strncmp(param, "height", 16) == 0)
+	{
+		target->hight = std::atoi(value);
+	}
+	else if (std::strncmp(param, "background", 16) == 0)
+	{
+		target->background = StringToColor(value);
+	}
+	else if (std::strncmp(param, "highlight", 16) == 0)
+	{
+		target->highlight = StringToColor(value);
+	}
+	else if (std::strncmp(param, "textcolor", 16) == 0)
+	{
+		target->textcolor = StringToColor(value);
+	}
+	else if (std::strncmp(param, "texthighlight", 16) == 0)
+	{
+		target->texthighlight = StringToColor(value);
+	}
+	else
+	{
+		return false;
+	}
+	return true;
+}
+
+Color InputHud::StringToColor(const char* color)
+{
+	int len = std::strlen(color);
+	if (len != 6 && len != 8)
+	{
+		return Color(0, 0, 0);
+	}
+	int shift = len == 6 ? 16 : 24;
+	unsigned int hex = strtoul(color, NULL, 16);
+	int r, g, b, a = 0xff;
+	r = (hex >> shift) & 0xff;
+	shift -= 8;
+	g = (hex >> shift) & 0xff;
+	shift -= 8;
+	b = (hex >> shift) & 0xff;
+	if (len == 8)
+		a = hex & 0xff;
+	return Color(r, g, b, a);
+}
+
 void InputHud::DrawInputHud()
 {
 	if (awaitingFrameDraw)
@@ -98,147 +372,172 @@ void InputHud::DrawInputHud()
 		currentAng = Vector(va[0], va[1], va[3]);
 		awaitingFrameDraw = false;
 	}
-	auto surface = spt_hud.surface;
-	auto scheme = spt_hud.scheme;
-	auto screen = spt_hud.screen;
-	ihudFont = scheme->GetFont(y_spt_ihud_font.GetString(), false);
-	const int IN_ATTACK = (1 << 0);
-	const int IN_JUMP = (1 << 1);
-	const int IN_DUCK = (1 << 2);
-	const int IN_FORWARD = (1 << 3);
-	const int IN_BACK = (1 << 4);
-	const int IN_USE = (1 << 5);
-	const int IN_MOVELEFT = (1 << 9);
-	const int IN_MOVERIGHT = (1 << 10);
-	const int IN_ATTACK2 = (1 << 11);
+	surface = spt_hud.surface;
 
-	int xOffset = y_spt_ihud_x.GetInt();
-	int yOffset = y_spt_ihud_y.GetInt();
-	int gridSize = y_spt_ihud_grid_size.GetInt();
-	int padding = y_spt_ihud_grid_padding.GetInt();
+	xOffset = y_spt_ihud_x.GetInt();
+	yOffset = y_spt_ihud_y.GetInt();
+	gridSize = y_spt_ihud_grid_size.GetInt();
+	padding = y_spt_ihud_grid_padding.GetInt();
 
-	Color buttonColor;
-	Color shadowColor;
-	Color buttonFontColor;
-	Color shadowFontColor;
-
-#define GET_COLOR(cmd, color) \
-	{ \
-		static int r = 0, g = 0, b = 0, a = 0; \
-		if (strcmp("", cmd.GetString()) != 0) \
-		{ \
-			sscanf(cmd.GetString(), "%d %d %d %d", &r, &g, &b, &a); \
-		} \
-		color = Color(r, g, b, a); \
-	}
-
-	GET_COLOR(y_spt_ihud_button_color, buttonColor);
-	GET_COLOR(y_spt_ihud_shadow_color, shadowColor);
-	GET_COLOR(y_spt_ihud_font_color, buttonFontColor);
-	GET_COLOR(y_spt_ihud_shadow_font_color, shadowFontColor);
-
-#define DRAW_BUTTON(button, col, row, size, colSize, rowSize, text) \
-	{ \
-		Color btnColor = (buttonBits & (button)) ? buttonColor : shadowColor; \
-		Color fontColor = (buttonBits & (button)) ? buttonFontColor : shadowFontColor; \
-		DrawRectAndCenterTxt(btnColor, \
-		                     xOffset + col * (size + padding), \
-		                     yOffset + row * (size + padding), \
-		                     xOffset + (col + colSize) * (size + padding) - padding, \
-		                     yOffset + (row + rowSize) * (size + padding) - padding, \
-		                     ihudFont, \
-		                     fontColor, \
-		                     surface, \
-		                     text); \
-	}
-
-	if (y_spt_ihud.GetInt() == 2)
+	if (y_spt_ihud.GetBool())
 	{
-		gridSize /= 2;
-
-		// Angle
-		Vector ang = currentAng - previousAng;
-		while (ang.x < -180.0f)
-			ang.x += 360.0f;
-		if (ang.x > 180.0f)
-			ang.x -= 360.0f;
-		float len = ang.Length();
-		if (len > 0)
+		if (tasPreset)
 		{
-			ang /= len;
-			ang *= pow(len / 180.0f, 0.2);
-			ang.y *= -1;
+			gridSize /= 2;
+
+			// Angle
+			Vector ang = currentAng - previousAng;
+			while (ang.x < -180.0f)
+				ang.x += 360.0f;
+			if (ang.x > 180.0f)
+				ang.x -= 360.0f;
+			float len = ang.Length();
+			if (len > 0)
+			{
+				ang /= len;
+				ang *= pow(len / 180.0f, 0.2);
+				ang.y *= -1;
+			}
+
+			// Movement
+			Vector movement = inputMovement;
+			int movementSpeed = movement.Length();
+			float maxSpeed = utils::GetProperty<float>(0, "m_flMaxspeed");
+			movement /= movementSpeed > maxSpeed ? movementSpeed : maxSpeed;
+
+			// Draw
+			int r = 2 * gridSize;
+			int cX1 = (xOffset + xOffset + 5 * (gridSize + padding) - padding) / 2;
+			int cY1 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
+			int cX2 =
+			    (xOffset + 5 * (gridSize + padding) + xOffset + 10 * (gridSize + padding) - padding) / 2;
+			int cY2 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
+			int movX = cX1 + r * movement.x;
+			int movY = cY1 - r * movement.y;
+			int angX = cX2 + r * ang.y;
+			int angY = cY2 + r * ang.x;
+			surface->DrawSetColor(anglesSetting.background);
+			surface->DrawFilledRect(xOffset,
+			                        yOffset,
+			                        xOffset + 5 * (gridSize + padding) - padding,
+			                        yOffset + 5 * (gridSize + padding) - padding);
+			surface->DrawFilledRect(xOffset + 5 * (gridSize + padding),
+			                        yOffset,
+			                        xOffset + 10 * (gridSize + padding) - padding,
+			                        yOffset + 5 * (gridSize + padding) - padding);
+
+			int th = surface->GetFontTall(anglesSetting.font);
+			surface->DrawSetTextFont(anglesSetting.font);
+			surface->DrawSetTextColor(anglesSetting.textcolor);
+			wchar_t* text = L"move analog";
+			surface->DrawSetTextPos(cX1 - r, cY1 - r - th);
+			surface->DrawPrintText(text, wcslen(text));
+			text = L"view analog";
+			surface->DrawSetTextPos(cX2 - r, cY2 - r - th);
+			surface->DrawPrintText(text, wcslen(text));
+
+			int joyStickSize = gridSize / 5;
+			surface->DrawSetColor(255, 200, 100, 100); // oragne
+			surface->DrawOutlinedCircle(cX1, cY1, r, 64);
+			surface->DrawOutlinedRect(cX1 - r, cY1 - r, cX1 + r, cY1 + r);
+			surface->DrawOutlinedCircle(movX, movY, joyStickSize, 16);
+			surface->DrawLine(cX1 - r, cY1, cX1 + r, cY1);
+			surface->DrawLine(cX1, cY1 - r, cX1, cY1 + r);
+			surface->DrawLine(cX1, cY1, movX, movY);
+			surface->DrawSetColor(100, 200, 255, 100); // blue
+			surface->DrawOutlinedCircle(cX2, cY2, r, 64);
+			surface->DrawOutlinedRect(cX2 - r, cY2 - r, cX2 + r, cY2 + r);
+			surface->DrawOutlinedCircle(angX, angY, joyStickSize, 16);
+			surface->DrawLine(cX2 - r, cY2, cX2 + r, cY2);
+			surface->DrawLine(cX2, cY2 - r, cX2, cY2 + r);
+			surface->DrawLine(cX2, cY2, angX, angY);
+
+			Button button = buttonSetting["duck"];
+			button.enabled = true;
+			button.x = 5;
+			button.y = 0;
+			button.width = 2;
+			button.hight = 1;
+			button.text = L"Duck";
+			DrawButton(button);
+			button = buttonSetting["use"];
+			button.enabled = true;
+			button.x = 5;
+			button.y = 2;
+			button.width = 2;
+			button.hight = 1;
+			button.text = L"Use";
+			DrawButton(button);
+			button = buttonSetting["jump"];
+			button.enabled = true;
+			button.x = 5;
+			button.y = 4;
+			button.width = 2;
+			button.hight = 1;
+			button.text = L"Jump";
+			DrawButton(button);
+			button = buttonSetting["attack"];
+			button.enabled = true;
+			button.x = 5;
+			button.y = 6;
+			button.width = 2;
+			button.hight = 1;
+			button.text = L"Blue";
+			DrawButton(button);
+			button = buttonSetting["attack2"];
+			button.enabled = true;
+			button.x = 5;
+			button.y = 8;
+			button.width = 2;
+			button.hight = 1;
+			button.text = L"Orange";
+			DrawButton(button);
 		}
+		else
+		{
+			for (const auto& kv : buttonSetting)
+			{
+				DrawButton(kv.second);
+			}
 
-		// Movement
-		Vector movement = inputMovement;
-		int movementSpeed = movement.Length();
-		float maxSpeed = utils::GetProperty<float>(0, "m_flMaxspeed");
-		movement /= movementSpeed > maxSpeed ? movementSpeed : maxSpeed;
+			// mouse
+			if (anglesSetting.enabled)
+			{
+				Vector ang = currentAng - previousAng;
+				while (ang.x < -180.0f)
+					ang.x += 360.0f;
+				if (ang.x > 180.0f)
+					ang.x -= 360.0f;
+				float len = ang.Length();
+				if (len > 0)
+				{
+					ang /= len;
+					ang *= pow(len / 180.0f, 0.2);
+					ang.y *= -1;
+				}
 
-		// Draw
-		int r = 2 * gridSize;
-		int cX1 = (xOffset + xOffset + 5 * (gridSize + padding) - padding) / 2;
-		int cY1 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
-		int cX2 = (xOffset + 5 * (gridSize + padding) + xOffset + 10 * (gridSize + padding) - padding) / 2;
-		int cY2 = (yOffset + yOffset + 5 * (gridSize + padding) - padding) / 2;
-		int movX = cX1 + r * movement.x;
-		int movY = cY1 - r * movement.y;
-		int angX = cX2 + r * ang.y;
-		int angY = cY2 + r * ang.x;
-		surface->DrawSetColor(buttonColor);
-		surface->DrawFilledRect(xOffset,
-		                        yOffset,
-		                        xOffset + 5 * (gridSize + padding) - padding,
-		                        yOffset + 5 * (gridSize + padding) - padding);
-		surface->DrawFilledRect(xOffset + 5 * (gridSize + padding),
-		                        yOffset,
-		                        xOffset + 10 * (gridSize + padding) - padding,
-		                        yOffset + 5 * (gridSize + padding) - padding);
+				int r = gridSize;
+				int cX = xOffset + (anglesSetting.y + 1) * (gridSize + padding) - padding / 2;
+				int cY = yOffset + (anglesSetting.x + 1) * (gridSize + padding) - padding / 2;
+				int angX = cX + r * ang.y;
+				int angY = cY + r * ang.x;
+				surface->DrawSetColor(anglesSetting.background);
+				surface->DrawFilledRect(xOffset + anglesSetting.y * (gridSize + padding),
+				                        yOffset + anglesSetting.x * (gridSize + padding),
+				                        xOffset + (anglesSetting.y + 2) * (gridSize + padding)
+				                            - padding,
+				                        yOffset + (anglesSetting.x + 2) * (gridSize + padding)
+				                            - padding);
 
-		int th = surface->GetFontTall(ihudFont);
-		surface->DrawSetTextFont(ihudFont);
-		surface->DrawSetTextColor(buttonFontColor);
-		wchar_t* text = L"move analog";
-		surface->DrawSetTextPos(cX1 - r, cY1 - r - th);
-		surface->DrawPrintText(text, wcslen(text));
-		text = L"view analog";
-		surface->DrawSetTextPos(cX2 - r, cY2 - r - th);
-		surface->DrawPrintText(text, wcslen(text));
-
-		int joyStickSize = gridSize / 5;
-		surface->DrawSetColor(255, 200, 100, 100); // oragne
-		surface->DrawOutlinedCircle(cX1, cY1, r, 64);
-		surface->DrawOutlinedRect(cX1 - r, cY1 - r, cX1 + r, cY1 + r);
-		surface->DrawOutlinedCircle(movX, movY, joyStickSize, 16);
-		surface->DrawLine(cX1 - r, cY1, cX1 + r, cY1);
-		surface->DrawLine(cX1, cY1 - r, cX1, cY1 + r);
-		surface->DrawLine(cX1, cY1, movX, movY);
-		surface->DrawSetColor(100, 200, 255, 100); // blue
-		surface->DrawOutlinedCircle(cX2, cY2, r, 64);
-		surface->DrawOutlinedRect(cX2 - r, cY2 - r, cX2 + r, cY2 + r);
-		surface->DrawOutlinedCircle(angX, angY, joyStickSize, 16);
-		surface->DrawLine(cX2 - r, cY2, cX2 + r, cY2);
-		surface->DrawLine(cX2, cY2 - r, cX2, cY2 + r);
-		surface->DrawLine(cX2, cY2, angX, angY);
-
-		DRAW_BUTTON(IN_DUCK, 0, 5, gridSize, 2, 1, L"Duck");
-		DRAW_BUTTON(IN_USE, 2, 5, gridSize, 2, 1, L"Use");
-		DRAW_BUTTON(IN_JUMP, 4, 5, gridSize, 2, 1, L"Jump");
-		DRAW_BUTTON(IN_ATTACK, 6, 5, gridSize, 2, 1, L"Blue");
-		DRAW_BUTTON(IN_ATTACK2, 8, 5, gridSize, 2, 1, L"Orange");
-	}
-	else
-	{
-		DRAW_BUTTON(IN_FORWARD, 2, 0, gridSize, 1, 1, L"W");
-		DRAW_BUTTON(IN_USE, 3, 0, gridSize, 1, 1, L"E");
-		DRAW_BUTTON(IN_MOVELEFT, 1, 1, gridSize, 1, 1, L"A");
-		DRAW_BUTTON(IN_BACK, 2, 1, gridSize, 1, 1, L"S");
-		DRAW_BUTTON(IN_MOVERIGHT, 3, 1, gridSize, 1, 1, L"D");
-		DRAW_BUTTON(IN_DUCK, 0, 2, gridSize, 1, 1, L"Duck");
-		DRAW_BUTTON(IN_JUMP, 1, 2, gridSize, 3, 1, L"Jump");
-		DRAW_BUTTON(IN_ATTACK, 4, 2, gridSize, 1, 1, L"L");
-		DRAW_BUTTON(IN_ATTACK2, 5, 2, gridSize, 1, 1, L"R");
+				int joyStickSize = gridSize / 10;
+				surface->DrawSetColor(anglesSetting.highlight);
+				surface->DrawOutlinedCircle(cX, cY, r, 64);
+				surface->DrawOutlinedCircle(angX, angY, joyStickSize, 16);
+				surface->DrawLine(cX - r, cY, cX + r, cY);
+				surface->DrawLine(cX, cY - r, cX, cY + r);
+				surface->DrawLine(cX, cY, angX, angY);
+			}
+		}
 	}
 }
 
@@ -249,7 +548,6 @@ void InputHud::DrawRectAndCenterTxt(Color buttonColor,
                                     int y1,
                                     vgui::HFont font,
                                     Color textColor,
-                                    IMatSystemSurface* surface,
                                     const wchar_t* text)
 {
 	surface->DrawSetColor(buttonColor);
@@ -263,6 +561,21 @@ void InputHud::DrawRectAndCenterTxt(Color buttonColor,
 	surface->DrawSetTextColor(textColor);
 	surface->DrawSetTextPos(xc - (tw / 2), yc - (th / 2));
 	surface->DrawPrintText(text, wcslen(text));
+}
+
+void InputHud::DrawButton(Button button)
+{
+	if (!button.enabled)
+		return;
+	bool state = buttonBits & button.mask;
+	DrawRectAndCenterTxt(state ? button.highlight : button.background,
+	                     xOffset + button.y * (gridSize + padding),
+	                     yOffset + button.x * (gridSize + padding),
+	                     xOffset + (button.y + button.width) * (gridSize + padding) - padding,
+	                     yOffset + (button.x + button.hight) * (gridSize + padding) - padding,
+	                     button.font,
+	                     state ? button.texthighlight : button.textcolor,
+	                     button.text.c_str());
 }
 
 void __fastcall InputHud::HOOKED_DecodeUserCmdFromBuffer(void* thisptr, int edx, bf_read& buf, int sequence_number)

--- a/spt/features/ihud.hpp
+++ b/spt/features/ihud.hpp
@@ -4,6 +4,7 @@
 #include "..\feature.hpp"
 #include "hud.hpp"
 #include "basehandle.h"
+#include "Color.h"
 
 #ifdef OE
 #include "..\game_shared\usercmd.h"
@@ -19,6 +20,26 @@ class InputHud : public FeatureWrapper<InputHud>
 public:
 	void DrawInputHud();
 	void SetInputInfo(int button, Vector movement);
+	bool ModifySetting(const char* element, const char* param, const char* value);
+
+	struct Button
+	{
+		bool enabled;
+		std::wstring text;
+		vgui::HFont font;
+		int x;
+		int y;
+		int width;
+		int hight;
+		Color background;
+		Color highlight;
+		Color textcolor;
+		Color texthighlight;
+		int mask;
+	};
+	bool tasPreset = false;
+	std::map<std::string, Button> buttonSetting;
+	Button anglesSetting;
 
 protected:
 	virtual bool ShouldLoadFeature() override;
@@ -45,12 +66,20 @@ private:
 	                          int y1,
 	                          vgui::HFont font,
 	                          Color textColor,
-	                          IMatSystemSurface* surface,
 	                          const wchar_t* text);
+	void DrawButton(Button button);
+	Color StringToColor(const char* hex);
+
+	IMatSystemSurface* surface;
+
+	int xOffset;
+	int yOffset;
+	int gridSize;
+	int padding;
+
 	Vector inputMovement;
 	Vector currentAng;
 	Vector previousAng;
-	vgui::HFont ihudFont;
 	int buttonBits;
 
 	bool awaitingFrameDraw;


### PR DESCRIPTION
`y_spt_ihud_modify <element|all> <param> <value>`
Modifies parameters in given element.
- Elements: all, angles, forward, back, moveright, moveleft, use, duck, jump, attack, attack2
- Params: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.
- background, highlight, textcolor, and texthighlight are colors, use hex string. e.g. 563FFF for rgb or 563FFFA0 for rgba.

`y_spt_ihud_preset`
Load ihud preset.
- Valid options: normal, normal_mouse, tas.

Removed y_spt_ihud_button_color
Removed y_spt_ihud_shadow_color
Removed y_spt_ihud_font_color
Removed y_spt_ihud_shadow_font_color
Removed y_spt_ihud_font
Removed portal2 submodule