### PR TITLE
Add Lost Coast and additional step for BMS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ A plugin for all your pausing needs.
     | Half-Life 2            | `hl2`
     | Half-Life 2: Episode 1 | `episodic`
     | Half-Life 2: Episode 2 | `ep2`
+    | Half-Life 2: Lost Coast| `lostcoast`
     | Portal                 | `portal`
     | Black Mesa             | `bms`
 
 3. Launch the game.
 4. Go to `Options > Keyboard > Advanced`, check `Enable developer console`, and press OK.
 5. Press the tilde key (<kbd>~</kbd>) and enter `plugin_load spt` into the developer console.
+  
+ Note: Must `disconnect` first in Black Mesa.
 
    Add `plugin_load spt` to `cfg/autoexec.cfg` to load SourcePauseTool automatically.
 


### PR DESCRIPTION
Sometimes bms folks get questions about loading spt since it doesn't say you need to be disconnected to load it.