### PR TITLE
Added camera control cinematic and fix demo stuff

### DIFF
--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -32,6 +32,7 @@ extern ConVar y_spt_vag_target;
 extern ConVar y_spt_vag_trace_portal;
 extern ConVar y_spt_cam_control;
 extern ConVar y_spt_cam_drive;
+extern ConVar y_spt_cam_path_draw;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -2,6 +2,8 @@
 #include "camera.hpp"
 #include "playerio.hpp"
 #include "interfaces.hpp"
+#include "signals.hpp"
+#include "command.hpp"
 #include "..\sptlib-wrapper.hpp"
 #include "..\cvars.hpp"
 
@@ -19,19 +21,30 @@ ConVar y_spt_cam_control(
     "y_spt_cam_control",
     "0",
     FCVAR_CHEAT,
-    "Camera is separated and can be controlled by user input. (Requires sv_cheats 1 if not playing demo)\n");
-ConVar y_spt_cam_drive("y_spt_cam_drive", "1", FCVAR_CHEAT, "Enables or disables camera drive mode.\n");
+    "y_spt_cam_control <type> - Changes the camera control type.\n"
+    "0 = Default\n"
+    "1 = Drive mode\n"
+    "    Camera is separated and can be controlled by user input.\n"
+    "    Use +forward, +back, +moveright, +moveleft, +moveup, +movedown, +duck, +speed keys to drive camera.\n"
+    "    In-game: Requires sv_cheats 1. Set y_spt_cam_drive 1 to enable drive mode.\n"
+    "    Demo playback: Hold right mouse button to enable drive mode.\n"
+    "2 = Cinematic mode\n"
+    "    Camera is controlled by predefined path.\n"
+    "    See commands y_spt_cam_path_");
+ConVar y_spt_cam_drive("y_spt_cam_drive", "1", FCVAR_CHEAT, "Enables or disables camera drive mode in-game.");
+ConVar y_spt_cam_path_draw("y_spt_cam_path_draw", "0", FCVAR_CHEAT, "Draws the current camera path.");
+ConVar y_spt_cam_fov("y_spt_cam_fov", "0", 0, "Sets the camera drive mode FOV.");
 
-CON_COMMAND(y_spt_cam_setpos, "y_spt_cam_setpos <x> <y> <z> - Sets camera position (requires camera Drive Mode)\n")
+CON_COMMAND(y_spt_cam_setpos, "y_spt_cam_setpos <x> <y> <z> - Sets the camera position. (requires camera drive mode)")
 {
 	if (args.ArgC() != 4)
 	{
-		Msg("Usage: y_spt_cam_setpos <x> <y> <z>;\n");
+		Msg("Usage: y_spt_cam_setpos <x> <y> <z>\n");
 		return;
 	}
-	if (!y_spt_cam_control.GetBool())
+	if (!y_spt_cam_control.GetInt() == 1 || !spt_camera.CanOverrideView())
 	{
-		Msg("Requires camera Drive Mode.\n");
+		Msg("Requires camera drive mode.\n");
 		return;
 	}
 	Vector pos = {0.0, 0.0, 0.0};
@@ -39,20 +52,20 @@ CON_COMMAND(y_spt_cam_setpos, "y_spt_cam_setpos <x> <y> <z> - Sets camera positi
 	{
 		pos[i] = atof(args.Arg(i + 1));
 	}
-	spt_camera.cam_origin = pos;
+	spt_camera.current_cam.origin = pos;
 }
 
 CON_COMMAND(y_spt_cam_setang,
-            "y_spt_cam_setang <pitch> <yaw> [roll] - Sets camera angles (requires camera Drive Mode)\n")
+            "y_spt_cam_setang <pitch> <yaw> [roll] - Sets the camera angles. (requires camera drive mode)")
 {
 	if (args.ArgC() != 3 && args.ArgC() != 4)
 	{
-		Msg("Usage: y_spt_cam_setang <pitch> <yaw> [roll];\n");
+		Msg("Usage: y_spt_cam_setang <pitch> <yaw> [roll]\n");
 		return;
 	}
-	if (!y_spt_cam_control.GetBool())
+	if (!y_spt_cam_control.GetInt() == 1 || !spt_camera.CanOverrideView())
 	{
-		Msg("Requires camera Drive Mode.\n");
+		Msg("Requires camera drive mode.\n");
 		return;
 	}
 	QAngle ang = {0.0, 0.0, 0.0};
@@ -60,7 +73,130 @@ CON_COMMAND(y_spt_cam_setang,
 	{
 		ang[i] = atof(args.Arg(i + 1));
 	}
-	spt_camera.cam_angles = ang;
+	spt_camera.current_cam.angles = ang;
+}
+
+CON_COMMAND(y_spt_cam_path_setkf,
+            "y_spt_cam_path_setkf [frame] [x] [y] [z] [yaw] [pitch] [roll] [fov]- Sets a camera path keyframe.")
+{
+	if (!spt_demostuff.Demo_IsPlayingBack())
+	{
+		Msg("Cinematic mode requires demo playback.\n");
+		return;
+	}
+	int argc = args.ArgC();
+	Camera::CameraInfo info;
+	int tick;
+	if (argc == 1)
+	{
+		tick = spt_demostuff.Demo_GetPlaybackTick();
+		info = spt_camera.current_cam;
+	}
+	else if (argc == 9)
+	{
+		tick = atoi(args.Arg(1));
+		float nums[7];
+		for (int i = 0; i < args.ArgC() - 2; i++)
+		{
+			nums[i] = std::stof(args.Arg(i + 2));
+		}
+		info.origin.x = nums[0];
+		info.origin.y = nums[1];
+		info.origin.z = nums[2];
+		info.angles.x = nums[3];
+		info.angles.y = nums[4];
+		info.angles.z = nums[5];
+		info.fov = nums[6];
+	}
+	else
+	{
+		Msg("Usage: y_spt_cam_path_setkf [frame] [x] [y] [z] [yaw] [pitch] [roll] [fov]\n");
+		return;
+	}
+	spt_camera.keyframes[tick] = info;
+	Msg("[%d]\n%s\n", tick, std::string(info).c_str());
+	spt_camera.RecomputeInterpPath();
+}
+
+CON_COMMAND(y_spt_cam_path_showkfs, "y_spt_cam_path_showkfs - Prints all keyframes.")
+{
+	for (const auto& kv : spt_camera.keyframes)
+	{
+		Msg("[%d]\n%s\n", kv.first, std::string(kv.second).c_str());
+	}
+}
+
+CON_COMMAND(y_spt_cam_path_getkfs, "y_spt_cam_path_getkfs - Prints all keyframes in commands.")
+{
+	for (const auto& kv : spt_camera.keyframes)
+	{
+		Camera::CameraInfo info = kv.second;
+		Msg("y_spt_cam_path_setkf %d %f %f %f %f %f %f %f;\n",
+		    kv.first,
+		    info.origin.x,
+		    info.origin.y,
+		    info.origin.z,
+		    info.angles.x,
+		    info.angles.y,
+		    info.angles.z,
+		    info.fov);
+	}
+}
+
+#ifdef SSDK2013
+// autocomplete crashes on stemapipe :((
+CON_COMMAND(y_spt_cam_path_rmkf, "y_spt_cam_path_rmkf <tick> - Removes a keyframe.")
+#else
+static int y_spt_cam_path_rmkf_CompletionFunc(
+    const char* partial,
+    char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])
+{
+	std::vector<std::string> completion;
+	for (const auto& kv : spt_camera.keyframes)
+	{
+		completion.push_back(std::to_string(kv.first));
+	}
+	AutoCompletList y_spt_cam_path_rmkf_Complete("y_spt_cam_path_rmkf", completion);
+	return y_spt_cam_path_rmkf_Complete.AutoCompletionFunc(partial, commands);
+}
+
+CON_COMMAND_F_COMPLETION(y_spt_cam_path_rmkf,
+                         "y_spt_cam_path_rmkf <tick> - Removes a keyframe.",
+                         0,
+                         y_spt_cam_path_rmkf_CompletionFunc)
+#endif
+{
+	if (args.ArgC() != 2)
+	{
+		Msg("Usage: y_spt_cam_path_rmkf <tick>\n");
+		return;
+	}
+	if (!spt_demostuff.Demo_IsPlayingBack())
+	{
+		Msg("Cinematic mode requires demo playback.\n");
+		return;
+	}
+	int tick = atoi(args.Arg(1));
+	bool removed = spt_camera.keyframes.erase(tick);
+	if (removed)
+	{
+		spt_camera.RecomputeInterpPath();
+		Msg("Removed keyframe at frame %d.\n", tick);
+	}
+	else
+		Msg("Keyframe at frame %d does not exist.\n", tick);
+}
+
+CON_COMMAND(y_spt_cam_path_clear, "y_spt_cam_path_clear - Removes all keyframes.")
+{
+	if (!spt_demostuff.Demo_IsPlayingBack())
+	{
+		Msg("Cinematic mode requires demo playback.\n");
+		return;
+	}
+	spt_camera.keyframes.clear();
+	spt_camera.RecomputeInterpPath();
+	Msg("Removed all keyframes.\n");
 }
 
 namespace patterns
@@ -105,42 +241,80 @@ void Camera::InitHooks()
 	HOOK_FUNCTION(client, ClientModeShared__CreateMove);
 	HOOK_FUNCTION(client, CInput__MouseMove);
 	HOOK_FUNCTION(client, C_BasePlayer__ShouldDrawLocalPlayer);
-#ifdef SSDK2013
+#if defined(SSDK2013)
+	// This function only exist in steampipe
 	HOOK_FUNCTION(client, C_BasePlayer__ShouldDrawThisPlayer);
 #endif
 }
 
-bool Camera::ShouldOverrideView() const
+bool Camera::CanOverrideView() const
 {
-	return y_spt_cam_control.GetBool() && interfaces::engine_client->IsInGame()
-	       && (_sv_cheats->GetBool() || interfaces::engine_client->IsPlayingDemo());
+	// Requires sv_cheats if not playing demo
+	return interfaces::engine_client->IsInGame() && _sv_cheats->GetBool() || spt_demostuff.Demo_IsPlayingBack();
 }
 
-bool Camera::IsInDriveMode() const
+bool Camera::CanInput() const
 {
-	return ShouldOverrideView() && y_spt_cam_drive.GetBool() && !interfaces::engine_vgui->IsGameUIVisible();
+	// Is in drive mode and y_spt_cam_drive
+	// If playing demo automatically enables input and need right click to drive
+	if (!CanOverrideView() || y_spt_cam_control.GetInt() != 1)
+		return false;
+	bool can_input;
+	if (spt_demostuff.Demo_IsPlayingBack())
+		can_input = interfaces::inputSystem->IsButtonDown(MOUSE_RIGHT);
+	else
+		can_input = y_spt_cam_drive.GetBool();
+	return can_input && !interfaces::engine_vgui->IsGameUIVisible();
 }
 
 void Camera::GetCurrentView()
 {
-	cam_origin = spt_playerio.GetPlayerEyePos();
+	current_cam.origin = spt_playerio.GetPlayerEyePos();
 	float ang[3];
 	EngineGetViewAngles(ang);
-	cam_angles = QAngle(ang[0], ang[1], 0);
+	current_cam.angles = QAngle(ang[0], ang[1], 0);
+}
+
+void Camera::RefreshTimeOffset()
+{
+	time_offset = interfaces::engine_tool->ClientTime() - spt_demostuff.Demo_GetPlaybackTick() / 66.6666f;
 }
 
 void Camera::OverrideView(CViewSetup* view)
 {
-	if (ShouldOverrideView())
+	int control_type = CanOverrideView() ? y_spt_cam_control.GetInt() : 0;
+	if (y_spt_cam_fov.GetBool())
+		current_cam.fov = y_spt_cam_fov.GetFloat();
+	else
+		current_cam.fov = view->fov;
+	HandleDriveMode(control_type == 1);
+	HandleCinematicMode(control_type == 2 && spt_demostuff.Demo_IsPlayingBack());
+	if (control_type)
 	{
-		HandleInput(true);
-		view->origin = cam_origin;
-		view->angles = cam_angles;
+		view->origin = current_cam.origin;
+		view->angles = current_cam.angles;
+		view->fov = current_cam.fov;
 	}
-	else if (input_active)
+}
+
+void Camera::HandleDriveMode(bool active)
+{
+	static bool drive_active = false;
+	if (drive_active ^ active)
 	{
-		HandleInput(false);
+		if (drive_active && !active)
+		{
+			// On drive mode end
+			HandleInput(false);
+		}
+		else
+		{
+			// On drive mode start
+			GetCurrentView();
+		}
 	}
+	HandleInput(active && CanInput());
+	drive_active = active;
 }
 
 static bool isBindDown(const char* bind)
@@ -158,30 +332,32 @@ static bool isBindDown(const char* bind)
 
 void Camera::HandleInput(bool active)
 {
+	static bool input_active = false;
+
 	static std::chrono::time_point<std::chrono::steady_clock> last_frame;
-	auto now = std::chrono::steady_clock::now();
 
 	if (input_active ^ active)
 	{
 		if (input_active && !active)
 		{
-			// On camera control end
+			// On input mode end
 			interfaces::vgui_input->SetCursorPos(old_cursor[0], old_cursor[1]);
 		}
 		else
 		{
-			// On camera control start
-			last_frame = now;
-			GetCurrentView();
+			// On input mode start
+			last_frame = std::chrono::steady_clock::now();
 			interfaces::vgui_input->GetCursorPos(old_cursor[0], old_cursor[1]);
 		}
 	}
 
-	float real_frame_time = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_frame).count();
-	last_frame = now;
-
-	if (active && IsInDriveMode())
+	if (active)
 	{
+		auto now = std::chrono::steady_clock::now();
+		float real_frame_time =
+		    std::chrono::duration_cast<std::chrono::duration<float>>(now - last_frame).count();
+		last_frame = now;
+
 		float frame_time = real_frame_time;
 		Vector movement(0.0f, 0.0f, 0.0f);
 
@@ -215,39 +391,279 @@ void Camera::HandleInput(bool active)
 		float yaw = -(float)dx * 0.022f * sensitivity->GetFloat();
 
 		// Apply mouse
-		cam_angles.x += pitch;
-		cam_angles.x = clamp(cam_angles.x, -89.0f, 89.0f);
-		cam_angles.y += yaw;
-		if (cam_angles.y > 180.0f)
-			cam_angles.y -= 360.0f;
-		else if (cam_angles.y < -180.0f)
-			cam_angles.y += 360.0f;
+		QAngle angles = current_cam.angles;
+		angles.x += pitch;
+		angles.x = clamp(angles.x, -89.0f, 89.0f);
+		angles.y += yaw;
+		if (angles.y > 180.0f)
+			angles.y -= 360.0f;
+		else if (angles.y < -180.0f)
+			angles.y += 360.0f;
+		current_cam.angles = angles;
 
 		// Now apply forward, side, up
 
 		Vector fwd, side, up;
 
-		AngleVectors(cam_angles, &fwd, &side, &up);
+		AngleVectors(angles, &fwd, &side, &up);
 
 		VectorNormalize(movement);
 		movement *= move_speed * frame_time;
 
-		cam_origin += fwd * movement.x;
-		cam_origin += side * movement.y;
-		cam_origin += up * movement.z;
+		current_cam.origin += fwd * movement.x;
+		current_cam.origin += side * movement.y;
+		current_cam.origin += up * movement.z;
 	}
 	input_active = active;
 }
 
-void __fastcall Camera::HOOKED_ClientModeShared__OverrideView(void* thisptr, int edx, CViewSetup* view)
+// Canera path interp code from SourceAutoRecord
+// https://github.com/p2sr/SourceAutoRecord/blob/master/src/Features/Camera.cpp
+static float InterpCurve(std::vector<Vector> points, float x, bool is_angles = false)
+{
+	enum
+	{
+		FIRST,
+		PREV,
+		NEXT,
+		LAST
+	};
+
+	if (is_angles)
+	{
+		float old_y = 0;
+		for (int i = 0; i < 4; i++)
+		{
+			float ang_diff = points[i].y - old_y;
+			ang_diff += (ang_diff > 180) ? -360 : (ang_diff < -180) ? 360 : 0;
+			points[i].y = old_y += ang_diff;
+			old_y = points[i].y;
+		}
+	}
+
+	if (x <= points[PREV].x)
+		return points[PREV].y;
+	if (x >= points[NEXT].x)
+		return points[NEXT].y;
+
+	float t = (x - points[PREV].x) / (points[NEXT].x - points[PREV].x);
+
+	float t2 = t * t, t3 = t * t * t;
+	float x0 = (points[FIRST].x - points[PREV].x) / (points[NEXT].x - points[PREV].x);
+	float x1 = 0, x2 = 1;
+	float x3 = (points[LAST].x - points[PREV].x) / (points[NEXT].x - points[PREV].x);
+	float m1 = ((points[NEXT].y - points[PREV].y) / (x2 - x1) + (points[PREV].y - points[FIRST].y) / (x1 - x0)) / 2;
+	float m2 = ((points[LAST].y - points[NEXT].y) / (x3 - x2) + (points[NEXT].y - points[PREV].y) / (x2 - x1)) / 2;
+
+	return (2 * t3 - 3 * t2 + 1) * points[PREV].y + (t3 - 2 * t2 + t) * m1 + (-2 * t3 + 3 * t2) * points[NEXT].y
+	       + (t3 - t2) * m2;
+}
+
+std::vector<Vector> Camera::CameraInfoToPoints(float* x, CameraInfo* y, CameraInfoParameter param)
+{
+	std::vector<Vector> points;
+	for (int i = 0; i < 4; i++)
+	{
+		Vector v;
+		v.x = x[i];
+		CameraInfo cs = y[i];
+		switch (param)
+		{
+		case ORIGIN_X:
+			v.y = cs.origin.x;
+			break;
+		case ORIGIN_Y:
+			v.y = cs.origin.y;
+			break;
+		case ORIGIN_Z:
+			v.y = cs.origin.z;
+			break;
+		case ANGLES_X:
+			v.y = cs.angles.x;
+			break;
+		case ANGLES_Y:
+			v.y = cs.angles.y;
+			break;
+		case ANGLES_Z:
+			v.y = cs.angles.z;
+			break;
+		case FOV:
+			v.y = cs.fov;
+			break;
+		}
+		points.push_back(v);
+	}
+	return points;
+}
+
+Camera::CameraInfo Camera::InterpPath(float time)
+{
+	enum
+	{
+		FIRST,
+		PREV,
+		NEXT,
+		LAST
+	};
+
+	// reading 4 frames closest to time
+	float frame_time = time * 66.6666f;
+	int frames[4] = {INT_MIN, INT_MIN, INT_MAX, INT_MAX};
+	for (auto const& state : keyframes)
+	{
+		int state_time = state.first;
+		if (frame_time - state_time >= 0 && frame_time - state_time < frame_time - frames[PREV])
+		{
+			frames[FIRST] = frames[PREV];
+			frames[PREV] = state_time;
+		}
+		if (state_time - frame_time >= 0 && state_time - frame_time < frames[NEXT] - frame_time)
+		{
+			frames[LAST] = frames[NEXT];
+			frames[NEXT] = state_time;
+		}
+		if (state_time > frames[FIRST] && state_time < frames[PREV])
+		{
+			frames[FIRST] = state_time;
+		}
+		if (state_time > frames[NEXT] && state_time < frames[LAST])
+		{
+			frames[LAST] = state_time;
+		}
+	}
+
+	// x values for interpolation
+	float x[4];
+	for (int i = 0; i < 4; i++)
+		x[i] = (float)frames[i];
+
+	// making sure all X values are correct before reading Y values,
+	// "frames" fixed for read, "x" fixed for interpolation.
+	// if there's at least one cam state in the map, none of these should be MIN or MAX after this.
+	if (frames[PREV] == INT_MIN)
+	{
+		x[PREV] = (float)frames[NEXT];
+		frames[PREV] = frames[NEXT];
+	}
+	if (frames[NEXT] == INT_MAX)
+	{
+		x[NEXT] = (float)frames[PREV];
+		frames[NEXT] = frames[PREV];
+	}
+	if (frames[FIRST] == INT_MIN)
+	{
+		x[FIRST] = (float)(2 * frames[PREV] - frames[NEXT]);
+		frames[FIRST] = frames[PREV];
+	}
+	if (frames[LAST] == INT_MAX)
+	{
+		x[LAST] = (float)(2 * frames[NEXT] - frames[PREV]);
+		frames[LAST] = frames[NEXT];
+	}
+
+	// filling Y values
+	CameraInfo y[4];
+	for (int i = 0; i < 4; i++)
+	{
+		y[i] = keyframes[frames[i]];
+	}
+
+	// interpolating each parameter
+	CameraInfo interp;
+	interp.origin.x = InterpCurve(CameraInfoToPoints(x, y, ORIGIN_X), frame_time);
+	interp.origin.y = InterpCurve(CameraInfoToPoints(x, y, ORIGIN_Y), frame_time);
+	interp.origin.z = InterpCurve(CameraInfoToPoints(x, y, ORIGIN_Z), frame_time);
+	interp.angles.x = InterpCurve(CameraInfoToPoints(x, y, ANGLES_X), frame_time, true);
+	interp.angles.y = InterpCurve(CameraInfoToPoints(x, y, ANGLES_Y), frame_time, true);
+	interp.angles.z = InterpCurve(CameraInfoToPoints(x, y, ANGLES_Z), frame_time, true);
+	interp.fov = InterpCurve(CameraInfoToPoints(x, y, FOV), frame_time);
+
+	return interp;
+}
+
+void Camera::HandleCinematicMode(bool active)
+{
+	if (!active)
+		return;
+	if (!keyframes.size())
+		return;
+	float current_time = interfaces::engine_tool->ClientTime() - time_offset;
+	current_cam = InterpPath(current_time);
+}
+
+void Camera::RecomputeInterpPath()
+{
+	interp_path_cache.clear();
+	if (!keyframes.size())
+		return;
+	int start = keyframes.begin()->first;
+	int end = keyframes.rbegin()->first;
+	for (int i = start; i <= end; i++)
+	{
+		interp_path_cache.push_back(InterpPath(i / 66.6666f));
+	}
+}
+
+void Camera::DrawPath()
+{
+	if (!y_spt_cam_path_draw.GetBool() || !spt_demostuff.Demo_IsPlayingBack())
+		return;
+	if (!interp_path_cache.size())
+		return;
+	auto last = interp_path_cache[0];
+	int start = keyframes.begin()->first;
+
+#ifdef OE
+#define NDEBUG_PERSIST_TILL_NEXT_SERVER 0.01023f
+#endif
+
+	for (int i = 0; i < interp_path_cache.size(); i++)
+	{
+		auto current = interp_path_cache[i];
+		Vector forward;
+		AngleVectors(current.angles, &forward);
+		interfaces::debugOverlay->AddLineOverlay(current.origin,
+		                                         last.origin,
+		                                         255,
+		                                         255,
+		                                         255,
+		                                         false,
+		                                         NDEBUG_PERSIST_TILL_NEXT_SERVER);
+		if (keyframes.find(start + i) != keyframes.end())
+		{
+			interfaces::debugOverlay->AddLineOverlay(current.origin,
+			                                         current.origin + forward * 50.0f,
+			                                         0,
+			                                         255,
+			                                         0,
+			                                         false,
+			                                         NDEBUG_PERSIST_TILL_NEXT_SERVER);
+			interfaces::debugOverlay->AddTextOverlay(current.origin,
+			                                         NDEBUG_PERSIST_TILL_NEXT_SERVER,
+			                                         "[%d]",
+			                                         start + i);
+		}
+		else
+			interfaces::debugOverlay->AddLineOverlay(current.origin,
+			                                         current.origin + forward * 25.0f,
+			                                         255,
+			                                         255,
+			                                         0,
+			                                         false,
+			                                         NDEBUG_PERSIST_TILL_NEXT_SERVER);
+		last = current;
+	}
+}
+
+HOOK_THISCALL(void, Camera, ClientModeShared__OverrideView, CViewSetup* view)
 {
 	spt_camera.OverrideView(view);
 	spt_camera.ORIG_ClientModeShared__OverrideView(thisptr, edx, view);
 }
 
-bool __fastcall Camera::HOOKED_ClientModeShared__CreateMove(void* thisptr, int edx, float flInputSampleTime, void* cmd)
+HOOK_THISCALL(bool, Camera, ClientModeShared__CreateMove, float flInputSampleTime, void* cmd)
 {
-	if (spt_camera.IsInDriveMode())
+	if (spt_camera.CanInput())
 	{
 		// Block all inputs
 		auto usercmd = reinterpret_cast<CUserCmd*>(cmd);
@@ -259,9 +675,9 @@ bool __fastcall Camera::HOOKED_ClientModeShared__CreateMove(void* thisptr, int e
 	return spt_camera.ORIG_ClientModeShared__CreateMove(thisptr, edx, flInputSampleTime, cmd);
 }
 
-bool __fastcall Camera::HOOKED_C_BasePlayer__ShouldDrawLocalPlayer(void* thisptr, int edx)
+HOOK_THISCALL(bool, Camera, C_BasePlayer__ShouldDrawLocalPlayer)
 {
-	if (spt_camera.ShouldOverrideView())
+	if (spt_camera.CanOverrideView() && y_spt_cam_control.GetBool())
 	{
 		return true;
 	}
@@ -269,11 +685,11 @@ bool __fastcall Camera::HOOKED_C_BasePlayer__ShouldDrawLocalPlayer(void* thisptr
 }
 
 #if defined(SSDK2013)
-bool __fastcall Camera::HOOKED_C_BasePlayer__ShouldDrawThisPlayer(void* thisptr, int edx)
+HOOK_THISCALL(bool, Camera, C_BasePlayer__ShouldDrawThisPlayer)
 {
 	// ShouldDrawLocalPlayer only decides draw view model or weapon model in steampipe
 	// We need ShouldDrawThisPlayer to make player model draw
-	if (spt_camera.ShouldOverrideView())
+	if (spt_camera.CanOverrideView() && y_spt_cam_control.GetBool())
 	{
 		return true;
 	}
@@ -284,7 +700,7 @@ bool __fastcall Camera::HOOKED_C_BasePlayer__ShouldDrawThisPlayer(void* thisptr,
 void __fastcall Camera::HOOKED_CInput__MouseMove(void* thisptr, int edx, void* cmd)
 {
 	// Block mouse inputs and stop the game from resetting cursor pos
-	if (spt_camera.IsInDriveMode())
+	if (spt_camera.CanInput())
 		return;
 	spt_camera.ORIG_CInput__MouseMove(thisptr, edx, cmd);
 }
@@ -310,8 +726,25 @@ void Camera::LoadFeature()
 	{
 		InitConcommandBase(y_spt_cam_control);
 		InitConcommandBase(y_spt_cam_drive);
+		InitConcommandBase(y_spt_cam_fov);
 		InitCommand(y_spt_cam_setpos);
 		InitCommand(y_spt_cam_setang);
+
+		if (spt_demostuff.Demo_IsDemoPlayerAvailable() && DemoStartPlaybackSignal.Works
+		    && interfaces::engine_tool)
+		{
+			DemoStartPlaybackSignal.Connect(this, &Camera::RefreshTimeOffset);
+			InitCommand(y_spt_cam_path_setkf);
+			InitCommand(y_spt_cam_path_showkfs);
+			InitCommand(y_spt_cam_path_getkfs);
+			InitCommand(y_spt_cam_path_rmkf);
+			InitCommand(y_spt_cam_path_clear);
+			if (interfaces::debugOverlay && FrameSignal.Works)
+			{
+				FrameSignal.Connect(this, &Camera::DrawPath);
+				InitConcommandBase(y_spt_cam_path_draw);
+			}
+		}
 
 		sensitivity = interfaces::g_pCVar->FindVar("sensitivity");
 	}

--- a/spt/features/demo.hpp
+++ b/spt/features/demo.hpp
@@ -11,6 +11,7 @@ public:
 	bool Demo_IsPlayingBack() const;
 	bool Demo_IsPlaybackPaused() const;
 	bool Demo_IsAutoRecordingAvailable() const;
+	bool Demo_IsDemoPlayerAvailable() const;
 	void StartAutorecord();
 	void StopAutorecord();
 
@@ -36,8 +37,9 @@ private:
 
 	DECL_HOOK_THISCALL(void, StopRecording);
 	DECL_HOOK_THISCALL(void, SetSignonState, int state);
+	DECL_HOOK_THISCALL(bool, CDemoPlayer__StartPlayback, const char* filename, bool as_time_demo);
 	uintptr_t ORIG_Record = 0;
-	void OnTick();
+	void OnFrame();
 };
 
 extern DemoStuff spt_demostuff;

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -31,6 +31,7 @@
 #include "vgui\isystem.h"
 #include "vgui\ivgui.h"
 #include "ienginevgui.h"
+#include "toolframework\ienginetool.h"
 #include "inputsystem\iinputsystem.h"
 #include "SDK\hl_movedata.h"
 #include "SDK\igamemovement.h"
@@ -56,6 +57,7 @@ namespace interfaces
 	vgui::ISchemeManager* scheme = nullptr;
 	vgui::IInput* vgui_input = nullptr;
 	IEngineVGui* engine_vgui = nullptr;
+	IEngineTool* engine_tool = nullptr;
 	IVDebugOverlay* debugOverlay = nullptr;
 	IMaterialSystem* materialSystem = nullptr;
 	IInputSystem* inputSystem = nullptr;
@@ -162,6 +164,7 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 	interfaces::debugOverlay = (IVDebugOverlay*)interfaceFactory(VDEBUG_OVERLAY_INTERFACE_VERSION, NULL);
 	interfaces::materialSystem = (IMaterialSystem*)interfaceFactory(MATERIAL_SYSTEM_INTERFACE_VERSION, NULL);
 	interfaces::engine_vgui = (IEngineVGui*)interfaceFactory(VENGINE_VGUI_VERSION, NULL);
+	interfaces::engine_tool = (IEngineTool*)interfaceFactory(VENGINETOOL_INTERFACE_VERSION, NULL);
 	interfaces::vgui_input = (vgui::IInput*)interfaceFactory(VGUI_INPUT_INTERFACE_VERSION, NULL);
 	interfaces::surface = (IMatSystemSurface*)interfaceFactory(MAT_SYSTEM_SURFACE_INTERFACE_VERSION, NULL);
 	interfaces::scheme = (vgui::ISchemeManager*)interfaceFactory(VGUI_SCHEME_INTERFACE_VERSION, NULL);
@@ -267,6 +270,9 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 
 	if (!interfaces::engine_vgui)
 		DevWarning("SPT: Failed to get the engine vgui interface.\n");
+
+	if (!interfaces::engine_tool)
+		DevWarning("SPT: Failed to get the engine tool interface.\n");
 
 	if (!interfaces::vgui_input)
 		DevWarning("SPT: Failed to get the vgui input interface.\n");

--- a/spt/utils/interfaces.hpp
+++ b/spt/utils/interfaces.hpp
@@ -8,6 +8,7 @@
 #include "vgui\IScheme.h"
 #include "vgui\IInput.h"
 #include "ienginevgui.h"
+#include "toolframework\ienginetool.h"
 #include "inputsystem\iinputsystem.h"
 #include "cdll_int.h"
 #include "icliententitylist.h"
@@ -22,6 +23,7 @@ namespace interfaces
 	extern vgui::ISchemeManager* scheme;
 	extern vgui::IInput* vgui_input;
 	extern IEngineVGui* engine_vgui;
+	extern IEngineTool* engine_tool;
 	extern IVDebugOverlay* debugOverlay;
 	extern IMaterialSystem* materialSystem;
 	extern IInputSystem* inputSystem;

--- a/spt/utils/signals.cpp
+++ b/spt/utils/signals.cpp
@@ -12,3 +12,4 @@ Gallant::Signal2<void*, bool> SetPausedSignal;
 Gallant::Signal1<bool> SV_ActivateServerSignal;
 Gallant::Signal1<uintptr_t> CreateMoveSignal;
 Gallant::Signal0<void> VagCrashSignal;
+Gallant::Signal0<void> DemoStartPlaybackSignal;

--- a/spt/utils/signals.hpp
+++ b/spt/utils/signals.hpp
@@ -13,3 +13,4 @@ extern Gallant::Signal2<void*, bool> SetPausedSignal;
 extern Gallant::Signal1<bool> SV_ActivateServerSignal;
 extern Gallant::Signal1<uintptr_t> CreateMoveSignal;
 extern Gallant::Signal0<void> VagCrashSignal;
+extern Gallant::Signal0<void> DemoStartPlaybackSignal;


### PR DESCRIPTION
<img width="960" alt="Screenshot 2022-07-16 043343" src="https://user-images.githubusercontent.com/72735402/179347361-dcb0afd2-fe07-4e6e-b1e9-24b5fab85830.png">

- New camera setting cvar:
`y_spt_fov`

- Change `y_spt_cam_control 1`
Now you need to hold right mouse button to enable drive mode during demo playback. (To get better interaction with `demoui`)

- Camera cinematic mode :
`y_spt_cam_control 2` - Camera is controlled by predefined path.
`y_spt_cam_path_setkf` - Sets a keyframe.
`y_spt_cam_path_showkfs` -  Prints all keyframes.
`y_spt_cam_path_getkfs` - Prints all keyframes in commands.
`y_spt_cam_path_rmkf` - Removes a keyframe.
`y_spt_cam_path_clear` - Removes all keyframes.
`y_spt_cam_path_draw` - Draws the current camera path.

- Fixed `y_spt_pause_demo_on_tick`

- Added 7197370 Record patterns

- Added Demoplayer offsets for 3420, 1910503, 7197370

