### PR TITLE
Add y_spt_demo_block_cmd and prevent glitching ihud

### DIFF
--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -17,6 +17,7 @@ extern ConVar y_spt_focus_nosleep;
 extern ConVar y_spt_stucksave;
 extern ConVar y_spt_piwsave;
 extern ConVar y_spt_pause_demo_on_tick;
+extern ConVar y_spt_block_demo_cmd;
 extern ConVar y_spt_on_slide_pause_for;
 extern ConVar y_spt_prevent_vag_crash;
 extern ConVar y_spt_disable_tone_map_reset;
@@ -33,6 +34,7 @@ extern ConVar y_spt_vag_trace_portal;
 extern ConVar y_spt_cam_control;
 extern ConVar y_spt_cam_drive;
 extern ConVar y_spt_cam_path_draw;
+extern ConVar y_spt_cam_fov;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/features/demo.hpp
+++ b/spt/features/demo.hpp
@@ -38,6 +38,7 @@ private:
 	DECL_HOOK_THISCALL(void, StopRecording);
 	DECL_HOOK_THISCALL(void, SetSignonState, int state);
 	DECL_HOOK_THISCALL(bool, CDemoPlayer__StartPlayback, const char* filename, bool as_time_demo);
+	DECL_HOOK_THISCALL(const char*, CDemoFile__ReadConsoleCommand);
 	uintptr_t ORIG_Record = 0;
 	void OnFrame();
 };

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -14,11 +14,11 @@
 
 InputHud spt_ihud;
 
-ConVar y_spt_ihud("y_spt_ihud", "0", 0, "Draws movement inputs of client.\n");
-ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", 0, "Grid size of input HUD.\n");
+ConVar y_spt_ihud("y_spt_ihud", "0", 0, "Draws movement inputs of client.");
+ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", 0, "Grid size of input HUD.");
 ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding", "2", 0, "Padding between grids of input HUD.");
-ConVar y_spt_ihud_x("y_spt_ihud_x", "2", 0, "X position of input HUD.\n", true, 0.0f, true, 100.0f);
-ConVar y_spt_ihud_y("y_spt_ihud_y", "2", 0, "Y position of input HUD.\n", true, 0.0f, true, 100.0f);
+ConVar y_spt_ihud_x("y_spt_ihud_x", "2", 0, "X position of input HUD.", true, 0.0f, true, 100.0f);
+ConVar y_spt_ihud_y("y_spt_ihud_y", "2", 0, "Y position of input HUD.", true, 0.0f, true, 100.0f);
 
 // default setting
 static const Color background = {0, 0, 0, 233};
@@ -29,7 +29,7 @@ static const std::string font = FONT_Trebuchet20;
 
 CON_COMMAND(
     y_spt_ihud_modify,
-    "y_spt_ihud_modify <element|all> <param> <value> - Modifies parameters in given element.\nParams: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.\n")
+    "y_spt_ihud_modify <element|all> <param> <value> - Modifies parameters in given element.\nParams: enabled, text, font, x, y, width, height, background, highlight, textcolor, texthighlight.")
 {
 	if (args.ArgC() != 4)
 	{
@@ -66,7 +66,7 @@ CON_COMMAND(
 }
 
 CON_COMMAND_AUTOCOMPLETE(y_spt_ihud_preset,
-                         "Load ihud preset.\nValid options: normal, normal_mouse, tas.\n",
+                         "Load ihud preset.\nValid options: normal, normal_mouse, tas.",
                          0,
                          ({"normal", "normal_mouse", "tas"}))
 {
@@ -211,7 +211,7 @@ CON_COMMAND_AUTOCOMPLETE(y_spt_ihud_preset,
 	}
 }
 
-CON_COMMAND(y_spt_ihud_add_key, "y_spt_ihud_add_key <key> - Add custom key to ihud.\n")
+CON_COMMAND(y_spt_ihud_add_key, "y_spt_ihud_add_key <key> - Add custom key to ihud.")
 {
 	if (args.ArgC() != 2)
 	{
@@ -499,7 +499,7 @@ void InputHud::DrawInputHud()
 	gridSize = y_spt_ihud_grid_size.GetInt();
 	padding = y_spt_ihud_grid_padding.GetInt();
 
-	if (y_spt_ihud.GetBool())
+	if (y_spt_ihud.GetBool() && !interfaces::engine_vgui->IsGameUIVisible())
 	{
 		Vector ang;
 		if (tasPreset || anglesSetting.enabled)


### PR DESCRIPTION
- `y_spt_demo_block_cmd` - Stop all commands from being run by demo playback.

- Turn off ihud when the game UI is visible. (Prevent glitching ihud during pause or in Glados room)
Glitching ihud:
![unknown](https://user-images.githubusercontent.com/72735402/179396657-8af9a721-667e-4fed-8b06-ccc17c8e82f2.png)
- Removed newline at the end of ihud help string.