### PR TITLE
Fix y_spt_additional_jumpboost and Add y_spt_aircontrol

### DIFF
--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -12,7 +12,7 @@ void FormatConCmd(const char* fmt, ...);
 extern ConVar y_spt_pause;
 extern ConVar y_spt_motion_blur_fix;
 extern ConVar y_spt_autojump;
-extern ConVar y_spt_additional_jumpboost;
+extern ConVar y_spt_jumpboost;
 extern ConVar y_spt_aircontrol;
 extern ConVar y_spt_focus_nosleep;
 extern ConVar y_spt_stucksave;

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -13,6 +13,7 @@ extern ConVar y_spt_pause;
 extern ConVar y_spt_motion_blur_fix;
 extern ConVar y_spt_autojump;
 extern ConVar y_spt_additional_jumpboost;
+extern ConVar y_spt_aircontrol;
 extern ConVar y_spt_focus_nosleep;
 extern ConVar y_spt_stucksave;
 extern ConVar y_spt_piwsave;

--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -16,14 +16,14 @@
 AutojumpFeature spt_autojump;
 ConVar y_spt_autojump("y_spt_autojump", "0", FCVAR_ARCHIVE | FCVAR_DEMO);
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_CHEAT);
-ConVar y_spt_additional_jumpboost("y_spt_additional_jumpboost",
-                                  "0",
-                                  FCVAR_CHEAT,
-                                  "Enables special game movement mechanic.\n"
-                                  "0 = Default.\n"
-                                  "1 = ABH movement mechanic.\n"
-                                  "2 = OE movement mechanic.\n"
-                                  "3 = HL2DM movement mechanic.");
+ConVar y_spt_jumpboost("y_spt_jumpboost",
+                       "0",
+                       FCVAR_CHEAT,
+                       "Enables special game movement mechanic.\n"
+                       "0 = Default.\n"
+                       "1 = ABH movement mechanic.\n"
+                       "2 = OE movement mechanic.\n"
+                       "3 = No jumpboost. (multiplayer mode movement)");
 ConVar y_spt_aircontrol("y_spt_aircontrol", "0", FCVAR_CHEAT, "Enables HL2 air control.");
 
 namespace patterns
@@ -244,7 +244,7 @@ void AutojumpFeature::LoadFeature()
 
 	if (ORIG_FinishGravity)
 	{
-		InitConcommandBase(y_spt_additional_jumpboost);
+		InitConcommandBase(y_spt_jumpboost);
 		m_bDucked = spt_entutils.GetPlayerField<bool>("m_Local.m_bDucked");
 	}
 
@@ -376,7 +376,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton_client)
 
 HOOK_THISCALL(void, AutojumpFeature, FinishGravity)
 {
-	if (spt_autojump.insideCheckJumpButton && y_spt_additional_jumpboost.GetBool())
+	if (spt_autojump.insideCheckJumpButton && y_spt_jumpboost.GetBool())
 	{
 		CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off_mv_ptr));
 		bool ducked = spt_autojump.m_bDucked.GetValue();
@@ -400,7 +400,7 @@ HOOK_THISCALL(void, AutojumpFeature, FinishGravity)
 			float flNewSpeed = (flSpeedAddition + mv->m_vecVelocity.Length2D());
 
 			// If we're over the maximum, we want to only boost as much as will get us to the goal speed
-			switch (y_spt_additional_jumpboost.GetInt())
+			switch (y_spt_jumpboost.GetInt())
 			{
 			case 1:
 				if (flNewSpeed > flMaxSpeed)

--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -7,7 +7,6 @@
 #include "dbg.h"
 #include "signals.hpp"
 #include "..\cvars.hpp"
-#include "ent_props.hpp"
 #include "game_detection.hpp"
 
 #ifdef OE
@@ -15,16 +14,17 @@
 #endif
 
 AutojumpFeature spt_autojump;
-ConVar y_spt_autojump("y_spt_autojump", "0", FCVAR_ARCHIVE);
+ConVar y_spt_autojump("y_spt_autojump", "0", FCVAR_ARCHIVE | FCVAR_DEMO);
 ConVar _y_spt_autojump_ensure_legit("_y_spt_autojump_ensure_legit", "1", FCVAR_CHEAT);
 ConVar y_spt_additional_jumpboost("y_spt_additional_jumpboost",
                                   "0",
-                                  0,
+                                  FCVAR_CHEAT,
                                   "Enables special game movement mechanic.\n"
                                   "0 = Default.\n"
                                   "1 = ABH movement mechanic.\n"
                                   "2 = OE movement mechanic.\n"
                                   "3 = HL2DM movement mechanic.");
+ConVar y_spt_aircontrol("y_spt_aircontrol", "0", FCVAR_CHEAT, "Enables HL2 air control.");
 
 namespace patterns
 {
@@ -114,6 +114,22 @@ namespace patterns
 	    "55 8B EC 83 EC 3C 56 89 4D D8 8B 45 D8 8B 48 08 81 C1 ?? ?? ?? ?? E8 ?? ?? ?? ?? 0F B6 C8 85 C9",
 	    "missinginfo1_6",
 	    "55 8B EC 83 EC 18 56 8B F1 8B 4E 04 80 B9 ?? ?? ?? ?? ?? 74 0E 8B 76 08 83 4E 28 02 32 C0 5E 8B E5");
+	PATTERNS(
+	    CPortalGameMovement__AirMove,
+	    "5135",
+	    "83 EC 38 56 8B F1 8D 44 24 ?? 50 8B 46 ?? 8D 4C 24 ?? 51 8D 54 24 ?? 52 83 C0 0C 50 E8 ?? ?? ?? ?? 8B 46 ?? D9 40 ?? 83 C4 10 D9 5C 24 ?? 8D 4C 24 ?? D9 40 ?? D9 5C 24 ?? D9 EE D9 54 24 ?? D9 5C 24 ?? FF 15 ?? ?? ?? ?? DD D8 8D 4C 24 ?? FF 15 ?? ?? ?? ?? DD D8 D9 44 24 ?? 8B 46 ??",
+	    "1910593",
+	    "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B ?? 89 6C 24 ?? 8B EC 83 EC 78 56 57 8B F1",
+	    "7197370",
+	    "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B ?? 89 6C 24 ?? 8B EC 83 EC 68 56 57 8D 45 ?? 8B F1");
+	PATTERNS(
+	    CGameMovement__AirMove,
+	    "5135",
+	    "83 EC 38 56 8B F1 8D 44 24 ?? 50 8B 46 ?? 8D 4C 24 ?? 51 8D 54 24 ?? 52 83 C0 0C 50 E8 ?? ?? ?? ?? 8B 46 ?? D9 40 ?? 83 C4 10 D9 5C 24 ?? 8D 4C 24 ?? D9 40 ?? D9 5C 24 ?? D9 EE D9 54 24 ?? D9 5C 24 ?? FF 15 ?? ?? ?? ?? DD D8 8D 4C 24 ?? FF 15 ?? ?? ?? ?? DD D8 D9 44 24 ?? 8D 4C 24 ??",
+	    "1910593",
+	    "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B ?? 89 6C 24 ?? 8B EC 83 EC 5C 56 8B F1 8D 45 ??",
+	    "7197370",
+	    "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B ?? 89 6C 24 ?? 8B EC 83 EC 6C 56 8D 45 ??");
 } // namespace patterns
 
 void AutojumpFeature::InitHooks()
@@ -121,6 +137,11 @@ void AutojumpFeature::InitHooks()
 	HOOK_FUNCTION(server, CheckJumpButton);
 	HOOK_FUNCTION(client, CheckJumpButton_client);
 	HOOK_FUNCTION(server, FinishGravity);
+	if (utils::DoesGameLookLikePortal())
+	{
+		HOOK_FUNCTION(server, CPortalGameMovement__AirMove);
+		FIND_PATTERN(server, CGameMovement__AirMove);
+	}
 }
 
 bool AutojumpFeature::ShouldLoadFeature()
@@ -140,98 +161,79 @@ void AutojumpFeature::LoadFeature()
 		switch (ptnNumber)
 		{
 		case 0:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 1:
-			off1M_nOldButtons = 1;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 1;
 			break;
 
 		case 2:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 3:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 4:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 5:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 6:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 7:
-			off1M_nOldButtons = 1;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 1;
 			break;
 
 		case 8:
-			off1M_nOldButtons = 1;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 1;
 			break;
 
 		case 9:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 10:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 11:
-			off1M_nOldButtons = 1;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 1;
 			break;
 
 		case 12:
-			off1M_nOldButtons = 3;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 3;
 			break;
 
 		case 13:
-			off1M_nOldButtons = 1;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 1;
 			break;
 
 		case 14:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 15:
-			off1M_nOldButtons = 1;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 1;
 			break;
 
 		case 16:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 17:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 
 		case 18:
-			off1M_nOldButtons = 2;
-			off2M_nOldButtons = 40;
+			off_mv_ptr = 2;
 			break;
 		}
 	}
@@ -243,6 +245,12 @@ void AutojumpFeature::LoadFeature()
 	if (ORIG_FinishGravity)
 	{
 		InitConcommandBase(y_spt_additional_jumpboost);
+		m_bDucked = spt_entutils.GetPlayerField<bool>("m_Local.m_bDucked");
+	}
+
+	if (utils::DoesGameLookLikePortal() && ORIG_CGameMovement__AirMove && ORIG_CPortalGameMovement__AirMove)
+	{
+		InitConcommandBase(y_spt_aircontrol);
 	}
 }
 
@@ -257,7 +265,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton)
 	int* pM_nOldButtons = NULL;
 	int origM_nOldButtons = 0;
 
-	CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off1M_nOldButtons));
+	CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off_mv_ptr));
 	if (tas_log.GetBool())
 		DevMsg("[CheckJumpButton PRE ] origin: %.8f %.8f %.8f; velocity: %.8f %.8f %.8f\n",
 		       mv->GetAbsOrigin().x,
@@ -269,8 +277,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton)
 
 	if (y_spt_autojump.GetBool())
 	{
-		pM_nOldButtons =
-		    (int*)(*((uintptr_t*)thisptr + spt_autojump.off1M_nOldButtons) + spt_autojump.off2M_nOldButtons);
+		pM_nOldButtons = &mv->m_nOldButtons;
 		origM_nOldButtons = *pM_nOldButtons;
 
 		if (!spt_autojump.cantJumpNextTime) // Do not do anything if we jumped on the previous tick.
@@ -327,10 +334,10 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton_client)
 	int* pM_nOldButtons = NULL;
 	int origM_nOldButtons = 0;
 
+	CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off_mv_ptr));
 	if (y_spt_autojump.GetBool())
 	{
-		pM_nOldButtons =
-		    (int*)(*((uintptr_t*)thisptr + spt_autojump.off1M_nOldButtons) + spt_autojump.off2M_nOldButtons);
+		pM_nOldButtons = &mv->m_nOldButtons;
 		origM_nOldButtons = *pM_nOldButtons;
 
 		if (!spt_autojump.client_cantJumpNextTime) // Do not do anything if we jumped on the previous tick.
@@ -371,8 +378,8 @@ HOOK_THISCALL(void, AutojumpFeature, FinishGravity)
 {
 	if (spt_autojump.insideCheckJumpButton && y_spt_additional_jumpboost.GetBool())
 	{
-		CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off1M_nOldButtons));
-		bool ducked = spt_entutils.GetPlayerField<bool>("m_Local.m_bDucked").GetValue();
+		CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off_mv_ptr));
+		bool ducked = spt_autojump.m_bDucked.GetValue();
 
 		// Reset
 		mv->m_vecVelocity.x = old_vel.x;
@@ -416,4 +423,13 @@ HOOK_THISCALL(void, AutojumpFeature, FinishGravity)
 	}
 
 	return spt_autojump.ORIG_FinishGravity(thisptr, edx);
+}
+
+HOOK_THISCALL(void, AutojumpFeature, CPortalGameMovement__AirMove)
+{
+	if (y_spt_aircontrol.GetBool())
+	{
+		return spt_autojump.ORIG_CGameMovement__AirMove(thisptr, edx);
+	}
+	return spt_autojump.ORIG_CPortalGameMovement__AirMove(thisptr, edx);
 }

--- a/spt/features/autojump.hpp
+++ b/spt/features/autojump.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "..\feature.hpp"
+#include "ent_props.hpp"
 
 #if defined(OE)
 #include "vector.h"
@@ -12,8 +13,7 @@
 class AutojumpFeature : public FeatureWrapper<AutojumpFeature>
 {
 public:
-	ptrdiff_t off1M_nOldButtons = 0;
-	ptrdiff_t off2M_nOldButtons = 0;
+	ptrdiff_t off_mv_ptr = 0;
 	bool cantJumpNextTime = false;
 	bool insideCheckJumpButton = false;
 
@@ -30,9 +30,13 @@ private:
 	DECL_HOOK_THISCALL(bool, CheckJumpButton);
 	DECL_HOOK_THISCALL(bool, CheckJumpButton_client);
 	DECL_HOOK_THISCALL(void, FinishGravity);
+	DECL_HOOK_THISCALL(void, CPortalGameMovement__AirMove);
+	DECL_MEMBER_THISCALL(void, CGameMovement__AirMove);
 
 	bool client_cantJumpNextTime = false;
 	bool client_insideCheckJumpButton = false;
+
+	PlayerField<bool> m_bDucked;
 };
 
 extern AutojumpFeature spt_autojump;

--- a/spt/features/autojump.hpp
+++ b/spt/features/autojump.hpp
@@ -1,17 +1,12 @@
 #pragma once
 
 #include "..\feature.hpp"
-#include "thirdparty\Signal.h"
 
 #if defined(OE)
 #include "vector.h"
 #else
 #include "mathlib\vector.h"
 #endif
-
-typedef bool(__fastcall* _CheckJumpButton)(void* thisptr, int edx);
-typedef bool(__fastcall* _CheckJumpButton_client)(void* thisptr, int edx);
-typedef void(__fastcall* _FinishGravity)(void* thisptr, int edx);
 
 // y_spt_autojump
 class AutojumpFeature : public FeatureWrapper<AutojumpFeature>
@@ -32,15 +27,9 @@ protected:
 	virtual void UnloadFeature() override;
 
 private:
-	static bool __fastcall HOOKED_CheckJumpButton(void* thisptr, int edx);
-	static bool __fastcall HOOKED_CheckJumpButton_client(void* thisptr, int edx);
-	static void __fastcall HOOKED_FinishGravity(void* thisptr, int edx);
-
-	_CheckJumpButton ORIG_CheckJumpButton = nullptr;
-	_CheckJumpButton_client ORIG_CheckJumpButton_client = nullptr;
-	_FinishGravity ORIG_FinishGravity = nullptr;
-	ptrdiff_t off1M_bDucked = 0;
-	ptrdiff_t off2M_bDucked = 0;
+	DECL_HOOK_THISCALL(bool, CheckJumpButton);
+	DECL_HOOK_THISCALL(bool, CheckJumpButton_client);
+	DECL_HOOK_THISCALL(void, FinishGravity);
 
 	bool client_cantJumpNextTime = false;
 	bool client_insideCheckJumpButton = false;


### PR DESCRIPTION
- Fix y_spt_additional_jumpboost using 2838's implementation.
- Add FCVAR_DEMO flag to y_spt_autojump.
- Change the incorrect pattern label in FinishGravity.
- Add y_spt_aircontrol for Portal.