### PR TITLE
Portal 3420 TAS support and more patterns

### DIFF
--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -89,7 +89,11 @@ namespace patterns
 	    "missinginfo1_4_7",
 	    "55 8B EC 83 EC 0C 89 4D F8 8B 45 F8 8B 48 08 D9 05 ?? ?? ?? ?? D9 81 ?? ?? ?? ?? DA E9 DF E0 F6 C4 44",
 	    "missinginfo1_6",
-	    "8B 51 04 D9 82 ?? ?? ?? ?? D9 EE D9 C0 DD EA DF E0 DD D9 F6 C4 44 7A 3F D9 82 ?? ?? ?? ?? DA E9");
+	    "8B 51 04 D9 82 ?? ?? ?? ?? D9 EE D9 C0 DD EA DF E0 DD D9 F6 C4 44 7A 3F D9 82 ?? ?? ?? ?? DA E9",
+	    "1910503",
+	    "55 8B EC 51 0F 57 C9 57 8B F9 8B 4F ?? F3 0F 10 81 ?? ?? ?? ?? 0F 2E C1 9F",
+	    "7197370",
+	    "55 8B EC 51 F3 0F 10 0D ?? ?? ?? ?? 57 8B F9 8B 57 ?? F3 0F 10 82 ?? ?? ?? ?? 0F 2E C1 9F");
 	PATTERNS(
 	    CheckJumpButton_client,
 	    "5135",
@@ -236,6 +240,13 @@ void AutojumpFeature::LoadFeature()
 			off_mv_ptr = 2;
 			break;
 		}
+		if (off_mv_ptr == 1)
+			off_player_ptr = 2;
+		else if (off_mv_ptr == 2)
+			off_player_ptr = 1;
+		else
+			// not sure about dmomm
+			off_player_ptr = 0;
 	}
 	else
 	{

--- a/spt/features/autojump.hpp
+++ b/spt/features/autojump.hpp
@@ -14,6 +14,7 @@ class AutojumpFeature : public FeatureWrapper<AutojumpFeature>
 {
 public:
 	ptrdiff_t off_mv_ptr = 0;
+	ptrdiff_t off_player_ptr = 0;
 	bool cantJumpNextTime = false;
 	bool insideCheckJumpButton = false;
 

--- a/spt/features/generic.cpp
+++ b/spt/features/generic.cpp
@@ -97,7 +97,9 @@ namespace patterns
 	         "5135",
 	         "56 8B F1 80 BE ?? ?? ?? ?? 00 57 8B 7C 24 ?? 75 ??",
 	         "hls-220622",
-	         "55 8B EC 56 8B F1 57 8B 7D ?? 80 BE ?? ?? ?? ?? 00");
+	         "55 8B EC 56 8B F1 57 8B 7D ?? 80 BE ?? ?? ?? ?? 00",
+	         "3420",
+	         "81 EC 54 05 00 00 53 55 8B E9 80 7D ?? 00 BB 01 00 00 00");
 	PATTERNS(
 	    CHudDamageIndicator__GetDamagePosition,
 	    "5135",

--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -26,7 +26,7 @@ namespace patterns
 	PATTERNS(CGameMovement__TracePlayerBBox, "5135", "55 8B EC 83 E4 F0 83 EC 5C 56 8B F1 8B 06 8B 50 24");
 	PATTERNS(CPortalGameMovement__TracePlayerBBox,
 	         "5135",
-	         "55 8B EC 83 E4 F0 81 EC C4 00 00 00 53 56 8B F1 8B 46 08 83 C0 04 8B 00");
+	         "55 8B EC 83 E4 F0 81 EC C4 00 00 00 53 56 8B F1 8B 46 ?? 83 C0 04 8B 00 83 F8 FF 57");
 	PATTERNS(TracePlayerBBoxForGround,
 	         "5135",
 	         "55 8B EC 83 E4 F0 81 EC 84 00 00 00 53 56 8B 75 24 8B 46 0C D9 46 2C 8B 4E 10");

--- a/spt/features/vag.cpp
+++ b/spt/features/vag.cpp
@@ -49,7 +49,9 @@ bool VAG::ShouldLoadFeature()
 namespace patterns
 {
 	PATTERNS(MiddleOfTeleportTouchingEntity, "5135", "8B 80 24 27 00 00 8B CD 8B A9 24 27 00 00 89 44 24 3C");
-	PATTERNS(EndOfTeleportTouchingEntity, "5135", "E8 E3 CC DB FF 8D 8C 24 B8 00 00 00 E8 17 45 F5 FF");
+	PATTERNS(EndOfTeleportTouchingEntity,
+	         "5135",
+	         "E8 ?? ?? ?? ?? 8D 8C 24 ?? ?? ?? ?? E8 ?? ?? ?? ?? 8D 84 24 ?? ?? ?? ??");
 } // namespace patterns
 
 void VAG::InitHooks()

--- a/spt/strafe/strafestuff.cpp
+++ b/spt/strafe/strafestuff.cpp
@@ -20,6 +20,7 @@
 #include "property_getter.hpp"
 #include "..\features\playerio.hpp"
 #include "..\features\tracing.hpp"
+#include "..\features\autojump.hpp"
 #include "SDK\hl_movedata.h"
 #include "interfaces.hpp"
 
@@ -63,8 +64,8 @@ namespace Strafe
 	void SetMoveData()
 	{
 		data.m_nPlayerHandle = utils::GetServerPlayer()->GetRefEHandle();
-		void** player = reinterpret_cast<void**>((char*)interfaces::gm + 0x4);
-		CMoveData** mv = reinterpret_cast<CMoveData**>((char*)interfaces::gm + 0x8);
+		void** player = reinterpret_cast<void**>((uintptr_t*)interfaces::gm + spt_autojump.off_player_ptr);
+		CMoveData** mv = reinterpret_cast<CMoveData**>((uintptr_t*)interfaces::gm + spt_autojump.off_mv_ptr);
 		oldmv = *mv;
 		oldPlayer = *player;
 		*mv = &data;
@@ -73,8 +74,8 @@ namespace Strafe
 
 	void UnsetMoveData()
 	{
-		void** player = reinterpret_cast<void**>((char*)interfaces::gm + 0x4);
-		CMoveData** mv = reinterpret_cast<CMoveData**>((char*)interfaces::gm + 0x8);
+		void** player = reinterpret_cast<void**>((uintptr_t*)interfaces::gm + spt_autojump.off_player_ptr);
+		CMoveData** mv = reinterpret_cast<CMoveData**>((uintptr_t*)interfaces::gm + spt_autojump.off_mv_ptr);
 		*player = oldPlayer;
 		*mv = oldmv;
 	}


### PR DESCRIPTION
- 1910503 and 7197370 patterns for FinishGravity. (Now y_spt_jumpboost works on steampipe versions)
- ControllerMove patterns for 3420
- Use CheckJumpButton offsets in autojump for mv and player offsets in [strafestuff.cpp](https://github.com/YaLTeR/SourcePauseTool/compare/master...evanlin96069:3420?expand=1#diff-68301b67bcc384cdc01bcfdc24f1334446f221634143771bdc978fe0f85b9865) because different version can have different offsets
- Changed CPortalGameMovement__TracePlayerBBox patterns so it can also use in 3420
- Changed EndOfTeleportTouchingEntity patterns so it can also use in 3420