### PR TITLE
Added y_spt_dev_cvars

### DIFF
--- a/spt/utils/command.cpp
+++ b/spt/utils/command.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+#ifndef SSDK2013
+
 #include "command.hpp"
 #include "file.hpp"
 #include <filesystem>
@@ -82,3 +84,5 @@ int AutoCompletList::AutoCompletionFileFunc(const char* partial,
 	}
 	return AutoCompletionFunc(partial, commands);
 }
+
+#endif

--- a/spt/utils/command.hpp
+++ b/spt/utils/command.hpp
@@ -1,5 +1,14 @@
 #pragma once
 
+#ifdef SSDK2013
+// autocomplete crashes on stemapipe :((
+#define CON_COMMAND_AUTOCOMPLETEFILE(name, description, flags, subdirectory, extension) \
+	CON_COMMAND_F(name, description, flags)
+
+#define CON_COMMAND_AUTOCOMPLETE(name, description, flags, completion) CON_COMMAND_F(name, description, flags)
+
+#else
+
 #include "convar.h"
 
 class AutoCompletList
@@ -55,15 +64,9 @@ private:
 		return command##Complete.AutoCompletionFileFunc(partial, commands); \
 	}
 
-#ifdef SSDK2013
-// autocomplete crashes on stemapipe :((
-#define CON_COMMAND_AUTOCOMPLETEFILE(name, description, flags, subdirectory, extension) \
-	CON_COMMAND_F(name, description, flags)
-#else
 #define CON_COMMAND_AUTOCOMPLETEFILE(name, description, flags, subdirectory, extension) \
 	DECLARE_AUTOCOMPLETIONFILE_FUNCTION(name, subdirectory, extension) \
 	CON_COMMAND_F_COMPLETION(name, description, flags, AUTOCOMPLETION_FUNCTION(name))
-#endif
 
 #define DECLARE_AUTOCOMPLETION_FUNCTION(command, completion) \
 	AutoCompletList command##Complete(#command, std::vector<std::string> completion); \
@@ -76,3 +79,5 @@ private:
 #define CON_COMMAND_AUTOCOMPLETE(name, description, flags, completion) \
 	DECLARE_AUTOCOMPLETION_FUNCTION(name, completion) \
 	CON_COMMAND_F_COMPLETION(name, description, flags, AUTOCOMPLETION_FUNCTION(name))
+
+#endif


### PR DESCRIPTION
- `y_spt_dev_cvars` Prints all developer/hidden CVars.
- Added autocomplete for `y_spt_cvar` and `y_spt_cvar2`