### PR TITLE
Fixed 3420 tas_pause crash and override fov.

### DIFF
--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -35,7 +35,6 @@ extern ConVar y_spt_vag_trace_portal;
 extern ConVar y_spt_cam_control;
 extern ConVar y_spt_cam_drive;
 extern ConVar y_spt_cam_path_draw;
-extern ConVar y_spt_cam_fov;
 
 extern ConVar tas_strafe;
 extern ConVar tas_strafe_type;

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#ifndef OE
 #include "camera.hpp"
 #include "playerio.hpp"
 #include "interfaces.hpp"
@@ -7,11 +8,7 @@
 #include "..\sptlib-wrapper.hpp"
 #include "..\cvars.hpp"
 
-#ifdef OE
-#include "..\game_shared\usercmd.h"
-#else
 #include "usercmd.h"
-#endif
 
 #include <chrono>
 
@@ -33,7 +30,8 @@ ConVar y_spt_cam_control(
     "    See commands y_spt_cam_path_");
 ConVar y_spt_cam_drive("y_spt_cam_drive", "1", FCVAR_CHEAT, "Enables or disables camera drive mode in-game.");
 ConVar y_spt_cam_path_draw("y_spt_cam_path_draw", "0", FCVAR_CHEAT, "Draws the current camera path.");
-ConVar y_spt_cam_fov("y_spt_cam_fov", "0", 0, "Override camera FOV (won't record in demos).");
+
+ConVar _y_spt_force_fov("_y_spt_force_fov", "0", 0, "Force FOV to some value.");
 
 CON_COMMAND(y_spt_cam_setpos, "y_spt_cam_setpos <x> <y> <z> - Sets the camera position. (requires camera drive mode)")
 {
@@ -283,8 +281,8 @@ void Camera::RefreshTimeOffset()
 void Camera::OverrideView(CViewSetup* view)
 {
 	int control_type = CanOverrideView() ? y_spt_cam_control.GetInt() : 0;
-	if (y_spt_cam_fov.GetBool())
-		current_cam.fov = y_spt_cam_fov.GetFloat();
+	if (_y_spt_force_fov.GetBool())
+		current_cam.fov = _y_spt_force_fov.GetFloat();
 	else
 		current_cam.fov = view->fov;
 	HandleDriveMode(control_type == 1);
@@ -319,14 +317,12 @@ void Camera::HandleDriveMode(bool active)
 
 static bool isBindDown(const char* bind)
 {
-#ifndef OE
 	const char* key = interfaces::engine_client->Key_LookupBinding(bind);
 	if (key)
 	{
 		ButtonCode_t code = interfaces::inputSystem->StringToButtonCode(key);
 		return interfaces::inputSystem->IsButtonDown(code);
 	}
-#endif
 	return false;
 }
 
@@ -726,7 +722,7 @@ void Camera::LoadFeature()
 	{
 		InitConcommandBase(y_spt_cam_control);
 		InitConcommandBase(y_spt_cam_drive);
-		InitConcommandBase(y_spt_cam_fov);
+		InitConcommandBase(_y_spt_force_fov);
 		InitCommand(y_spt_cam_setpos);
 		InitCommand(y_spt_cam_setang);
 
@@ -751,3 +747,5 @@ void Camera::LoadFeature()
 }
 
 void Camera::UnloadFeature() {}
+
+#endif

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -33,7 +33,7 @@ ConVar y_spt_cam_control(
     "    See commands y_spt_cam_path_");
 ConVar y_spt_cam_drive("y_spt_cam_drive", "1", FCVAR_CHEAT, "Enables or disables camera drive mode in-game.");
 ConVar y_spt_cam_path_draw("y_spt_cam_path_draw", "0", FCVAR_CHEAT, "Draws the current camera path.");
-ConVar y_spt_cam_fov("y_spt_cam_fov", "0", 0, "Sets the camera drive mode FOV.");
+ConVar y_spt_cam_fov("y_spt_cam_fov", "0", 0, "Override camera FOV (won't record in demos).");
 
 CON_COMMAND(y_spt_cam_setpos, "y_spt_cam_setpos <x> <y> <z> - Sets the camera position. (requires camera drive mode)")
 {
@@ -293,8 +293,8 @@ void Camera::OverrideView(CViewSetup* view)
 	{
 		view->origin = current_cam.origin;
 		view->angles = current_cam.angles;
-		view->fov = current_cam.fov;
 	}
+	view->fov = current_cam.fov;
 }
 
 void Camera::HandleDriveMode(bool active)

--- a/spt/features/camera.hpp
+++ b/spt/features/camera.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "..\feature.hpp"
 #include "view_shared.h"
 #include "demo.hpp"

--- a/spt/features/taspause.cpp
+++ b/spt/features/taspause.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "..\feature.hpp"
 #include "convar.hpp"
+#include "..\utils\game_detection.hpp"
 
 typedef void(__cdecl* _Host_AccumulateTime)(float dt);
 ConVar tas_pause("tas_pause", "0", 0, "Does a pause where you can look around when the game is paused.\n");
@@ -53,7 +54,8 @@ void TASPause::LoadFeature()
 {
 	if (ORIG__Host_RunFrame)
 	{
-		pHost_Frametime = *reinterpret_cast<float**>((uintptr_t)ORIG__Host_RunFrame + 227);
+		ptrdiff_t off_pHost_Frametime = (utils::GetBuildNumber() <= 3420) ? 309 : 227;
+		pHost_Frametime = *reinterpret_cast<float**>((uintptr_t)ORIG__Host_RunFrame + off_pHost_Frametime);
 	}
 	else
 	{


### PR DESCRIPTION
- Fixed 3420 tas_pause crash by adding pHost_Frametime offset for 3420.
- `y_spt_cam_fov` now overrides all camera FOV, but won't record the FOV in demos. (For TASing/segmenting in 3420 with FOV 90 but still recording FOV 75 demos)