### PR TITLE
Fixed crash in SDK2013 modifications

### DIFF
--- a/spt/features/demo.cpp
+++ b/spt/features/demo.cpp
@@ -138,7 +138,7 @@ void DemoStuff::PreHook()
 		else if (index == 2)
 		{
 			// new steampipe hl2
-			if (utils::GetBuildNumber() >= 7196940 || utils::GetBuildNumber() == 0)
+			if (utils::GetBuildNumber() >= 2229355 || utils::GetBuildNumber() == 0)
 			{
 				// 7197370 offset
 				pDemoplayer = *reinterpret_cast<void***>(ORIG_Record + 0x9C);

--- a/spt/features/demo.cpp
+++ b/spt/features/demo.cpp
@@ -138,7 +138,7 @@ void DemoStuff::PreHook()
 		else if (index == 2)
 		{
 			// new steampipe hl2
-			if (utils::GetBuildNumber() >= 7196940)
+			if (utils::GetBuildNumber() >= 7196940 || utils::GetBuildNumber() == 0)
 			{
 				// 7197370 offset
 				pDemoplayer = *reinterpret_cast<void***>(ORIG_Record + 0x9C);


### PR DESCRIPTION
Valve somehow fucked up a build system at SDK2013 Base, so if u launch some modification, it outputs `0` as build number.

At first I thought it was issue at my side, but it's not, I asked a few other runners and they have a same build output, so I have to do this hack to avoid crash:

![0](https://user-images.githubusercontent.com/58108407/189525690-cbd8563e-f840-42f5-abda-790451e90c36.PNG)

