### PR TITLE
Changed language standard to C++20

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ A plugin for all your pausing needs.
     * *Loading SourcePauseTool more than once will crash the game!*
 
 ### Building
-0. You will need [Visual Studio 2019](https://visualstudio.microsoft.com/vs/older-downloads/) and [git](https://git-scm.com).
+0. You will need [Visual Studio 2019](https://visualstudio.microsoft.com/free-developer-offers/) (or later) and [git](https://git-scm.com).
 1. Open Visual Studio 2019. Click on Tools → Get Tools and Features... from the top bar of the window.
 <br>This should open the Visual Studio Installer in another window. From the Workload tab, install `Desktop development with C++`. From the Individual Components tab, install:
-    * MSVC v141 - VS 2017 C++ x64/x86 build tools
-    * C++ Windows XP Support for VS 2017 (v141) tools
+    * MSVC v142 - VS 2019 C++ x64/x86 build tools
 2. Run the following in cmd:
     ```
     git clone --recurse-submodules https://github.com/YaLTeR/SourcePauseTool.git

--- a/spt.sln
+++ b/spt.sln
@@ -8,7 +8,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SPT", "spt.vcxproj", "{B657
 		{F142A341-5EE0-442D-A15F-98AE9B48DBAE} = {F142A341-5EE0-442D-A15F-98AE9B48DBAE}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libMinHook", "SPTLib\Windows\minhook\build\VC15\libMinHook.vcxproj", "{F142A341-5EE0-442D-A15F-98AE9B48DBAE}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libMinHook", "SPTLib\Windows\minhook\build\VC16\libMinHook.vcxproj", "{F142A341-5EE0-442D-A15F-98AE9B48DBAE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -37,24 +37,24 @@
   <PropertyGroup Label="Globals">
     <ProjectName>SPT</ProjectName>
     <ProjectGuid>{B6572CBE-7C7F-4FFF-94DE-AFBBBAB11C64}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -65,28 +65,28 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -240,9 +240,10 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
       <ErrorReporting>Prompt</ErrorReporting>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -309,9 +310,10 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
       <ErrorReporting>Prompt</ErrorReporting>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -379,9 +381,10 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
       <ErrorReporting>Prompt</ErrorReporting>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -449,9 +452,10 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
       <ErrorReporting>Prompt</ErrorReporting>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -522,9 +526,10 @@
       <ErrorReporting>Prompt</ErrorReporting>
       <PreprocessToFile>false</PreprocessToFile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -599,9 +604,10 @@
       <ErrorReporting>Prompt</ErrorReporting>
       <PreprocessToFile>false</PreprocessToFile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -677,9 +683,10 @@
       <ErrorReporting>Prompt</ErrorReporting>
       <PreprocessToFile>false</PreprocessToFile>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -833,10 +840,11 @@
       <CompileAs>CompileAsCpp</CompileAs>
       <ErrorReporting>Prompt</ErrorReporting>
       <PreprocessToFile>false</PreprocessToFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -1418,6 +1426,7 @@
     <ClInclude Include="spt\utils\property_getter.hpp" />
     <ClInclude Include="spt\utils\signals.hpp" />
     <ClInclude Include="spt\utils\string_utils.hpp" />
+    <ClInclude Include="spt\utils\typeinfo.h" />
     <ClInclude Include="spt\vgui\vgui_utils.hpp" />
     <ClInclude Include="thirdparty\Delegate.h" />
     <ClInclude Include="thirdparty\json.hpp" />
@@ -1426,7 +1435,7 @@
     <ClInclude Include="thirdparty\Signal.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="SPTLib\Windows\minhook\build\VC15\libMinHook.vcxproj">
+    <ProjectReference Include="SPTLib\Windows\minhook\build\VC16\libMinHook.vcxproj">
       <Project>{f142a341-5ee0-442d-a15f-98ae9b48dbae}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -600,6 +600,9 @@
     <ClInclude Include="spt\features\restart.hpp">
       <Filter>spt\features</Filter>
     </ClInclude>
+    <ClInclude Include="spt\utils\typeinfo.h">
+      <Filter>spt\utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Library Include="..\..\lib\public\mathlib.lib">

--- a/spt/features/aim.hpp
+++ b/spt/features/aim.hpp
@@ -4,10 +4,11 @@
 #include "..\aim\aimstuff.hpp"
 #include "..\strafe\strafestuff.hpp"
 
-typedef struct
+typedef struct _angset_command
 {
-	float angle = 0.0f;
-	bool set = false;
+	float angle;
+	bool set;
+	_angset_command() : angle(0.0f), set(false) {}
 } angset_command_t;
 
 class AimFeature : public FeatureWrapper<AimFeature>

--- a/spt/features/hops_hud.cpp
+++ b/spt/features/hops_hud.cpp
@@ -402,7 +402,7 @@ public:
 	void DrawHopHud();
 	bool ShouldDraw();
 	void PrintStrafeCol(std::function<void(const ljstats::SegmentStats&, wchar_t* buffer, int x, int y)>,
-	                    wchar_t* fieldName,
+	                    const wchar_t* fieldName,
 	                    int x,
 	                    int y,
 	                    int MARGIN);
@@ -440,7 +440,7 @@ bool HopsHud::ShouldDraw()
 }
 
 void HopsHud::PrintStrafeCol(std::function<void(const ljstats::SegmentStats&, wchar_t*, int, int)> func,
-                             wchar_t* fieldName,
+                             const wchar_t* fieldName,
                              int x,
                              int y,
                              int MARGIN)

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -552,7 +552,7 @@ void InputHud::DrawInputHud()
 			int th = surface->GetFontTall(anglesSettingFont);
 			surface->DrawSetTextFont(anglesSettingFont);
 			surface->DrawSetTextColor(anglesSetting.textcolor);
-			wchar_t* text = L"move analog";
+			const wchar_t* text = L"move analog";
 			surface->DrawSetTextPos(cX1 - r, cY1 - r - th);
 			surface->DrawPrintText(text, wcslen(text));
 			text = L"view analog";

--- a/spt/features/overlays/draw_seams.cpp
+++ b/spt/features/overlays/draw_seams.cpp
@@ -180,8 +180,9 @@ void DrawSeamsFeature::OnOverlaySignal(OverlayRenderer& ovr)
 	Vector test1Target = edgeTr.endpos + tr.plane.normal * distanceToSeam;
 	Vector test2Target = edgeTr.endpos + edgeTr.plane.normal * distanceToSeam;
 
-	bool test1 = TestSeamshot(test1Start, test1Target, tr.plane, edgeTr.plane, QAngle());
-	bool test2 = TestSeamshot(test2Start, test2Target, tr.plane, edgeTr.plane, QAngle());
+	QAngle t1Angle, t2Angle;
+	bool test1 = TestSeamshot(test1Start, test1Target, tr.plane, edgeTr.plane, t1Angle);
+	bool test2 = TestSeamshot(test2Start, test2Target, tr.plane, edgeTr.plane, t2Angle);
 	bool seamshot = test1 || test2;
 
 	const int uiScale = 10;

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -538,7 +538,7 @@ CON_COMMAND(y_spt_find_portals, "Prints info for all portals")
 			bool activated = utils::GetProperty<bool>(i, "m_bActivated");
 			bool closed = (remoteIdx & INDEX_MASK) == INDEX_MASK;
 			auto openStr = closed ? (activated ? "a closed" : "an invisible") : "an open";
-			auto& origin = utils::GetPortalPosition(ent);
+			const auto& origin = utils::GetPortalPosition(ent);
 
 			Msg("SPT: There's %s %s portal with index %d at %.8f %.8f %.8f.\n",
 			    openStr,

--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -226,8 +226,8 @@ CON_COMMAND(
 		return;
 	}
 
-	Vector a_normal;
-	const auto distance = std::max(trace_fire_portal(a, a_normal), trace_fire_portal(b, Vector()));
+	Vector a_normal, b_normal;
+	const auto distance = std::max(trace_fire_portal(a, a_normal), trace_fire_portal(b,b_normal));
 
 	// If our trace had a distance greater than the a or b distance by this amount, treat it as a seam shot.
 	constexpr double GOOD_DISTANCE_DIFFERENCE = 50.0 * 50.0;

--- a/spt/overlay/portal_camera.cpp
+++ b/spt/overlay/portal_camera.cpp
@@ -74,11 +74,8 @@ bool getPortal(IClientEntity** portal_edict, Vector& new_player_origin, QAngle& 
 
 	if (!portal)
 	{
-		auto& player_origin = utils::GetPlayerEyePosition();
-		auto& player_angles = utils::GetPlayerEyeAngles();
-
-		new_player_origin = player_origin;
-		new_player_angles = player_angles;
+		new_player_origin = utils::GetPlayerEyePosition();
+		new_player_angles = utils::GetPlayerEyeAngles();
 
 		return false;
 	}
@@ -111,8 +108,8 @@ void calculateSGPosition(Vector& new_player_origin, QAngle& new_player_angles)
 
 bool isInfrontOfPortal(IClientEntity* saveglitch_portal, const Vector& player_origin)
 {
-	auto& portal_origin = utils::GetPortalPosition(saveglitch_portal);
-	auto& portal_angles = utils::GetPortalAngles(saveglitch_portal);
+	const auto& portal_origin = utils::GetPortalPosition(saveglitch_portal);
+	const auto& portal_angles = utils::GetPortalAngles(saveglitch_portal);
 
 	Vector delta = player_origin - portal_origin;
 	Vector normal;
@@ -129,7 +126,7 @@ std::wstring calculateWillAGSG(Vector& new_player_origin, QAngle& new_player_ang
 		return L"no portal selected";
 
 	Vector enter_origin = utils::GetPortalPosition(enter_portal);
-	auto& enter_angles = utils::GetPortalAngles(enter_portal);
+	const auto& enter_angles = utils::GetPortalAngles(enter_portal);
 	Vector enterForward;
 	AngleVectors(enter_angles, &enterForward);
 
@@ -137,7 +134,8 @@ std::wstring calculateWillAGSG(Vector& new_player_origin, QAngle& new_player_ang
 		return L"no, bad entry portal";
 
 	Vector pos;
-	calculateAGPosition(pos, QAngle());
+	QAngle qa;
+	calculateAGPosition(pos, qa);
 
 	if (enterForward.Dot(pos - enter_origin) >= 0)
 		return L"no, tp position in front";
@@ -150,10 +148,10 @@ void calculateAGOffsetPortal(IClientEntity* enter_portal,
                              Vector& new_player_origin,
                              QAngle& new_player_angles)
 {
-	auto& enter_origin = utils::GetPortalPosition(enter_portal);
-	auto& enter_angles = utils::GetPortalAngles(enter_portal);
-	auto& exit_origin = utils::GetPortalPosition(exit_portal);
-	auto& exit_angles = utils::GetPortalAngles(exit_portal);
+	const auto& enter_origin = utils::GetPortalPosition(enter_portal);
+	const auto& enter_angles = utils::GetPortalAngles(enter_portal);
+	const auto& exit_origin = utils::GetPortalPosition(exit_portal);
+	const auto& exit_angles = utils::GetPortalAngles(exit_portal);
 
 	Vector exitForward, exitRight, exitUp;
 	Vector enterForward, enterRight, enterUp;
@@ -179,8 +177,8 @@ void calculateAGOffsetPortal(IClientEntity* enter_portal,
 
 void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_origin, QAngle& new_player_angles)
 {
-	auto& player_origin = utils::GetPlayerEyePosition();
-	auto& player_angles = utils::GetPlayerEyeAngles();
+	const auto& player_origin = utils::GetPlayerEyePosition();
+	const auto& player_angles = utils::GetPlayerEyeAngles();
 	VMatrix matrix;
 	matrix.Identity();
 
@@ -264,7 +262,7 @@ IClientEntity* getPortal(const char* arg, bool verbose)
 			for (auto i : indices)
 			{
 				auto ent = utils::GetClientEntity(i);
-				auto& origin = utils::GetPortalPosition(ent);
+				const auto& origin = utils::GetPortalPosition(ent);
 
 				if (verbose)
 					Msg("%d located at %.8f %.8f %.8f\n", i, origin.x, origin.y, origin.z);

--- a/spt/scripts/range_variable.hpp
+++ b/spt/scripts/range_variable.hpp
@@ -200,6 +200,7 @@ namespace scripts
 		return value;
 	}
 
+	template<> 
 	inline float RangeVariable<float>::Normalize(float value)
 	{
 		if (isAngle)

--- a/spt/scripts/tester.cpp
+++ b/spt/scripts/tester.cpp
@@ -235,7 +235,7 @@ namespace scripts
 		for (auto& entry : std::filesystem::recursive_directory_iterator(folder))
 		{
 			auto& path = entry.path();
-			auto& str = path.string().substr(GetGameDir().length() + 1);
+			auto str = path.string().substr(GetGameDir().length() + 1);
 			int extPos = str.find(SCRIPT_EXT);
 
 			if (extPos != -1)

--- a/spt/scripts2/range_variable2.hpp
+++ b/spt/scripts2/range_variable2.hpp
@@ -200,6 +200,7 @@ namespace scripts2
 		return value;
 	}
 
+	template<>
 	inline float RangeVariable<float>::Normalize(float value)
 	{
 		if (isAngle)

--- a/spt/scripts2/tester2.cpp
+++ b/spt/scripts2/tester2.cpp
@@ -235,7 +235,7 @@ namespace scripts2
 		for (auto& entry : std::filesystem::recursive_directory_iterator(folder))
 		{
 			auto& path = entry.path();
-			auto& str = path.string().substr(GetGameDir().length() + 1);
+			auto str = path.string().substr(GetGameDir().length() + 1);
 			int extPos = str.find(SCRIPT_EXT);
 
 			if (extPos != -1)

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -344,7 +344,7 @@ namespace utils
 			else // error occurred
 			{
 				i = argSize;
-				arr = L"error occurred in parsing";
+				arr = (wchar_t*)L"error occurred in parsing";
 				entries = 1;
 				break;
 			}

--- a/spt/utils/ent_utils.hpp
+++ b/spt/utils/ent_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "cdll_int.h"
 #include "client_class.h"
 #include "engine\ivmodelinfo.h"

--- a/spt/utils/game_detection.cpp
+++ b/spt/utils/game_detection.cpp
@@ -108,7 +108,7 @@ namespace utils
 		DevMsg("Found date string: %s\n", wholeString);
 		const char* date_str = wholeString + 20;
 
-		char* months[] = {
+		const char* months[] = {
 		    "Jan",
 		    "Feb",
 		    "Mar",
@@ -193,9 +193,9 @@ namespace utils
 			                                &moduleSize))
 			    {
 				    moduleEnd = moduleStart + moduleSize;
-				    char* BUILD_STRING = "Exe build:";
-				    uint8_t* beginNeedle = reinterpret_cast<uint8_t*>(BUILD_STRING);
-				    uint8_t* endNeedle = beginNeedle + strlen(BUILD_STRING);
+				    const char* BUILD_STRING = "Exe build:";
+				    const uint8_t* beginNeedle = reinterpret_cast<const uint8_t*>(BUILD_STRING);
+				    const uint8_t* endNeedle = beginNeedle + strlen(BUILD_STRING);
 
 				    int match = kmp::match_first(beginNeedle, endNeedle, moduleStart, moduleEnd);
 

--- a/spt/utils/string_utils.hpp
+++ b/spt/utils/string_utils.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 #include <wchar.h>
 #include <tier0\wchartypes.h>
 
@@ -25,19 +26,40 @@ inline void GetDoublet(std::istringstream& stream, std::string& out1, std::strin
 }
 
 template<typename T1, typename T2>
-inline void GetDoublet(const std::string& s, T1& out1, T2& out2, char delim)
-{
-	std::istringstream is(s);
-	GetDoublet(is, out1, out2, delim);
-}
-
-template<typename T1, typename T2>
 inline void GetDoublet(std::istringstream& stream, T1& out1, T2& out2, char delim)
 {
 	std::string s1, s2;
 	GetDoublet(stream, s1, s2, delim);
 	out1 = ParseValue<T1>(s1);
 	out2 = ParseValue<T2>(s2);
+}
+
+template<typename T1, typename T2>
+inline void GetDoublet(const std::string& s, T1& out1, T2& out2, char delim)
+{
+	std::istringstream is(s);
+	GetDoublet(is, out1, out2, delim);
+}
+
+inline void GetTriplet(std::istringstream& stream, std::string& out1, std::string& out2, std::string& out3, char delim)
+{
+	std::getline(stream, out1, delim);
+	if (!stream.good())
+		throw std::exception("Unable to read triplet!");
+	std::getline(stream, out2, delim);
+	if (!stream.good())
+		throw std::exception("Unable to read triplet!");
+	std::getline(stream, out3);
+}
+
+template<typename T1, typename T2, typename T3>
+inline void GetTriplet(std::istringstream& stream, T1& out1, T2& out2, T3& out3, char delim)
+{
+	std::string s1, s2, s3;
+	GetTriplet(stream, s1, s2, s3, delim);
+	out1 = ParseValue<T1>(s1);
+	out2 = ParseValue<T2>(s2);
+	out3 = ParseValue<T3>(s3);
 }
 
 template<typename T1, typename T2, typename T3>
@@ -51,16 +73,6 @@ inline void GetStringTriplet(const std::string& s, std::string& out1, std::strin
 {
 	std::istringstream is(s);
 	GetTriplet(is, out1, out2, out3, delim);
-}
-
-template<typename T1, typename T2, typename T3>
-inline void GetTriplet(std::istringstream& stream, T1& out1, T2& out2, T3& out3, char delim)
-{
-	std::string s1, s2, s3;
-	GetTriplet(stream, s1, s2, s3, delim);
-	out1 = ParseValue<T1>(s1);
-	out2 = ParseValue<T2>(s2);
-	out3 = ParseValue<T3>(s3);
 }
 
 template<typename T1, typename T2, typename T3, typename T4>
@@ -79,17 +91,6 @@ inline void GetQuadlet(std::istringstream& stream, T1& out1, T2& out2, T3& out3,
 	out2 = ParseValue<T2>(s2);
 	out3 = ParseValue<T3>(s3);
 	out4 = ParseValue<T4>(s4);
-}
-
-inline void GetTriplet(std::istringstream& stream, std::string& out1, std::string& out2, std::string& out3, char delim)
-{
-	std::getline(stream, out1, delim);
-	if (!stream.good())
-		throw std::exception("Unable to read triplet!");
-	std::getline(stream, out2, delim);
-	if (!stream.good())
-		throw std::exception("Unable to read triplet!");
-	std::getline(stream, out3);
 }
 
 inline void GetQuadlet(std::istringstream& stream,

--- a/spt/utils/typeinfo.h
+++ b/spt/utils/typeinfo.h
@@ -1,0 +1,4 @@
+#pragma once
+// MSVC 14.23+ workaround
+// Required in Debug builds only
+#include <typeinfo>


### PR DESCRIPTION
Don't mind the original branch name. Meant to work on something else and ended up doing this
Not really a C++ pro, so maybe some of the changes may not be the most adequate, but a summary of the changes is:

- Changed platform toolset to v142 (VS2019) and language standard to stdcpp20
- Updated README installing instruction pointing to the new platform toolset
- Worked around toolset bug by adding a new header (typeinfo.h)
  - Wasn't sure if it was better to make a new folder for it or just use one of the existing include paths
- Added compiler option to prevent PCH compilation from running out of memory
- Updated SPTlib submodule (perhaps wasn't 100% needed, but figured it was a decent idea) and SDK/episode1 submodule (required)
- Pointed to a different libMinHook vcxproj (so the previously used project could be kept on v141_xp)
- Made many variables const when possible
- Included some headers here and there as part of troubleshooting
  - Seems like some files in the project aren't self sufficient when it comes to which headers they include, but it all happens to work because the required headers are imported externally
- Moved some functions around in string_utils because it seemed like the compiler was choosing the wrong overloads and throwing errors
  - Maybe it would also magically fix itself once other errors in the project were solved but doesn't hurt to keep it as it is I guess
- Other misc/small changes required because of the language standard change