### PR TITLE
Less warnings

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -244,13 +244,14 @@
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -314,13 +315,14 @@
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -385,13 +387,14 @@
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -456,13 +459,14 @@
       <PreprocessToFile>false</PreprocessToFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -530,13 +534,14 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -608,13 +613,14 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -687,13 +693,14 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -845,13 +852,14 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>4471</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;ws2_32.lib;vstdlib.lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/spt/cvars.cpp
+++ b/spt/cvars.cpp
@@ -71,9 +71,9 @@ void Cvar_UnregisterSPTCvars()
 
 	interfaces::g_pCVar->UnlinkVariables(FCVAR_PLUGIN);
 
-	for (ConCommandBase* command : commandsToAdd)
+	for (ConCommandBase* concmd : commandsToAdd)
 	{
-		interfaces::g_pCVar->RegisterConCommandBase(command);
+		interfaces::g_pCVar->RegisterConCommandBase(concmd);
 	}
 
 	cmd_to_feature.clear();

--- a/spt/features/boog.cpp
+++ b/spt/features/boog.cpp
@@ -74,7 +74,7 @@ bool BoogFeature::ShouldDrawBoog()
 void BoogFeature::DrawBoog()
 {
 	auto surface = interfaces::surface;
-	auto view = spt_hud.renderView;
+	auto renderView = spt_hud.renderView;
 
 	if (boogFont == 0)
 	{
@@ -99,12 +99,12 @@ void BoogFeature::DrawBoog()
 	int tall = 0, len = 0;
 	surface->GetTextSize(boogFont, L"boog", len, tall);
 
-	int x = view->width / 2 - len / 2;
-	int y = view->height / 2 + 100;
+	int x = renderView->width / 2 - len / 2;
+	int y = renderView->height / 2 + 100;
 	
-	if (tall + y > view->height)
+	if (tall + y > renderView->height)
 	{
-		y = view->height - tall;
+		y = renderView->height - tall;
 	}
 
 	surface->DrawSetTextPos(x, y);

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -613,7 +613,7 @@ void Camera::DrawPath()
 #define NDEBUG_PERSIST_TILL_NEXT_SERVER 0.01023f
 #endif
 
-	for (int i = 0; i < interp_path_cache.size(); i++)
+	for (size_t i = 0; i < interp_path_cache.size(); i++)
 	{
 		auto current = interp_path_cache[i];
 		Vector forward;

--- a/spt/features/cvar.cpp
+++ b/spt/features/cvar.cpp
@@ -39,8 +39,8 @@ CON_COMMAND_F_COMPLETION(y_spt_cvar, "CVar manipulation.", 0, y_spt_cvar_Complet
 		return;
 	}
 
-	ConVar* cvar = g_pCVar->FindVar(args.Arg(1));
-	if (!cvar)
+	ConVar* cv = g_pCVar->FindVar(args.Arg(1));
+	if (!cv)
 	{
 		Warning("Couldn't find the cvar: %s\n", args.Arg(1));
 		return;
@@ -48,29 +48,29 @@ CON_COMMAND_F_COMPLETION(y_spt_cvar, "CVar manipulation.", 0, y_spt_cvar_Complet
 
 	if (args.ArgC() == 2)
 	{
-		Msg("\"%s\" = \"%s\"\n", cvar->GetName(), cvar->GetString(), cvar->GetHelpText());
-		Msg("Default: %s\n", cvar->GetDefault());
+		Msg("\"%s\" = \"%s\"\n", cv->GetName(), cv->GetString(), cv->GetHelpText());
+		Msg("Default: %s\n", cv->GetDefault());
 
 		float val;
-		if (cvar->GetMin(val))
+		if (cv->GetMin(val))
 		{
 			Msg("Min: %f\n", val);
 		}
 
-		if (cvar->GetMax(val))
+		if (cv->GetMax(val))
 		{
 			Msg("Max: %f\n", val);
 		}
 
-		const char* helpText = cvar->GetHelpText();
+		const char* helpText = cv->GetHelpText();
 		if (helpText[0] != '\0')
-			Msg("- %s\n", cvar->GetHelpText());
+			Msg("- %s\n", cv->GetHelpText());
 
 		return;
 	}
 
 	const char* value = args.Arg(2);
-	cvar->SetValue(value);
+	cv->SetValue(value);
 }
 
 CON_COMMAND(y_spt_cvar_random, "Randomize CVar value.")
@@ -84,8 +84,8 @@ CON_COMMAND(y_spt_cvar_random, "Randomize CVar value.")
 		return;
 	}
 
-	ConVar* cvar = g_pCVar->FindVar(args.Arg(1));
-	if (!cvar)
+	ConVar* cv = g_pCVar->FindVar(args.Arg(1));
+	if (!cv)
 	{
 		Warning("Couldn't find the cvar: %s\n", args.Arg(1));
 		return;
@@ -95,7 +95,7 @@ CON_COMMAND(y_spt_cvar_random, "Randomize CVar value.")
 	float max = std::stof(args.Arg(3));
 
 	float r = utils::RandomFloat(min, max);
-	cvar->SetValue(r);
+	cv->SetValue(r);
 }
 
 #if !defined(OE)
@@ -124,8 +124,8 @@ CON_COMMAND_F_COMPLETION(y_spt_cvar2,
 		return;
 	}
 
-	ConVar* cvar = g_pCVar->FindVar(args.Arg(1));
-	if (!cvar)
+	ConVar* cv = g_pCVar->FindVar(args.Arg(1));
+	if (!cv)
 	{
 		Warning("Couldn't find the cvar: %s\n", args.Arg(1));
 		return;
@@ -133,29 +133,29 @@ CON_COMMAND_F_COMPLETION(y_spt_cvar2,
 
 	if (args.ArgC() == 2)
 	{
-		Msg("\"%s\" = \"%s\"\n", cvar->GetName(), cvar->GetString(), cvar->GetHelpText());
-		Msg("Default: %s\n", cvar->GetDefault());
+		Msg("\"%s\" = \"%s\"\n", cv->GetName(), cv->GetString(), cv->GetHelpText());
+		Msg("Default: %s\n", cv->GetDefault());
 
 		float val;
-		if (cvar->GetMin(val))
+		if (cv->GetMin(val))
 		{
 			Msg("Min: %f\n", val);
 		}
 
-		if (cvar->GetMax(val))
+		if (cv->GetMax(val))
 		{
 			Msg("Max: %f\n", val);
 		}
 
-		const char* helpText = cvar->GetHelpText();
+		const char* helpText = cv->GetHelpText();
 		if (helpText[0] != '\0')
-			Msg("- %s\n", cvar->GetHelpText());
+			Msg("- %s\n", cv->GetHelpText());
 
 		return;
 	}
 
 	const char* value = args.ArgS() + strlen(args.Arg(1)) + 1;
-	cvar->SetValue(value);
+	cv->SetValue(value);
 }
 
 CON_COMMAND(y_spt_dev_cvars, "Prints all developer/hidden CVars.")

--- a/spt/features/hops_hud.cpp
+++ b/spt/features/hops_hud.cpp
@@ -453,7 +453,6 @@ void HopsHud::PrintStrafeCol(std::function<void(const ljstats::SegmentStats&, wc
 
 	auto surface = interfaces::surface;
 	auto fontTall = surface->GetFontTall(hopsFont);
-	int ticks = ljstats::lastJump.TotalTicks();
 
 	surface->DrawSetTextPos(x, y);
 	surface->DrawPrintText(fieldName, wcslen(fieldName));

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -451,8 +451,8 @@ void InputHud::GetCurrentSize(int& x, int& y)
 	int gridWidth = 0;
 	int gridHeight = 0;
 
-	int gridSize = y_spt_ihud_grid_size.GetInt();
-	int padding = y_spt_ihud_grid_padding.GetInt();
+	gridSize = y_spt_ihud_grid_size.GetInt();
+	padding = y_spt_ihud_grid_padding.GetInt();
 
 	if (tasPreset)
 	{
@@ -670,9 +670,9 @@ void InputHud::DrawRectAndCenterTxt(Color buttonColor,
                                     Color textColor,
                                     const wchar_t* text)
 {
-	vgui::HFont font;
+	vgui::HFont rectFont;
 
-	if (!spt_hud.GetFont(fontName, font))
+	if (!spt_hud.GetFont(fontName, rectFont))
 	{
 		return;
 	}
@@ -681,10 +681,10 @@ void InputHud::DrawRectAndCenterTxt(Color buttonColor,
 	surface->DrawFilledRect(x0, y0, x1, y1);
 
 	int tw, th;
-	surface->GetTextSize(font, text, tw, th);
+	surface->GetTextSize(rectFont, text, tw, th);
 	int xc = x0 + ((x1 - x0) / 2);
 	int yc = y0 + ((y1 - y0) / 2);
-	surface->DrawSetTextFont(font);
+	surface->DrawSetTextFont(rectFont);
 	surface->DrawSetTextColor(textColor);
 	surface->DrawSetTextPos(xc - (tw / 2), yc - (th / 2));
 	surface->DrawPrintText(text, wcslen(text));

--- a/spt/features/leafvis.cpp
+++ b/spt/features/leafvis.cpp
@@ -43,6 +43,9 @@ static __forceinline int GetLeafIndex()
 	return y_spt_draw_leaf.GetInt();
 }
 
+#pragma warning(push)
+#pragma warning(disable : 4740)
+
 /**
 * The game calls CM_PointLeafnum, returning the leaf index of the current view
 * point and loads ESI with it. This hooks is right after that, setting the leaf
@@ -64,3 +67,5 @@ __declspec(naked) void LeafVisFeature::HOOKED_MiddleOfLeafVisBuild()
 		jmp spt_leafvis.ORIG_MiddleOfLeafVisBuild;
 	}
 }
+
+#pragma warning(pop)

--- a/spt/features/vag.cpp
+++ b/spt/features/vag.cpp
@@ -72,6 +72,9 @@ void VAG::LoadFeature()
 
 void VAG::UnloadFeature() {}
 
+#pragma warning(push)
+#pragma warning(disable : 4740)
+
 __declspec(naked) void VAG::HOOKED_MiddleOfTeleportTouchingEntity()
 {
 	/**
@@ -106,6 +109,8 @@ __declspec(naked) void VAG::HOOKED_EndOfTeleportTouchingEntity()
 	}
 }
 
+#pragma warning(pop)
+
 /**
 * A no free edicts crash when trying to do a vag happens when the 2nd teleport places the entity
 * behind the entry portal. This causes another teleport by the entry portal to be queued which
@@ -135,9 +140,7 @@ void __fastcall VAG::HOOKED_MiddleOfTeleportTouchingEntity_Func(void* portalPtr,
 		    portalNorm->z,
 		    spt_vag.recursiveTeleportCount);
 		// push entity further into the portal so it comes further out after the teleport
-		entPos->x -= portalNorm->x;
-		entPos->y -= portalNorm->y;
-		entPos->z -= portalNorm->z;
+		*entPos -= *portalNorm;
 		VagCrashSignal();
 	}
 }

--- a/spt/features/visualizations/renderer/mesh_defs_private.hpp
+++ b/spt/features/visualizations/renderer/mesh_defs_private.hpp
@@ -64,7 +64,11 @@
 
 #include "mathlib\vector.h"
 #include "materialsystem\imaterial.h"
+
+#pragma warning(push)
+#pragma warning(disable : 5054)
 #include "materialsystem\imesh.h"
+#pragma warning(pop)
 
 #define VPROF_LEVEL 1
 #ifndef SSDK2007

--- a/spt/features/visualizations/renderer/source files/materials_manager.cpp
+++ b/spt/features/visualizations/renderer/source files/materials_manager.cpp
@@ -4,29 +4,7 @@
 
 #ifdef SPT_MESH_RENDERING_ENABLED
 
-#include "vstdlib\IKeyValuesSystem.h"
 #include "interfaces.hpp"
-
-// We need KeyValues to make materials; they in turn need KeyValuesSystem(), but we don't link against vstdlib.
-// Here's a little hack to make that work - find the KeyValuesSystem function by searching for its symbol.
-#pragma warning(push)
-#pragma warning(disable : 4273)
-IKeyValuesSystem* KeyValuesSystem()
-{
-	static IKeyValuesSystem* ptr = nullptr;
-
-	if (ptr != nullptr)
-		return ptr;
-
-	void* moduleHandle;
-	if (MemUtils::GetModuleInfo(L"vstdlib.dll", &moduleHandle, nullptr, nullptr))
-	{
-		typedef IKeyValuesSystem*(__cdecl * _KVS)();
-		ptr = ((_KVS)MemUtils::GetSymbolAddress(moduleHandle, "KeyValuesSystem"))();
-	}
-	return ptr;
-}
-#pragma warning(pop)
 
 void MeshBuilderMatMgr::Load()
 {

--- a/spt/ipc/ipc.cpp
+++ b/spt/ipc/ipc.cpp
@@ -30,7 +30,7 @@ static bool DataAvailable(int& socket)
 	timeout.tv_usec = 0;
 
 	FD_ZERO(&read);
-	FD_SET(socket, &read);
+	FD_SET((uint32_t)socket, &read);
 	int result = select(socket + 1, &read, &read, &read, &timeout);
 
 	return result > 0;

--- a/spt/scripts/tester.cpp
+++ b/spt/scripts/tester.cpp
@@ -221,15 +221,15 @@ namespace scripts
 		}
 	}
 
-	void Tester::RunAutomatedTest(const std::string& folder, bool generating, const std::string& testFileName)
+	void Tester::RunAutomatedTest(const std::string& folder, bool generating, const std::string& fileName)
 	{
-		OpenLogFile(testFileName);
+		OpenLogFile(fileName);
 		LoadTest(folder, generating, true);
 	}
 
-	void Tester::RunAllTests(const std::string& folder, bool generating, bool automatedTest)
+	void Tester::RunAllTests(const std::string& folder, bool generating, bool automated)
 	{
-		this->automatedTest = automatedTest;
+		this->automatedTest = automated;
 		Reset();
 
 		for (auto& entry : std::filesystem::recursive_directory_iterator(folder))
@@ -296,9 +296,9 @@ namespace scripts
 			Msg("[TEST] %s : %s\n", testName.c_str(), msg);
 		}
 	}
-	void Tester::OpenLogFile(const std::string& testFileName)
+	void Tester::OpenLogFile(const std::string& fileName)
 	{
-		logFileStream.open(testFileName);
+		logFileStream.open(fileName);
 	}
 	void Tester::CloseLogFile()
 	{

--- a/spt/scripts2/tester2.cpp
+++ b/spt/scripts2/tester2.cpp
@@ -221,15 +221,15 @@ namespace scripts2
 		}
 	}
 
-	void Tester::RunAutomatedTest(const std::string& folder, bool generating, const std::string& testFileName)
+	void Tester::RunAutomatedTest(const std::string& folder, bool generating, const std::string& fileName)
 	{
-		OpenLogFile(testFileName);
+		OpenLogFile(fileName);
 		LoadTest(folder, generating, true);
 	}
 
-	void Tester::RunAllTests(const std::string& folder, bool generating, bool automatedTest)
+	void Tester::RunAllTests(const std::string& folder, bool generating, bool automated)
 	{
-		this->automatedTest = automatedTest;
+		this->automatedTest = automated;
 		Reset();
 
 		for (auto& entry : std::filesystem::recursive_directory_iterator(folder))
@@ -296,9 +296,9 @@ namespace scripts2
 			Msg("[TEST] %s : %s\n", testName.c_str(), msg);
 		}
 	}
-	void Tester::OpenLogFile(const std::string& testFileName)
+	void Tester::OpenLogFile(const std::string& fileName)
 	{
-		logFileStream.open(testFileName);
+		logFileStream.open(fileName);
 	}
 	void Tester::CloseLogFile()
 	{


### PR DESCRIPTION
Rebuilding on Release gave 143 warnings, now it gives 1 (from SPTLib).
- renamed some params/local vars to remove "hides class member" warning
- removed a couple signed/unsigned mismatches
- suppressed SDK imesh.h warning (operator+ deprecated between enumerations of different types)
- suppressed inline asm warning
- re-added the link against vstdlib.lib so I don't have to manually create KeyValuesSystem()
- globally suppressed enum forward declaration type warning, the SDK forward declared enums a lot so I don't think a full fix is feasible to PR into the SDK

Building for OE still gives some conversion warnings from ssemath.h and some uninitialized warning from vector.h. Not sure what the best fix is since those files are included everywhere and I think the latter could actually be useful.