### PR TITLE
Port of waezone's Microsegmenting

### DIFF
--- a/microsegmenting.cpp
+++ b/microsegmenting.cpp
@@ -1,13 +1,13 @@
 #include "stdafx.h"
 #include "..\feature.hpp"
 #include "..\sptlib-wrapper.hpp"
+#include <sstream>
 
 // Port of waezone's microsegmenting AHK file
 class MicroSegmenting : public FeatureWrapper<MicroSegmenting>
 {
 public:
 	int currentSegment = 1;
-	int previousSegment = 0;
 	std::string runFolder = "";
 	ConVar* playerName = nullptr;
 
@@ -43,7 +43,6 @@ CON_COMMAND(y_spt_microsegmenting_set, "Set the current segment. Usage: y_spt_mi
 		return;
 	}
 	spt_microsegmenting.currentSegment = std::atoi(args.Arg(1));
-	spt_microsegmenting.previousSegment = spt_microsegmenting.currentSegment - 1;
 
 	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
 }
@@ -51,7 +50,6 @@ CON_COMMAND(y_spt_microsegmenting_set, "Set the current segment. Usage: y_spt_mi
 CON_COMMAND(y_spt_microsegmenting_previous, "Go back one segment.")
 {
 	spt_microsegmenting.currentSegment--;
-	spt_microsegmenting.previousSegment--;
 
 	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
 }
@@ -59,7 +57,6 @@ CON_COMMAND(y_spt_microsegmenting_previous, "Go back one segment.")
 CON_COMMAND(y_spt_microsegmenting_next, "Go up one segment.")
 {
 	spt_microsegmenting.currentSegment++;
-	spt_microsegmenting.previousSegment++;
 
 	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
 }
@@ -77,7 +74,7 @@ CON_COMMAND(y_spt_microsegmenting_record, "Start recording a segment. If provide
 	}
 }
 
-CON_COMMAND(y_spt_microsegmenting_stop, "Stop the current segment. If provided with an arguement, runs an alias of that name instead of the default commands after saving.")
+CON_COMMAND(y_spt_microsegmenting_stop, "Stop the current segment. If provided with an arguement, runs an alias of that name instead of the default commands after saving. Defaut commands: \"echo #SAVE#;sensitivity 0;wait 100;stop\"")
 {
 	std::ostringstream saveCmd;
 	saveCmd << "save " << spt_microsegmenting.runFolder << spt_microsegmenting.currentSegment << "-"
@@ -94,10 +91,10 @@ CON_COMMAND(y_spt_microsegmenting_stop, "Stop the current segment. If provided w
 	}
 }
 
-CON_COMMAND(y_spt_microsegmenting_load, "Loads the current segment. If provided with one arguement, runs an alias of that name after loading. If provided with a 2nd, uses that as the player name instead of your own.")
+CON_COMMAND(y_spt_microsegmenting_load, "Loads the current segment. If provided with one arguement, runs an alias of that name after loading instead of the default command. Default command: \"sensitivity 0\" If provided with a 2nd, uses that as the player name instead of your own.")
 {
 	std::ostringstream loadCmd;
-	loadCmd << "load " << spt_microsegmenting.runFolder << spt_microsegmenting.previousSegment << "-"
+	loadCmd << "load " << spt_microsegmenting.runFolder << spt_microsegmenting.currentSegment - 1 << "-"
 	        << ((args.ArgC() > 2) ? args.Arg(2) : spt_microsegmenting.playerName->GetString()) << "-";
 	EngineConCmd(loadCmd.str().c_str());
 

--- a/microsegmenting.cpp
+++ b/microsegmenting.cpp
@@ -35,12 +35,11 @@ void MicroSegmenting::UnloadFeature()
 	playerName = nullptr;
 }
 
-CON_COMMAND(spt_microsegmenting_set_current_segment,
-            "The current segment. Usage: spt_microsegmenting_set_current_segment <number>")
+CON_COMMAND(y_spt_microsegmenting_set, "Set the current segment. Usage: y_spt_microsegmenting_set <number>")
 {
 	if (args.ArgC() != 2)
 	{
-		Msg("Usage: spt_microsegmenting_set_current_segment <number>\n");
+		Msg("Usage: y_spt_microsegmenting_set <number>\n");
 		return;
 	}
 	spt_microsegmenting.currentSegment = std::atoi(args.Arg(1));
@@ -49,7 +48,7 @@ CON_COMMAND(spt_microsegmenting_set_current_segment,
 	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
 }
 
-CON_COMMAND(spt_microsegmenting_previous_segment, "Go back one segment.")
+CON_COMMAND(y_spt_microsegmenting_previous, "Go back one segment.")
 {
 	spt_microsegmenting.currentSegment--;
 	spt_microsegmenting.previousSegment--;
@@ -57,7 +56,7 @@ CON_COMMAND(spt_microsegmenting_previous_segment, "Go back one segment.")
 	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
 }
 
-CON_COMMAND(spt_microsegmenting_next_segment, "Go up one segment.")
+CON_COMMAND(y_spt_microsegmenting_next, "Go up one segment.")
 {
 	spt_microsegmenting.currentSegment++;
 	spt_microsegmenting.previousSegment++;
@@ -65,8 +64,7 @@ CON_COMMAND(spt_microsegmenting_next_segment, "Go up one segment.")
 	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
 }
 
-CON_COMMAND(spt_microsegmenting_record_segment,
-            "Start recording a segment. If provided with an arguement, runs an alias of that name after recording.")
+CON_COMMAND(y_spt_microsegmenting_record, "Start recording a segment. If provided with an arguement, runs an alias of that name after recording.")
 {
 	std::ostringstream startCmd;
 	startCmd << "record " << spt_microsegmenting.runFolder << spt_microsegmenting.currentSegment << "-"
@@ -79,9 +77,7 @@ CON_COMMAND(spt_microsegmenting_record_segment,
 	}
 }
 
-CON_COMMAND(
-    spt_microsegmenting_stop_segment,
-    "Stop the current segment. If provided with an arguement, runs an alias of that name instead of the default commands after saving.")
+CON_COMMAND(y_spt_microsegmenting_stop, "Stop the current segment. If provided with an arguement, runs an alias of that name instead of the default commands after saving.")
 {
 	std::ostringstream saveCmd;
 	saveCmd << "save " << spt_microsegmenting.runFolder << spt_microsegmenting.currentSegment << "-"
@@ -98,9 +94,7 @@ CON_COMMAND(
 	}
 }
 
-CON_COMMAND(
-    spt_microsegmenting_load_segment,
-    "Loads the current segment. If provided with one arguement, runs an alias of that name after loading. If provided with a 2nd, uses that as the player name instead of your own.")
+CON_COMMAND(y_spt_microsegmenting_load, "Loads the current segment. If provided with one arguement, runs an alias of that name after loading. If provided with a 2nd, uses that as the player name instead of your own.")
 {
 	std::ostringstream loadCmd;
 	loadCmd << "load " << spt_microsegmenting.runFolder << spt_microsegmenting.previousSegment << "-"
@@ -117,9 +111,7 @@ CON_COMMAND(
 	}
 }
 
-CON_COMMAND(
-    spt_microsegmenting_folder,
-    "If set, resulting demos/saves will be loaded and saved from this folder. Need to create it in both the root mod directory and in the SAVE folder.")
+CON_COMMAND(y_spt_microsegmenting_folder, "If set, resulting demos/saves will be loaded and saved from this folder. Need to create it in both the root mod directory and in the SAVE folder.")
 {
 	spt_microsegmenting.runFolder = "";
 
@@ -133,11 +125,11 @@ void MicroSegmenting::LoadFeature()
 {
 	spt_microsegmenting.playerName = g_pCVar->FindVar("name");
 
-	InitCommand(spt_microsegmenting_set_current_segment);
-	InitCommand(spt_microsegmenting_previous_segment);
-	InitCommand(spt_microsegmenting_next_segment);
-	InitCommand(spt_microsegmenting_stop_segment);
-	InitCommand(spt_microsegmenting_record_segment);
-	InitCommand(spt_microsegmenting_load_segment);
-	InitCommand(spt_microsegmenting_folder);
+	InitCommand(y_spt_microsegmenting_set);
+	InitCommand(y_spt_microsegmenting_previous);
+	InitCommand(y_spt_microsegmenting_next);
+	InitCommand(y_spt_microsegmenting_stop);
+	InitCommand(y_spt_microsegmenting_record);
+	InitCommand(y_spt_microsegmenting_load);
+	InitCommand(y_spt_microsegmenting_folder);
 }

--- a/microsegmenting.cpp
+++ b/microsegmenting.cpp
@@ -1,0 +1,143 @@
+#include "stdafx.h"
+#include "..\feature.hpp"
+#include "..\sptlib-wrapper.hpp"
+
+// Port of waezone's microsegmenting AHK file
+class MicroSegmenting : public FeatureWrapper<MicroSegmenting>
+{
+public:
+	int currentSegment = 1;
+	int previousSegment = 0;
+	std::string runFolder = "";
+	ConVar* playerName = nullptr;
+
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void InitHooks() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void UnloadFeature() override;
+};
+
+static MicroSegmenting spt_microsegmenting;
+
+bool MicroSegmenting::ShouldLoadFeature()
+{
+	return true;
+}
+
+void MicroSegmenting::InitHooks() {}
+
+void MicroSegmenting::UnloadFeature()
+{
+	playerName = nullptr;
+}
+
+CON_COMMAND(spt_microsegmenting_set_current_segment,
+            "The current segment. Usage: spt_microsegmenting_set_current_segment <number>")
+{
+	if (args.ArgC() != 2)
+	{
+		Msg("Usage: spt_microsegmenting_set_current_segment <number>\n");
+		return;
+	}
+	spt_microsegmenting.currentSegment = std::atoi(args.Arg(1));
+	spt_microsegmenting.previousSegment = spt_microsegmenting.currentSegment - 1;
+
+	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
+}
+
+CON_COMMAND(spt_microsegmenting_previous_segment, "Go back one segment.")
+{
+	spt_microsegmenting.currentSegment--;
+	spt_microsegmenting.previousSegment--;
+
+	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
+}
+
+CON_COMMAND(spt_microsegmenting_next_segment, "Go up one segment.")
+{
+	spt_microsegmenting.currentSegment++;
+	spt_microsegmenting.previousSegment++;
+
+	Msg("########## SEGMENT %i ##########\n", spt_microsegmenting.currentSegment);
+}
+
+CON_COMMAND(spt_microsegmenting_record_segment,
+            "Start recording a segment. If provided with an arguement, runs an alias of that name after recording.")
+{
+	std::ostringstream startCmd;
+	startCmd << "record " << spt_microsegmenting.runFolder << spt_microsegmenting.currentSegment << "-"
+	         << spt_microsegmenting.playerName->GetString() << "-";
+	EngineConCmd(startCmd.str().c_str());
+
+	if (args.ArgC() >= 2)
+	{
+		EngineConCmd(args.Arg(1));
+	}
+}
+
+CON_COMMAND(
+    spt_microsegmenting_stop_segment,
+    "Stop the current segment. If provided with an arguement, runs an alias of that name instead of the default commands after saving.")
+{
+	std::ostringstream saveCmd;
+	saveCmd << "save " << spt_microsegmenting.runFolder << spt_microsegmenting.currentSegment << "-"
+	        << spt_microsegmenting.playerName->GetString() << "-";
+	EngineConCmd(saveCmd.str().c_str());
+
+	if (args.ArgC() >= 2)
+	{
+		EngineConCmd(args.Arg(1));
+	}
+	else
+	{
+		EngineConCmd("echo #SAVE#;sensitivity 0;wait 100;stop");
+	}
+}
+
+CON_COMMAND(
+    spt_microsegmenting_load_segment,
+    "Loads the current segment. If provided with one arguement, runs an alias of that name after loading. If provided with a 2nd, uses that as the player name instead of your own.")
+{
+	std::ostringstream loadCmd;
+	loadCmd << "load " << spt_microsegmenting.runFolder << spt_microsegmenting.previousSegment << "-"
+	        << ((args.ArgC() > 2) ? args.Arg(2) : spt_microsegmenting.playerName->GetString()) << "-";
+	EngineConCmd(loadCmd.str().c_str());
+
+	if (args.ArgC() >= 1)
+	{
+		EngineConCmd(args.Arg(1));
+	}
+	else
+	{
+		EngineConCmd("sensitivity 0");
+	}
+}
+
+CON_COMMAND(
+    spt_microsegmenting_folder,
+    "If set, resulting demos/saves will be loaded and saved from this folder. Need to create it in both the root mod directory and in the SAVE folder.")
+{
+	spt_microsegmenting.runFolder = "";
+
+	if (args.ArgC() >= 2)
+	{
+		spt_microsegmenting.runFolder.append(args.Arg(1)).append("\\");
+	}
+}
+
+void MicroSegmenting::LoadFeature()
+{
+	spt_microsegmenting.playerName = g_pCVar->FindVar("name");
+
+	InitCommand(spt_microsegmenting_set_current_segment);
+	InitCommand(spt_microsegmenting_previous_segment);
+	InitCommand(spt_microsegmenting_next_segment);
+	InitCommand(spt_microsegmenting_stop_segment);
+	InitCommand(spt_microsegmenting_record_segment);
+	InitCommand(spt_microsegmenting_load_segment);
+	InitCommand(spt_microsegmenting_folder);
+}

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -895,6 +895,7 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="microsegmenting.cpp" />
     <ClCompile Include="sptlib\Hooks.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">sptlib-stdafx.hpp</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">sptlib-stdafx.hpp</PrecompiledHeaderFile>

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -304,6 +304,9 @@
     <ClCompile Include="spt\features\property_getter.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="microsegmenting.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">


### PR DESCRIPTION
Uses only spt_ prefix, let me know if this change is still far out and i should make it y_.

Waezone's [microsegmenting](https://github.com/waezone/Random-Assortment-Of-Scripts/tree/master/Microsegmenting) is an ahk file designed to speed up segmenting, and allow for shorter segments overall as you don't need to manually edit a cfg file everytime. I have to the best of my ability ported this over. If someone knows of a way to make this less complicated for the end user let me know. Current a segment cfg would like this with it (things in [] are optional):

```
y_spt_autojump 1
y_spt_pause 1

bind "u" "spt_microsegmenting_record_segment [alias]"
bind f1 "spt_microsegmenting_load_segment [alias] [person]"
bind z "unpause; sensitivity 2.9"
bind mouse4 "spt_microsegmenting_stop_segment [alias]"
bind - "spt_microsegmenting_previous_segment"
bind = "spt_microsegmenting_next_segment"
[spt_segmenting_folder bmdq]
```
