### PR TITLE
Added portal placement HUD and improved seamshot tools.

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1187,6 +1187,7 @@
     <ClCompile Include="spt\features\vag_searcher.cpp" />
     <ClCompile Include="spt\features\visualizations\draw_seams.cpp" />
     <ClCompile Include="spt\features\visualizations\mesh_test.cpp" />
+    <ClCompile Include="spt\features\visualizations\portal_placement.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\source files\create_collide.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\source files\materials_manager.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\source files\mesh_builder.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -304,6 +304,9 @@
     <ClCompile Include="spt\features\property_getter.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\visualizations\portal_placement.cpp">
+      <Filter>spt\features\visualizations</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -89,6 +89,8 @@ extern ConVar y_spt_hud_ent_info;
 extern ConVar y_spt_hud_left;
 extern ConVar y_spt_hud_oob;
 extern ConVar y_spt_hud_isg;
+extern ConVar y_spt_hud_shadow_info;
+extern ConVar y_spt_hud_portal_placement;
 
 extern ConVar y_spt_ihud;
 extern ConVar y_spt_ihud_grid_size;
@@ -102,6 +104,7 @@ extern ConVar _y_spt_overlay_portal;
 extern ConVar _y_spt_overlay_width;
 extern ConVar _y_spt_overlay_fov;
 extern ConVar _y_spt_overlay_swap;
+extern ConVar _y_spt_overlay_no_roll;
 
 #ifdef OE
 extern ConVar y_spt_gamedir;

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -7,6 +7,7 @@
 #include "command.hpp"
 #include "..\sptlib-wrapper.hpp"
 #include "..\cvars.hpp"
+#include "overlay.hpp"
 
 #include "usercmd.h"
 
@@ -671,9 +672,27 @@ HOOK_THISCALL(bool, Camera, ClientModeShared__CreateMove, float flInputSampleTim
 	return spt_camera.ORIG_ClientModeShared__CreateMove(thisptr, edx, flInputSampleTime, cmd);
 }
 
+static bool ShouldDrawPlayerModel()
+{
+	if (!spt_camera.CanOverrideView() || !y_spt_cam_control.GetBool())
+		return false;
+
+#ifdef SPT_OVERLAY_ENABLED
+	// Don't draw playe rmodel in overlay
+	if (_y_spt_overlay.GetBool())
+	{
+		bool renderingOverlay = spt_overlay.renderingOverlay;
+		if (_y_spt_overlay_swap.GetBool())
+			renderingOverlay = !renderingOverlay;
+		return !renderingOverlay;
+	}
+#endif
+	return true;
+}
+
 HOOK_THISCALL(bool, Camera, C_BasePlayer__ShouldDrawLocalPlayer)
 {
-	if (spt_camera.CanOverrideView() && y_spt_cam_control.GetBool())
+	if (ShouldDrawPlayerModel())
 	{
 		return true;
 	}
@@ -685,7 +704,7 @@ HOOK_THISCALL(bool, Camera, C_BasePlayer__ShouldDrawThisPlayer)
 {
 	// ShouldDrawLocalPlayer only decides draw view model or weapon model in steampipe
 	// We need ShouldDrawThisPlayer to make player model draw
-	if (spt_camera.CanOverrideView() && y_spt_cam_control.GetBool())
+	if (ShouldDrawPlayerModel())
 	{
 		return true;
 	}

--- a/spt/features/hud.cpp
+++ b/spt/features/hud.cpp
@@ -64,25 +64,37 @@ bool HUDFeature::AddHudCallback(HudCallback callback)
 	return true;
 }
 
-void HUDFeature::DrawTopHudElement(const wchar* format, ...)
+void HUDFeature::vDrawTopHudElement(Color color, const wchar* format, va_list args)
 {
 	vgui::HFont font;
 
 	if (!GetFont(FONT_DefaultFixedOutline, font))
 		return;
-
-	va_list args;
-	va_start(args, format);
 	const wchar* text = FormatTempString(format, args);
-	va_end(args);
 
 	interfaces::surface->DrawSetTextFont(font);
-	interfaces::surface->DrawSetTextColor(255, 255, 255, 255);
+	interfaces::surface->DrawSetTextColor(color.r(), color.g(), color.b(), color.a());
 	interfaces::surface->DrawSetTexture(0);
 
 	interfaces::surface->DrawSetTextPos(topX, 2 + (topFontTall + 2) * topVertIndex);
 	interfaces::surface->DrawPrintText(text, wcslen(text));
 	++topVertIndex;
+}
+
+void HUDFeature::DrawTopHudElement(const wchar* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	vDrawTopHudElement({255, 255, 255, 255}, format, args);
+	va_end(args);
+}
+
+void HUDFeature::DrawColorTopHudElement(Color color, const wchar* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	vDrawTopHudElement(color, format, args);
+	va_end(args);
 }
 
 bool HUDFeature::ShouldLoadFeature()
@@ -123,9 +135,9 @@ void HUDFeature::PreHook()
 {
 	loadingSuccessful =
 #ifndef OE
-		ORIG_CMatSystemSurface__FinishDrawing && ORIG_CMatSystemSurface__StartDrawing &&
+	    ORIG_CMatSystemSurface__FinishDrawing && ORIG_CMatSystemSurface__StartDrawing &&
 #endif
-		ORIG_CEngineVGui__Paint;
+	    ORIG_CEngineVGui__Paint;
 }
 
 void HUDFeature::LoadFeature()

--- a/spt/features/hud.hpp
+++ b/spt/features/hud.hpp
@@ -47,6 +47,7 @@ public:
 
 	bool AddHudCallback(HudCallback callback);
 	void DrawTopHudElement(const wchar* format, ...);
+	void DrawColorTopHudElement(Color color, const wchar* format, ...);
 	virtual bool ShouldLoadFeature() override;
 	bool GetFont(const std::string& fontName, vgui::HFont& fontOut);
 
@@ -74,6 +75,7 @@ private:
 	DECL_MEMBER_THISCALL(void, CMatSystemSurface__FinishDrawing);
 
 	void DrawHUD(bool overlay);
+	void vDrawTopHudElement(Color color, const wchar* format, va_list args);
 };
 
 extern HUDFeature spt_hud;

--- a/spt/features/overlay.cpp
+++ b/spt/features/overlay.cpp
@@ -62,6 +62,7 @@ ConVar _y_spt_overlay_crosshair_color("_y_spt_overlay_crosshair_color",
                                       "0 255 0 255",
                                       FCVAR_CHEAT,
                                       "Overlay crosshair RGBA color.");
+ConVar _y_spt_overlay_no_roll("_y_spt_overlay_no_roll", "1", FCVAR_CHEAT, "Set the roll of overlay camera roll to 0.");
 
 Overlay spt_overlay;
 
@@ -118,6 +119,7 @@ void Overlay::LoadFeature()
 	InitConcommandBase(_y_spt_overlay_width);
 	InitConcommandBase(_y_spt_overlay_fov);
 	InitConcommandBase(_y_spt_overlay_swap);
+	InitConcommandBase(_y_spt_overlay_no_roll);
 
 #ifdef SPT_HUD_ENABLED
 	bool result = spt_hud.AddHudCallback(HudCallback(
@@ -279,6 +281,11 @@ void Overlay::ModifyView(CViewSetup* renderView)
 		}
 		// normalize yaw
 		renderView->angles.y = utils::NormalizeDeg(renderView->angles.y);
+
+		if (_y_spt_overlay_no_roll.GetBool())
+		{
+			renderView->angles.z = 0;
+		}
 	}
 }
 

--- a/spt/features/tracing.hpp
+++ b/spt/features/tracing.hpp
@@ -1,6 +1,10 @@
 #pragma once
 #include "..\feature.hpp"
 
+#if defined(SSDK2013) || defined(SSDK2007)
+#define SPT_TRACE_PORTAL_ENABLED
+#endif
+
 #if defined(OE)
 #include "vector.h"
 #else
@@ -82,7 +86,20 @@ public:
 	                     unsigned int fMask,
 	                     int collisionGroup,
 	                     trace_t& pm);
+
+#ifdef SPT_TRACE_PORTAL_ENABLED
+	void* GetActiveWeapon();
 	float TraceFirePortal(trace_t& tr, const Vector& startPos, const Vector& vDirection);
+
+	// Transform through portal if in portal enviroment
+	float TraceTransformFirePortal(trace_t& tr, const Vector& startPos, const QAngle& startAngles);
+	float TraceTransformFirePortal(trace_t& tr,
+	                               const Vector& startPos,
+	                               const QAngle& startAngles,
+	                               Vector& finalPos,
+	                               QAngle& finalAngles,
+	                               bool isPortal2);
+#endif
 
 protected:
 	virtual bool ShouldLoadFeature() override;

--- a/spt/features/visualizations/draw_seams.cpp
+++ b/spt/features/visualizations/draw_seams.cpp
@@ -1,16 +1,17 @@
 #include "stdafx.h"
 
 #include "renderer\mesh_renderer.hpp"
+#include "spt\features\tracing.hpp"
 
-#ifdef SPT_MESH_RENDERING_ENABLED
+#if defined(SPT_MESH_RENDERING_ENABLED) && defined(SPT_TRACE_PORTAL_ENABLED)
 
 #include "spt\feature.hpp"
 #include "spt\utils\signals.hpp"
 #include "spt\features\ent_props.hpp"
 #include "spt\utils\math.hpp"
 #include "spt\sptlib-wrapper.hpp"
-#include "spt\features\tracing.hpp"
 #include "spt\features\generic.hpp"
+#include "spt\utils\portal_utils.hpp"
 
 ConVar y_spt_draw_seams("y_spt_draw_seams", "0", FCVAR_CHEAT, "Draws seamshot stuff");
 
@@ -151,15 +152,11 @@ void DrawSeamsFeature::OnMeshRenderSignal(MeshRendererDelegate& mr)
 	if (!player)
 		return;
 
-	float va[3];
-	EngineGetViewAngles(va);
-	Vector cameraPosition = spt_generic.GetCameraOrigin();
-	QAngle angles(va[0], va[1], va[2]);
-	Vector vDirection;
-	AngleVectors(angles, &vDirection);
+	Vector cameraPosition = utils::GetPlayerEyePosition();
+	QAngle angles = utils::GetPlayerEyeAngles();
 
 	trace_t tr;
-	spt_tracing.TraceFirePortal(tr, cameraPosition, vDirection);
+	spt_tracing.TraceTransformFirePortal(tr, cameraPosition, angles);
 
 	if (tr.fraction >= 1.0f)
 		return;

--- a/spt/features/visualizations/mesh_test.cpp
+++ b/spt/features/visualizations/mesh_test.cpp
@@ -663,4 +663,29 @@ BEGIN_TEST_CASE("AddCPolyhedron", VEC_WRAP(600, -300, 0))
 }
 END_TEST_CASE()
 
+BEGIN_TEST_CASE("AddEllipse()", VEC_WRAP(800, -300, 0))
+{
+	Vector dir(4, 2, 13);
+	QAngle ang;
+	VectorAngles(dir, ang);
+	float radius = 100.0f;
+	for (float i = 8.0; i >= 2.0f; i -= 0.5f) // draw backwards and check for sorting
+	{
+		RENDER_DYNAMIC(
+		    mr,
+		    {
+			    mb.AddEllipse(testPos + Vector(-20, 0, -30) + dir * i,
+			                  ang,
+			                  radius / i,
+			                  radius / (10 - i),
+			                  32,
+			                  MeshColor::Outline({(byte)(250 - i * 40), 200, (byte)(i * 40), 50}));
+		    },
+		    ZTEST_FACES | ZTEST_LINES,
+		    CullType::Default,
+		    TranslucentSortType::AABB_Center); // test that this works with y_spt_draw_mesh_debug
+	}
+}
+END_TEST_CASE()
+
 #endif

--- a/spt/features/visualizations/portal_placement.cpp
+++ b/spt/features/visualizations/portal_placement.cpp
@@ -1,0 +1,257 @@
+#include "stdafx.h"
+
+#include "renderer\mesh_renderer.hpp"
+#include "spt\features\tracing.hpp"
+
+#if defined(SPT_MESH_RENDERING_ENABLED) && defined(SPT_TRACE_PORTAL_ENABLED)
+
+#include "spt\feature.hpp"
+#include "spt\features\hud.hpp"
+#include "spt\utils\ent_utils.hpp"
+#include "spt\utils\portal_utils.hpp"
+#include "spt\utils\game_detection.hpp"
+#include "spt\utils\signals.hpp"
+
+#define PORTAL_PLACEMENT_FAIL_NO_SERVER -1.0f
+#define PORTAL_PLACEMENT_FAIL_NO_WEAPON -2.0f
+
+#define PORTAL_PLACEMENT_SUCCESS_NO_BUMP 1.0f
+#define PORTAL_PLACEMENT_SUCCESS_CANT_FIT 0.1f
+#define PORTAL_PLACEMENT_SUCCESS_CLEANSER 0.028f
+#define PORTAL_PLACEMENT_SUCCESS_OVERLAP_LINKED 0.027f
+#define PORTAL_PLACEMENT_SUCCESS_NEAR 0.0265f
+#define PORTAL_PLACEMENT_SUCCESS_INVALID_VOLUME 0.026f
+#define PORTAL_PLACEMENT_SUCCESS_INVALID_SURFACE 0.025f
+#define PORTAL_PLACEMENT_SUCCESS_PASSTHROUGH_SURFACE 0.0f
+
+ConVar y_spt_hud_portal_placement("y_spt_hud_portal_placement",
+                                  "0",
+                                  FCVAR_CHEAT,
+                                  "Show portal placement info\n"
+                                  "1 = Boolean result\n"
+                                  "2 = String result\n"
+                                  "3 = Float result");
+ConVar y_spt_draw_pp("y_spt_draw_pp", "0", FCVAR_CHEAT, "Draw portal placement.");
+ConVar y_spt_draw_pp_blue("y_spt_draw_pp_blue", "1", FCVAR_CHEAT, "Draw blue portal placement.");
+ConVar y_spt_draw_pp_orange("y_spt_draw_pp_orange", "1", FCVAR_CHEAT, "Draw orange portal placement.");
+ConVar y_spt_draw_pp_failed("y_spt_draw_pp_failed", "0", FCVAR_CHEAT, "Draw failed portal placement.");
+ConVar y_spt_draw_pp_bbox("y_spt_draw_pp_bbox", "0", FCVAR_CHEAT, "Draw the bounding box of the portal placement.");
+
+// Portal placement related features
+class PortalPlacement : public FeatureWrapper<PortalPlacement>
+{
+public:
+	struct PlacementInfo
+	{
+		float placementResult;
+		Vector finalPos;
+		QAngle finalAngles;
+		trace_t tr;
+	};
+
+	void UpdatePlacementInfo();
+
+	PlacementInfo p1;
+	PlacementInfo p2;
+
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void UnloadFeature() override;
+
+	void OnMeshRenderSignal(MeshRendererDelegate& mr);
+};
+
+static PortalPlacement spt_pp;
+
+void PortalPlacement::UpdatePlacementInfo()
+{
+	auto player = utils::GetServerPlayer();
+	if (!player)
+	{
+		p1.placementResult = PORTAL_PLACEMENT_FAIL_NO_SERVER;
+		return;
+	}
+
+	if (!spt_tracing.ORIG_GetActiveWeapon(player))
+	{
+		p1.placementResult = PORTAL_PLACEMENT_FAIL_NO_WEAPON;
+		return;
+	}
+	Vector camPos = utils::GetPlayerEyePosition();
+	QAngle angles = utils::GetPlayerEyeAngles();
+
+	p1.placementResult =
+	    spt_tracing.TraceTransformFirePortal(p1.tr, camPos, angles, p1.finalPos, p1.finalAngles, false);
+	p2.placementResult =
+	    spt_tracing.TraceTransformFirePortal(p2.tr, camPos, angles, p2.finalPos, p2.finalAngles, true);
+}
+
+static void DrawPortal(MeshBuilderDelegate& mb, const PortalPlacement::PlacementInfo& info, color32 col)
+{
+	const float PORTAL_HALF_WIDTH = 32.0f;
+	const float PORTAL_HALF_HEIGHT = 54.0f;
+
+	const color32 failedColor = {255, 0, 0, 127};
+	const color32 noDrawColor = {0, 0, 0, 0};
+
+	color32 portalColor;
+	if (info.placementResult <= 0.5f)
+	{
+		if (info.placementResult <= 0.5f && y_spt_draw_pp_failed.GetBool()
+		    && info.placementResult != PORTAL_PLACEMENT_SUCCESS_PASSTHROUGH_SURFACE
+		    && info.placementResult != PORTAL_PLACEMENT_SUCCESS_CLEANSER)
+		{
+			portalColor = failedColor;
+		}
+		else
+		{
+			portalColor = noDrawColor;
+		}
+	}
+	else
+	{
+		portalColor = col;
+	}
+
+	MeshColor facePortalColor = MeshColor::Face(portalColor);
+	mb.AddEllipse(info.finalPos, info.finalAngles, PORTAL_HALF_WIDTH, PORTAL_HALF_HEIGHT, 32, facePortalColor);
+
+	if (y_spt_draw_pp_bbox.GetBool())
+	{
+		const Vector portalMaxs(1, PORTAL_HALF_WIDTH, PORTAL_HALF_HEIGHT);
+		MeshColor outlinePortalColor(noDrawColor, portalColor);
+		mb.AddBox(info.finalPos, -portalMaxs, portalMaxs, info.finalAngles, outlinePortalColor);
+	}
+}
+
+void PortalPlacement::OnMeshRenderSignal(MeshRendererDelegate& mr)
+{
+	if (!y_spt_draw_pp.GetBool())
+		return;
+
+	// HUD callback didn't update placement info
+	if (!y_spt_hud_portal_placement.GetBool())
+		UpdatePlacementInfo();
+
+	// No portalgun
+	if (p1.placementResult == PORTAL_PLACEMENT_FAIL_NO_SERVER
+	    || p1.placementResult == PORTAL_PLACEMENT_FAIL_NO_WEAPON)
+		return;
+
+	mr.DrawMesh(spt_meshBuilder.CreateDynamicMesh(
+	    [&](MeshBuilderDelegate& mb)
+	    {
+		    const color32 blueColor = {64, 160, 255, 127};
+		    const color32 orangeColor = {255, 160, 32, 127};
+
+		    // Draw in this order so the color will mix to purple when overlapping.
+		    if (y_spt_draw_pp_orange.GetBool())
+			    DrawPortal(mb, p2, orangeColor);
+
+		    if (y_spt_draw_pp_blue.GetBool())
+			    DrawPortal(mb, p1, blueColor);
+	    },
+	    {ZTEST_NONE}));
+}
+
+bool PortalPlacement::ShouldLoadFeature()
+{
+	return utils::DoesGameLookLikePortal();
+}
+
+static const wchar_t* PlacementResultToString(float placement)
+{
+	if (placement == PORTAL_PLACEMENT_SUCCESS_NO_BUMP)
+		return L"Success with no bump";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_CANT_FIT)
+		return L"Can't fit";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_CLEANSER)
+		return L"Fizzler";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_OVERLAP_LINKED)
+		return L"Overlaps existing portal";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_NEAR)
+		return L"Near existing portal";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_INVALID_VOLUME)
+		return L"Invalid volume";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_INVALID_SURFACE)
+		return L"Invalid surface";
+	if (placement == PORTAL_PLACEMENT_SUCCESS_PASSTHROUGH_SURFACE)
+		return L"Passthrough surface";
+	if (placement > 0.5f)
+		return L"Success with bump";
+	return L"Bump too far"; // Is this possible?
+}
+
+void PortalPlacement::LoadFeature()
+{
+	if (spt_tracing.ORIG_TraceFirePortal && spt_tracing.ORIG_GetActiveWeapon)
+	{
+#ifdef SPT_HUD_ENABLED
+		AddHudCallback(
+		    "pp",
+		    []()
+		    {
+			    if (!y_spt_hud_portal_placement.GetBool())
+				    return;
+
+			    spt_pp.UpdatePlacementInfo();
+			    float res1 = spt_pp.p1.placementResult;
+			    float res2 = spt_pp.p2.placementResult;
+
+			    const Color blue = {64, 160, 255, 255};
+			    const Color orange = {255, 160, 32, 255};
+			    const Color failed = {150, 150, 150, 255};
+
+			    const Color& blueTextColor = res1 > 0.5f ? blue : failed;
+			    const Color& orangeTextColor = res2 > 0.5f ? orange : failed;
+
+			    if (res1 == PORTAL_PLACEMENT_FAIL_NO_SERVER)
+			    {
+				    spt_hud.DrawTopHudElement(L"Portal: No server player");
+			    }
+			    else if (res1 == PORTAL_PLACEMENT_FAIL_NO_WEAPON)
+			    {
+				    spt_hud.DrawTopHudElement(L"Portal: No portalgun");
+			    }
+			    else if (y_spt_hud_portal_placement.GetInt() == 1)
+			    {
+				    spt_hud.DrawColorTopHudElement(blueTextColor, L"Portal1: %d", res1 > 0.5f);
+				    spt_hud.DrawColorTopHudElement(orangeTextColor, L"Portal2: %d", res2 > 0.5f);
+			    }
+			    else if (y_spt_hud_portal_placement.GetInt() == 2)
+			    {
+				    spt_hud.DrawColorTopHudElement(blueTextColor,
+				                                   L"Portal1: %s",
+				                                   PlacementResultToString(res1));
+				    spt_hud.DrawColorTopHudElement(orangeTextColor,
+				                                   L"Portal2: %s",
+				                                   PlacementResultToString(res2));
+			    }
+			    else
+			    {
+				    spt_hud.DrawColorTopHudElement(blueTextColor, L"Portal1: %f", res1);
+				    spt_hud.DrawColorTopHudElement(orangeTextColor, L"Portal2: %f", res2);
+			    }
+		    },
+		    y_spt_hud_portal_placement);
+#endif
+#ifdef SPT_MESH_RENDERING_ENABLED
+		if (spt_meshRenderer.signal.Works)
+		{
+			InitConcommandBase(y_spt_draw_pp);
+			InitConcommandBase(y_spt_draw_pp_blue);
+			InitConcommandBase(y_spt_draw_pp_orange);
+			InitConcommandBase(y_spt_draw_pp_failed);
+			InitConcommandBase(y_spt_draw_pp_bbox);
+			spt_meshRenderer.signal.Connect(this, &PortalPlacement::OnMeshRenderSignal);
+		}
+#endif
+	}
+}
+
+void PortalPlacement::UnloadFeature() {}
+
+#endif

--- a/spt/features/visualizations/renderer/mesh_builder.hpp
+++ b/spt/features/visualizations/renderer/mesh_builder.hpp
@@ -66,6 +66,13 @@ public:
 	// 'pos' is the circle center, an 'ang' of <0,0,0> means the circle normal points towards x+
 	void AddCircle(const Vector& pos, const QAngle& ang, float radius, int numPoints, const MeshColor& c);
 
+	void AddEllipse(const Vector& pos,
+	                const QAngle& ang,
+	                float radiusA,
+	                float radiusB,
+	                int numPoints,
+	                const MeshColor& c);
+
 	void AddBox(const Vector& pos, const Vector& mins, const Vector& maxs, const QAngle& ang, const MeshColor& c);
 
 	// numSubdivisions >= 0, 0 subdivsions is just a cube :)
@@ -118,7 +125,7 @@ private:
 	void _AddFacePolygonIndices(size_t vertsIdx, int numVerts, bool reverse);
 	void _AddLineStripIndices(size_t vertsIdx, int numVerts, bool loop);
 	void _AddSubdivCube(int numSubdivisions, const MeshColor& c);
-	Vector* _CreateCircleVerts(const Vector& pos, const QAngle& ang, float radius, int numPoints);
+	Vector* _CreateEllipseVerts(const Vector& pos, const QAngle& ang, float radiusA, float radiusB, int numPoints);
 
 	MeshBuilderDelegate() = default;
 	MeshBuilderDelegate(MeshBuilderDelegate&) = delete;

--- a/spt/features/visualizations/renderer/source files/mesh_construction.cpp
+++ b/spt/features/visualizations/renderer/source files/mesh_construction.cpp
@@ -201,9 +201,19 @@ void MeshBuilderDelegate::AddCircle(const Vector& pos,
                                     int numPoints,
                                     const MeshColor& col)
 {
-	if (numPoints < 3 || radius < 0 || (col.faceColor.a == 0 && col.lineColor.a == 0))
+	AddEllipse(pos, ang, radius, radius, numPoints, col);
+}
+
+void MeshBuilderDelegate::AddEllipse(const Vector& pos,
+                                     const QAngle& ang,
+                                     float radiusA,
+                                     float radiusB,
+                                     int numPoints,
+                                     const MeshColor& col)
+{
+	if (numPoints < 3 || radiusA < 0 || radiusB < 0 || (col.faceColor.a == 0 && col.lineColor.a == 0))
 		return;
-	AddPolygon(_CreateCircleVerts(pos, ang, radius, numPoints), numPoints, col);
+	AddPolygon(_CreateEllipseVerts(pos, ang, radiusA, radiusB, numPoints), numPoints, col);
 }
 
 void MeshBuilderDelegate::AddBox(const Vector& pos,
@@ -505,7 +515,7 @@ void MeshBuilderDelegate::AddCone(const Vector& pos,
 	if (height < 0 || radius < 0 || numCirclePoints < 3 || (c.faceColor.a == 0 && c.lineColor.a == 0))
 		return;
 
-	Vector* circleVerts = _CreateCircleVerts(pos, ang, radius, numCirclePoints);
+	Vector* circleVerts = _CreateEllipseVerts(pos, ang, radius, radius, numCirclePoints);
 
 	Vector tip;
 	AngleVectors(ang, &tip);
@@ -568,7 +578,7 @@ void MeshBuilderDelegate::AddCylinder(const Vector& pos,
 	AngleVectors(ang, &heightOff);
 	heightOff *= height;
 
-	Vector* circleVerts = _CreateCircleVerts(pos, ang, radius, numCirclePoints);
+	Vector* circleVerts = _CreateEllipseVerts(pos, ang, radius, radius, numCirclePoints);
 
 	if (c.faceColor.a != 0)
 	{
@@ -909,19 +919,21 @@ void MeshBuilderDelegate::_AddSubdivCube(int numSubdivisions, const MeshColor& c
 		}
 	}
 }
-
-Vector* MeshBuilderDelegate::_CreateCircleVerts(const Vector& pos, const QAngle& ang, float radius, int numPoints)
+Vector* MeshBuilderDelegate::_CreateEllipseVerts(const Vector& pos,
+                                                 const QAngle& ang,
+                                                 float radiusA,
+                                                 float radiusB,
+                                                 int numPoints)
 {
 	VMatrix mat;
 	mat.SetupMatrixOrgAngles(pos, ang);
-	mat = mat.Scale(Vector(radius));
 	Vector* scratch = Scratch(numPoints);
 	for (int i = 0; i < numPoints; i++)
 	{
 		float s, c;
 		SinCos(M_PI_F * 2 / numPoints * i, &s, &c);
 		// oriented clockwise, normal is towards x+ for an angle of <0,0,0>
-		scratch[i] = mat * Vector(0, s, c);
+		scratch[i] = mat * Vector(0, s * radiusA, c * radiusB);
 	}
 	return scratch;
 }

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -234,24 +234,14 @@ namespace utils
 
 	Vector GetPlayerEyePosition()
 	{
-		auto ply = GetPlayer();
-
-		if (ply)
-		{
-			auto offset = spt_propertyGetter.GetProperty<Vector>(0, "m_vecViewOffset[0]");
-
-			return ply->GetAbsOrigin() + offset;
-		}
-		else
-			return Vector();
+		return spt_playerio.m_vecAbsOrigin.GetValue() + spt_playerio.m_vecViewOffset.GetValue();
 	}
 
 	QAngle GetPlayerEyeAngles()
 	{
-		if (DoesGameLookLikePortal())
-			return spt_propertyGetter.GetProperty<QAngle>(0, "m_angEyeAngles[0]");
-		else
-			return spt_propertyGetter.GetProperty<QAngle>(0, "m_angRotation");
+		float va[3];
+		EngineGetViewAngles(va);
+		return QAngle(va[0], va[1], va[2]);
 	}
 
 	int PortalIsOrange(IClientEntity* ent)

--- a/spt/utils/portal_utils.cpp
+++ b/spt/utils/portal_utils.cpp
@@ -176,17 +176,19 @@ void calculateAGOffsetPortal(IClientEntity* enter_portal,
 	new_player_angles = utils::GetPlayerEyeAngles();
 }
 
-void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_origin, QAngle& new_player_angles)
+void transformThroghPortal(IClientEntity* saveglitch_portal,
+                           const Vector& start_pos,
+                           const QAngle start_angles,
+                           Vector& transformed_origin,
+                           QAngle& transformed_angles)
 {
-	const auto& player_origin = utils::GetPlayerEyePosition();
-	const auto& player_angles = utils::GetPlayerEyeAngles();
 	VMatrix matrix;
 	matrix.Identity();
 
-	if (isInfrontOfPortal(saveglitch_portal, player_origin))
+	if (isInfrontOfPortal(saveglitch_portal, start_pos))
 	{
-		new_player_origin = player_origin;
-		new_player_angles = player_angles;
+		transformed_origin = start_pos;
+		transformed_angles = start_angles;
 	}
 	else
 	{
@@ -208,14 +210,21 @@ void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_
 		}
 	}
 
-	auto eye_origin = player_origin;
+	auto eye_origin = start_pos;
 	auto new_eye_origin = matrix * eye_origin;
-	new_player_origin = new_eye_origin;
+	transformed_origin = new_eye_origin;
 
-	new_player_angles = TransformAnglesToWorldSpace(player_angles, matrix.As3x4());
-	new_player_angles.x = AngleNormalizePositive(new_player_angles.x);
-	new_player_angles.y = AngleNormalizePositive(new_player_angles.y);
-	new_player_angles.z = AngleNormalizePositive(new_player_angles.z);
+	transformed_angles = TransformAnglesToWorldSpace(start_angles, matrix.As3x4());
+	transformed_angles.x = AngleNormalizePositive(transformed_angles.x);
+	transformed_angles.y = AngleNormalizePositive(transformed_angles.y);
+	transformed_angles.z = AngleNormalizePositive(transformed_angles.z);
+}
+
+void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_origin, QAngle& new_player_angles)
+{
+	const auto& player_origin = utils::GetPlayerEyePosition();
+	const auto& player_angles = utils::GetPlayerEyeAngles();
+	transformThroghPortal(saveglitch_portal, player_origin, player_angles, new_player_origin, new_player_angles);
 }
 
 IClientEntity* getPortal(const char* arg, bool verbose)

--- a/spt/utils/portal_utils.hpp
+++ b/spt/utils/portal_utils.hpp
@@ -17,6 +17,11 @@ void calculateAGOffsetPortal(IClientEntity* enter_portal,
                              IClientEntity* exit_portal,
                              Vector& new_player_origin,
                              QAngle& new_player_angles);
+void transformThroghPortal(IClientEntity* saveglitch_portal,
+                           const Vector& start_pos,
+                           const QAngle start_angles,
+                           Vector& transformed_origin,
+                           QAngle& transformed_angles);
 void calculateSGPosition(Vector& new_player_origin, QAngle& new_player_angles);
 void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_origin, QAngle& new_player_angles);
 std::wstring calculateWillAGSG(Vector& new_player_origin, QAngle& new_player_angles);


### PR DESCRIPTION
# Portal Placement HUD
- Added `y_spt_hud_portal_placement`: Show portal placement info. (boolean/string/float)
  + Added function for color HUD text.
- Added `y_spt_draw_pp`: Draw portal placement.
- Added `y_spt_draw_pp_blue`: Draw blue portal placement.
- Added ` y_spt_draw_pp_orange`: Draw orange portal placement.
- Added  `y_spt_draw_pp_failed`: Draw failed portal placement.
- Added `y_spt_draw_pp_bbox`: Draw the bounding box of the portal placement.

# Improve Seamshot Tools
All of these apply for `y_spt_draw_seams`, `y_spt_find_seamshot`, and portal placement HUD.
- More accurate by using player eye pos instead of `spt_generic.GetCameraOrigin()`.
- Transform through portals. (i.e. works in spiderman/sg state.)
- Works during `tas_pause 1`.
- Check for server player. (Fixed crash during demo playback.)
- Use patterns instead of offset hooks. (Now works in 3420, 5135, latest steampipe!)
- Fixed incorrect `y_spt_draw_seams` behavior when `y_spt_cam_control 1`.
- Check if the player moves when setting `y_spt_find_seamshot` test points.

# Other Changes
- Added `_y_spt_overlay_no_roll`: Set overlay camera roll to 0. (Default enabled)
  + Because of the change in ent_utils for portal placement stuff, now overlay can have roll.
- Overlay now works during `tas_pause 1`.
- Fixed player model (when `y_spt_cam_control 1`) draw in the overlay.
- Added `AddEllipse()` in mesh builder for drawing portal shapes in portal placement HUD.
