### PR TITLE
Remove TraceFirePortal using non-test shot

### DIFF
--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -186,16 +186,8 @@ float Tracing::TraceTransformFirePortal(trace_t& tr,
 
 	const int PORTAL_PLACED_BY_PLAYER = 2;
 
-	return ORIG_TraceFirePortal(weapon,
-	                            0,
-	                            isPortal2,
-	                            transformedPos,
-	                            vDirection,
-	                            tr,
-	                            finalPos,
-	                            finalAngles,
-	                            PORTAL_PLACED_BY_PLAYER,
-	                            false);
+	return ORIG_TraceFirePortal(
+	    weapon, 0, isPortal2, transformedPos, vDirection, tr, finalPos, finalAngles, PORTAL_PLACED_BY_PLAYER, true);
 }
 
 #endif

--- a/spt/features/visualizations/portal_placement.cpp
+++ b/spt/features/visualizations/portal_placement.cpp
@@ -28,9 +28,9 @@ ConVar y_spt_hud_portal_placement("y_spt_hud_portal_placement",
                                   "0",
                                   FCVAR_CHEAT,
                                   "Show portal placement info\n"
-                                  "1 = Boolean result\n"
-                                  "2 = String result\n"
-                                  "3 = Float result");
+                                  "      1 = Boolean result\n"
+                                  "      2 = String result\n"
+                                  "      3 = Float result");
 ConVar y_spt_draw_pp("y_spt_draw_pp", "0", FCVAR_CHEAT, "Draw portal placement.");
 ConVar y_spt_draw_pp_blue("y_spt_draw_pp_blue", "1", FCVAR_CHEAT, "Draw blue portal placement.");
 ConVar y_spt_draw_pp_orange("y_spt_draw_pp_orange", "1", FCVAR_CHEAT, "Draw orange portal placement.");
@@ -173,6 +173,7 @@ static const wchar_t* PlacementResultToString(float placement)
 	if (placement == PORTAL_PLACEMENT_SUCCESS_OVERLAP_LINKED)
 		return L"Overlaps existing portal";
 	if (placement == PORTAL_PLACEMENT_SUCCESS_NEAR)
+		// Not possible for non-test shot
 		return L"Near existing portal";
 	if (placement == PORTAL_PLACEMENT_SUCCESS_INVALID_VOLUME)
 		return L"Invalid volume";


### PR DESCRIPTION
If are you near the portal, TracePortalFire will return 0.0265f (Near existing portal) only if the shot is not test shot,
otherwise, it will return 0.027f (Overlaps existing portal).
However, it will cancel the traveling portal shot if you look at a portal near the player before it lands.

In short, it might cause more unexpected glitches and the benefits of using it aren't much so I decide to remove it.