### PR TITLE
Disable Vcpkg

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -213,6 +213,9 @@
     <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
     <TargetName>spt-oe</TargetName>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command />


### PR DESCRIPTION
Some users (like me) has an option to enable Vcpkg, which if enabled, will cause all SPT builds to have an external absolute path reference to a minHook .dll. This causes the plugin to only be loadable if such the minHook dll exists in that specific path.