### PR TITLE
y_spt_mousemove & Correct BMS Retail VEngineClient

### DIFF
--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -109,6 +109,9 @@ ConVar y_spt_cam_path_draw("y_spt_cam_path_draw", "0", FCVAR_CHEAT, "Draws the c
 
 ConVar _y_spt_force_fov("_y_spt_force_fov", "0", 0, "Force FOV to some value.");
 
+// black mesa broke cl_mousenable and cl_mouselook so we'll need this...
+ConVar y_spt_mousemove("y_spt_mousemove", "1", 0, "Enables or disables reacting to mouse movement (for view angle changing or for movement using +strafe).");
+
 CON_COMMAND(y_spt_cam_setpos, "y_spt_cam_setpos <x> <y> <z> - Sets the camera position. (requires camera drive mode)")
 {
 	if (args.ArgC() != 4)
@@ -789,7 +792,7 @@ HOOK_THISCALL(bool, Camera, C_BasePlayer__ShouldDrawThisPlayer)
 void __fastcall Camera::HOOKED_CInput__MouseMove(void* thisptr, int edx, void* cmd)
 {
 	// Block mouse inputs and stop the game from resetting cursor pos
-	if (spt_camera.CanInput())
+	if (spt_camera.CanInput() || !y_spt_mousemove.GetBool())
 		return;
 	spt_camera.ORIG_CInput__MouseMove(thisptr, edx, cmd);
 }
@@ -811,6 +814,11 @@ void Camera::PreHook()
 
 void Camera::LoadFeature()
 {
+	if (ORIG_CInput__MouseMove)
+	{
+		InitConcommandBase(y_spt_mousemove);
+	}
+
 	if (loadingSuccessful)
 	{
 		InitConcommandBase(y_spt_cam_control);

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -159,7 +159,11 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 	interfaces::gm = gameServerFactory(INTERFACENAME_GAMEMOVEMENT, NULL);
 	interfaces::g_pCVar = g_pCVar;
 	interfaces::engine_server = (IVEngineServer*)interfaceFactory(INTERFACEVERSION_VENGINESERVER, NULL);
+#ifdef BMS
+	interfaces::engine_client = (IVEngineClient*)interfaceFactory("VEngineClient015", NULL);
+#else
 	interfaces::engine_client = (IVEngineClient*)interfaceFactory(VENGINE_CLIENT_INTERFACE_VERSION, NULL);
+#endif
 	interfaces::debugOverlay = (IVDebugOverlay*)interfaceFactory(VDEBUG_OVERLAY_INTERFACE_VERSION, NULL);
 	interfaces::materialSystem = (IMaterialSystem*)interfaceFactory(MATERIAL_SYSTEM_INTERFACE_VERSION, NULL);
 	interfaces::engine_vgui = (IEngineVGui*)interfaceFactory(VENGINE_VGUI_VERSION, NULL);


### PR DESCRIPTION
- Black Mesa Retail broke cl_mousemove and cl_mousenable in terms of using them to toggle viewangle changing.
- The VEngineClient version seen in the Black Mesa SDK is older than the current Retail versions used by runners.