### PR TITLE
Changes to HOOK macros

### DIFF
--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -204,14 +204,14 @@ void AutojumpFeature::LoadFeature()
 	}
 }
 
-void AutojumpFeature::UnloadFeature() 
+void AutojumpFeature::UnloadFeature()
 {
 	ptrCheckJumpButton = NULL;
 }
 
 static Vector old_vel(0.0f, 0.0f, 0.0f);
 
-HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton)
+IMPL_HOOK_THISCALL(AutojumpFeature, bool, CheckJumpButton, void*)
 {
 	const int IN_JUMP = (1 << 1);
 
@@ -243,7 +243,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton)
 
 	spt_autojump.insideCheckJumpButton = true;
 	old_vel = mv->m_vecVelocity;
-	bool rv = spt_autojump.ORIG_CheckJumpButton(thisptr, edx); // This function can only change the jump bit.
+	bool rv = spt_autojump.ORIG_CheckJumpButton(thisptr); // This function can only change the jump bit.
 	spt_autojump.insideCheckJumpButton = false;
 
 	if (y_spt_autojump.GetBool())
@@ -276,7 +276,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton)
 	return rv;
 }
 
-HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton_client)
+IMPL_HOOK_THISCALL(AutojumpFeature, bool, CheckJumpButton_client, void*)
 {
 	/*
 	Not sure if this gets called at all from the client dll, but
@@ -302,7 +302,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton_client)
 	spt_autojump.client_cantJumpNextTime = false;
 
 	spt_autojump.client_insideCheckJumpButton = true;
-	bool rv = spt_autojump.ORIG_CheckJumpButton_client(thisptr, edx); // This function can only change the jump bit.
+	bool rv = spt_autojump.ORIG_CheckJumpButton_client(thisptr); // This function can only change the jump bit.
 	spt_autojump.client_insideCheckJumpButton = false;
 
 	if (y_spt_autojump.GetBool())
@@ -327,7 +327,7 @@ HOOK_THISCALL(bool, AutojumpFeature, CheckJumpButton_client)
 	return rv;
 }
 
-HOOK_THISCALL(void, AutojumpFeature, FinishGravity)
+IMPL_HOOK_THISCALL(AutojumpFeature, void, FinishGravity, void*)
 {
 	if (spt_autojump.insideCheckJumpButton && y_spt_jumpboost.GetBool())
 	{
@@ -375,14 +375,14 @@ HOOK_THISCALL(void, AutojumpFeature, FinishGravity)
 		// </stolen from gamemovement.cpp>
 	}
 
-	return spt_autojump.ORIG_FinishGravity(thisptr, edx);
+	return spt_autojump.ORIG_FinishGravity(thisptr);
 }
 
-HOOK_THISCALL(void, AutojumpFeature, CPortalGameMovement__AirMove)
+IMPL_HOOK_THISCALL(AutojumpFeature, void, CPortalGameMovement__AirMove, void*)
 {
 	if (y_spt_aircontrol.GetBool())
 	{
-		return spt_autojump.ORIG_CGameMovement__AirMove(thisptr, edx);
+		return spt_autojump.ORIG_CGameMovement__AirMove(thisptr);
 	}
-	return spt_autojump.ORIG_CPortalGameMovement__AirMove(thisptr, edx);
+	return spt_autojump.ORIG_CPortalGameMovement__AirMove(thisptr);
 }

--- a/spt/features/autojump.hpp
+++ b/spt/features/autojump.hpp
@@ -33,11 +33,11 @@ protected:
 	virtual void UnloadFeature() override;
 
 private:
-	DECL_HOOK_THISCALL(bool, CheckJumpButton);
-	DECL_HOOK_THISCALL(bool, CheckJumpButton_client);
-	DECL_HOOK_THISCALL(void, FinishGravity);
-	DECL_HOOK_THISCALL(void, CPortalGameMovement__AirMove);
-	DECL_MEMBER_THISCALL(void, CGameMovement__AirMove);
+	DECL_HOOK_THISCALL(bool, CheckJumpButton, void*);
+	DECL_HOOK_THISCALL(bool, CheckJumpButton_client, void*);
+	DECL_HOOK_THISCALL(void, FinishGravity, void*);
+	DECL_HOOK_THISCALL(void, CPortalGameMovement__AirMove, void*);
+	DECL_MEMBER_THISCALL(void, CGameMovement__AirMove, void*);
 
 	bool client_cantJumpNextTime = false;
 	bool client_insideCheckJumpButton = false;

--- a/spt/features/collision_group.cpp
+++ b/spt/features/collision_group.cpp
@@ -18,7 +18,7 @@ namespace patterns
 class CollisionGroup : public FeatureWrapper<CollisionGroup>
 {
 public:
-	DECL_MEMBER_THISCALL(void, SetCollisionGroup, int collisionGroup);
+	DECL_MEMBER_THISCALL(void, SetCollisionGroup, void*, int collisionGroup);
 protected:
 	virtual bool ShouldLoadFeature() override
 	{
@@ -51,7 +51,7 @@ CON_COMMAND_F(y_spt_set_collision_group, "Set player's collision group\nUsually:
 	auto playerPtr = utils::GetServerPlayer();
 	int collide = atoi(args.Arg(1));
 
-	spt_collisiongroup.ORIG_SetCollisionGroup(playerPtr, 0, collide);
+	spt_collisiongroup.ORIG_SetCollisionGroup(playerPtr, collide);
 }
 
 void CollisionGroup::LoadFeature()

--- a/spt/features/demo.cpp
+++ b/spt/features/demo.cpp
@@ -217,11 +217,11 @@ void DemoStuff::StopAutorecord()
 	spt_demostuff.currentAutoRecordDemoNumber = 1;
 }
 
-HOOK_THISCALL(void, DemoStuff, StopRecording)
+IMPL_HOOK_THISCALL(DemoStuff, void, StopRecording, void*)
 { // This hook will get called twice per loaded save (in most games/versions, at least, according to SAR people), once with m_bLoadgame being false and the next one being true
 	if (!spt_demostuff.isAutoRecordingDemo)
 	{
-		spt_demostuff.ORIG_StopRecording(thisptr, edx);
+		spt_demostuff.ORIG_StopRecording(thisptr);
 		spt_demostuff.StopAutorecord();
 		return;
 	}
@@ -230,7 +230,7 @@ HOOK_THISCALL(void, DemoStuff, StopRecording)
 	int* pM_nDemoNumber = (int*)((uint32_t)thisptr + spt_demostuff.m_nDemoNumber_Offset);
 
 	// This will set m_nDemoNumber to 0 and m_bRecording to false
-	spt_demostuff.ORIG_StopRecording(thisptr, edx);
+	spt_demostuff.ORIG_StopRecording(thisptr);
 
 	if (spt_demostuff.isAutoRecordingDemo)
 	{
@@ -274,21 +274,21 @@ void DemoStuff::OnSignonStateSignal(void* thisptr, int edx, int state)
 	}
 }
 
-HOOK_THISCALL(bool, DemoStuff, CDemoPlayer__StartPlayback, const char* filename, bool as_time_demo)
+IMPL_HOOK_THISCALL(DemoStuff, bool, CDemoPlayer__StartPlayback, void*, const char* filename, bool as_time_demo)
 {
 	DemoStartPlaybackSignal();
-	return spt_demostuff.ORIG_CDemoPlayer__StartPlayback(thisptr, edx, filename, as_time_demo);
+	return spt_demostuff.ORIG_CDemoPlayer__StartPlayback(thisptr, filename, as_time_demo);
 }
 
-HOOK_THISCALL(const char*, DemoStuff, CDemoFile__ReadConsoleCommand)
+IMPL_HOOK_THISCALL(DemoStuff, const char*, CDemoFile__ReadConsoleCommand, void*)
 {
-	const char* cmd = spt_demostuff.ORIG_CDemoFile__ReadConsoleCommand(thisptr, edx);
+	const char* cmd = spt_demostuff.ORIG_CDemoFile__ReadConsoleCommand(thisptr);
 	if (y_spt_demo_block_cmd.GetBool())
 		return "";
 	return cmd;
 }
 
-HOOK_CDECL(void, DemoStuff, Stop)
+IMPL_HOOK_CDECL(DemoStuff, void, Stop)
 {
 	if (spt_demostuff.ORIG_Stop)
 	{

--- a/spt/features/demo.hpp
+++ b/spt/features/demo.hpp
@@ -35,9 +35,9 @@ private:
 	int m_bRecording_Offset = 0;
 	bool isAutoRecordingDemo = false;
 
-	DECL_HOOK_THISCALL(void, StopRecording);
-	DECL_HOOK_THISCALL(bool, CDemoPlayer__StartPlayback, const char* filename, bool as_time_demo);
-	DECL_HOOK_THISCALL(const char*, CDemoFile__ReadConsoleCommand);
+	DECL_HOOK_THISCALL(void, StopRecording, void*);
+	DECL_HOOK_THISCALL(bool, CDemoPlayer__StartPlayback, void*, const char* filename, bool as_time_demo);
+	DECL_HOOK_THISCALL(const char*, CDemoFile__ReadConsoleCommand, void*);
 	uintptr_t ORIG_Record = 0;
 	void OnFrame();
 	void OnSignonStateSignal(void* thisptr, int edx, int state);

--- a/spt/features/fastload.cpp
+++ b/spt/features/fastload.cpp
@@ -3,9 +3,17 @@
 #include "generic.hpp"
 #include "signals.hpp"
 #ifdef BMS
-ConVar y_spt_fast_loads("y_spt_fast_loads","1", 0,"Increases FPS and turns off rendering during loads to speed up load times. Values greater than one set fps_max to the value after loading.");
+ConVar y_spt_fast_loads(
+    "y_spt_fast_loads",
+    "1",
+    0,
+    "Increases FPS and turns off rendering during loads to speed up load times. Values greater than one set fps_max to the value after loading.");
 #else
-ConVar y_spt_fast_loads("y_spt_fast_loads","0", 0,"Increases FPS and turns off rendering during loads to potentially speed up long load times. Values greater than one set fps_max to the value after loading.");
+ConVar y_spt_fast_loads(
+    "y_spt_fast_loads",
+    "0",
+    0,
+    "Increases FPS and turns off rendering during loads to potentially speed up long load times. Values greater than one set fps_max to the value after loading.");
 #endif
 
 // Speed up loads minimally
@@ -20,7 +28,7 @@ public:
 protected:
 	virtual bool ShouldLoadFeature() override;
 	virtual void LoadFeature() override;
-	void OnLoad(void* thisptr, int edx, int state);
+	void OnLoad(void* thisptr, int state);
 	int lastSignOnState;
 };
 
@@ -46,8 +54,8 @@ void FastLoads::LoadFeature()
 	}
 }
 
-void FastLoads::OnLoad(void* thisptr, int edx, int state) {
-
+void FastLoads::OnLoad(void* thisptr, int state)
+{
 	if (state != 6 && lastSignOnState == 6)
 		fast_loads.TurnOnFastLoads();
 	else if (state == 6 && lastSignOnState != 6)
@@ -55,7 +63,7 @@ void FastLoads::OnLoad(void* thisptr, int edx, int state) {
 
 	lastSignOnState = state;
 }
-  
+
 void FastLoads::TurnOffFastLoads()
 {
 	int value = y_spt_fast_loads.GetInt();

--- a/spt/features/generic.cpp
+++ b/spt/features/generic.cpp
@@ -277,23 +277,23 @@ void __fastcall GenericFeature::HOOKED_ControllerMove(void* thisptr, int edx, fl
 	}
 }
 
-HOOK_CDECL(void, GenericFeature, SV_Frame, bool finalTick)
+IMPL_HOOK_CDECL(GenericFeature, void, SV_Frame, bool finalTick)
 {
 	SV_FrameSignal(finalTick);
 	spt_generic.ORIG_SV_Frame(finalTick);
 }
 
-HOOK_THISCALL(void, GenericFeature, ProcessMovement, void* pPlayer, void* pMove)
+IMPL_HOOK_THISCALL(GenericFeature, void, ProcessMovement, void*, void* pPlayer, void* pMove)
 {
 	ProcessMovementPre_Signal(pPlayer, pMove);
-	spt_generic.ORIG_ProcessMovement(thisptr, edx, pPlayer, pMove);
+	spt_generic.ORIG_ProcessMovement(thisptr, pPlayer, pMove);
 	ProcessMovementPost_Signal(pPlayer, pMove);
 }
 
 
-HOOK_THISCALL(void, GenericFeature, SetSignonState, int state)
+IMPL_HOOK_THISCALL(GenericFeature, void, SetSignonState, void*, int state)
 {
 	spt_generic.signOnState = state;
-	SetSignonStateSignal(thisptr, edx, state);
-	spt_generic.ORIG_SetSignonState(thisptr, edx, state);
+	SetSignonStateSignal(thisptr, state);
+	spt_generic.ORIG_SetSignonState(thisptr, state);
 }

--- a/spt/features/generic.hpp
+++ b/spt/features/generic.hpp
@@ -52,8 +52,8 @@ private:
 	static void __fastcall HOOKED_SetPaused(void* thisptr, int edx, bool paused);
 	static void __fastcall HOOKED_ControllerMove(void* thisptr, int edx, float frametime, void* cmd);
 	DECL_HOOK_CDECL(void, SV_Frame, bool finalTick);
-	DECL_HOOK_THISCALL(void, ProcessMovement, void* pPlayer, void* pMove);
-	DECL_HOOK_THISCALL(void, SetSignonState, int state);
+	DECL_HOOK_THISCALL(void, ProcessMovement, void*, void* pPlayer, void* pMove);
+	DECL_HOOK_THISCALL(void, SetSignonState, void*, int state);
 };
 
 extern GenericFeature spt_generic;

--- a/spt/features/hardlock.cpp
+++ b/spt/features/hardlock.cpp
@@ -21,7 +21,7 @@ protected:
 	virtual void InitHooks() override;
 
 private:
-	DECL_HOOK_THISCALL(void, BroadcastMessage, INetMessage& msg, IRecipientFilter& filter);
+	DECL_HOOK_THISCALL(void, BroadcastMessage, void*, INetMessage& msg, IRecipientFilter& filter) {}
 };
 
 static HardlockFix hardlock_fix;
@@ -35,7 +35,5 @@ void HardlockFix::InitHooks()
 {
 	HOOK_FUNCTION(engine, BroadcastMessage);
 }
-
-HOOK_THISCALL(void, HardlockFix, BroadcastMessage, INetMessage& msg, IRecipientFilter& filter) {}
 
 #endif

--- a/spt/features/hud.cpp
+++ b/spt/features/hud.cpp
@@ -110,7 +110,7 @@ void HUDFeature::InitHooks()
 }
 
 #ifdef BMS
-#define CALL(func_name, ...) ORIG_ISurface__##func_name(interfaces::surface, 0, __VA_ARGS__); 
+#define CALL(func_name, ...) ORIG_ISurface__##func_name(interfaces::surface, __VA_ARGS__); 
 #else
 #define CALL(func_name, ...) interfaces::surface->##func_name(__VA_ARGS__);
 #endif
@@ -288,7 +288,7 @@ void HUDFeature::DrawHUD(bool overlay)
 		return;
 
 #ifndef OE
-	ORIG_CMatSystemSurface__StartDrawing(interfaces::surface, 0);
+	ORIG_CMatSystemSurface__StartDrawing(interfaces::surface);
 #endif
 
 	try
@@ -333,11 +333,11 @@ void HUDFeature::DrawHUD(bool overlay)
 	}
 
 #ifndef OE
-	ORIG_CMatSystemSurface__FinishDrawing(interfaces::surface, 0);
+	ORIG_CMatSystemSurface__FinishDrawing(interfaces::surface);
 #endif
 }
 
-HOOK_THISCALL(void, HUDFeature, CEngineVGui__Paint, PaintMode_t mode)
+IMPL_HOOK_THISCALL(HUDFeature, void, CEngineVGui__Paint, void*, PaintMode_t mode)
 {
 	if (spt_hud.loadingSuccessful && mode & PAINT_INGAMEPANELS)
 	{
@@ -364,7 +364,7 @@ HOOK_THISCALL(void, HUDFeature, CEngineVGui__Paint, PaintMode_t mode)
 		spt_hud.DrawHUD(false);
 #endif
 	}
-	spt_hud.ORIG_CEngineVGui__Paint(thisptr, edx, mode);
+	spt_hud.ORIG_CEngineVGui__Paint(thisptr, mode);
 }
 
 HudCallback::HudCallback(std::string key, std::function<void()> draw, std::function<bool()> shouldDraw, bool overlay)

--- a/spt/features/hud.hpp
+++ b/spt/features/hud.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #define SPT_HUD_ENABLED
 
 #include <functional>
@@ -69,29 +68,41 @@ private:
 	ConVar* cl_showpos = nullptr;
 	ConVar* cl_showfps = nullptr;
 
-	DECL_HOOK_THISCALL(void, CEngineVGui__Paint, PaintMode_t mode);
-	DECL_MEMBER_THISCALL(void, CMatSystemSurface__StartDrawing);
-	DECL_MEMBER_THISCALL(void, CMatSystemSurface__FinishDrawing);
+	DECL_HOOK_THISCALL(void, CEngineVGui__Paint, void*, PaintMode_t mode);
+	DECL_MEMBER_THISCALL(void, CMatSystemSurface__StartDrawing, void*);
+	DECL_MEMBER_THISCALL(void, CMatSystemSurface__FinishDrawing, void*);
 
 #ifdef BMS
-	DECL_MEMBER_THISCALL(void, ISurface__DrawPrintText, const wchar_t* text, int textLen, vgui::FontDrawType_t drawType);
-	DECL_MEMBER_THISCALL(void, ISurface__DrawPrintText_BMSLatest, const wchar_t* text, int textLen, vgui::FontDrawType_t drawType, char unkBoolVal);
-	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTextPos, int x, int y);
-	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTextFont, vgui::HFont font);
-	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTextColor, int r, int g, int b, int a);
-	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTexture, int id);
-	DECL_MEMBER_THISCALL(int, ISurface__GetFontTall, vgui::HFont font);
-	DECL_MEMBER_THISCALL(void, ISurface__AddCustomFontFile, const char* fontName, const char* fontFileName);
+	DECL_MEMBER_THISCALL(void,
+	                     ISurface__DrawPrintText,
+	                     void*,
+	                     const wchar_t* text,
+	                     int textLen,
+	                     vgui::FontDrawType_t drawType);
+
+	DECL_MEMBER_THISCALL(void,
+	                     ISurface__DrawPrintText_BMSLatest,
+	                     void*,
+	                     const wchar_t* text,
+	                     int textLen,
+	                     vgui::FontDrawType_t drawType,
+	                     char unkBoolVal);
+
+	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTextPos, void*, int x, int y);
+	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTextFont, void*, vgui::HFont font);
+	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTextColor, void*, int r, int g, int b, int a);
+	DECL_MEMBER_THISCALL(void, ISurface__DrawSetTexture, void*, int id);
+	DECL_MEMBER_THISCALL(int, ISurface__GetFontTall, void*, vgui::HFont font);
+	DECL_MEMBER_THISCALL(void, ISurface__AddCustomFontFile, void*, const char* fontName, const char* fontFileName);
 
 	std::vector<patterns::MatchedPattern> MATCHES_ISurface__DrawSetTextFont;
 	std::vector<patterns::MatchedPattern> MATCHES_ISurface__GetFontTall;
 
 	bool isLatest = false;
-#endif	
+#endif
 
 	void DrawHUD(bool overlay);
 	void vDrawTopHudElement(Color color, const wchar* format, va_list args);
 };
 
 extern HUDFeature spt_hud;
-

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -71,7 +71,7 @@ protected:
 	virtual void UnloadFeature() override;
 
 private:
-	DECL_HOOK_THISCALL(void, DecodeUserCmdFromBuffer, bf_read& buf, int sequence_number);
+	DECL_HOOK_THISCALL(void, DecodeUserCmdFromBuffer, void*, bf_read& buf, int sequence_number);
 	void CreateMove(uintptr_t pCmd);
 	void DrawRectAndCenterTxt(Color buttonColor,
 	                          int x0,
@@ -802,9 +802,9 @@ void InputHud::DrawButton(Button button)
 	                     button.text.c_str());
 }
 
-HOOK_THISCALL(void, InputHud, DecodeUserCmdFromBuffer, bf_read& buf, int sequence_number)
+IMPL_HOOK_THISCALL(InputHud, void, DecodeUserCmdFromBuffer, void*, bf_read& buf, int sequence_number)
 {
-	spt_ihud.ORIG_DecodeUserCmdFromBuffer(thisptr, edx, buf, sequence_number);
+	spt_ihud.ORIG_DecodeUserCmdFromBuffer(thisptr, buf, sequence_number);
 
 	auto m_pCommands =
 	    *reinterpret_cast<uintptr_t*>(reinterpret_cast<uintptr_t>(thisptr) + spt_playerio.offM_pCommands);

--- a/spt/features/nosleep.cpp
+++ b/spt/features/nosleep.cpp
@@ -18,7 +18,7 @@ protected:
 	virtual void UnloadFeature() override;
 
 private:
-	DECL_HOOK_THISCALL(void, CInputSystem__SleepUntilInput, int nMaxSleepTimeMS);
+	DECL_HOOK_THISCALL(void, CInputSystem__SleepUntilInput, void*, int nMaxSleepTimeMS);
 };
 
 static NoSleepFeature spt_nosleep;
@@ -52,9 +52,9 @@ void NoSleepFeature::LoadFeature()
 
 void NoSleepFeature::UnloadFeature() {}
 
-HOOK_THISCALL(void, NoSleepFeature, CInputSystem__SleepUntilInput, int nMaxSleepTimeMS)
+IMPL_HOOK_THISCALL(NoSleepFeature, void, CInputSystem__SleepUntilInput, void*, int nMaxSleepTimeMS)
 {
 	if (y_spt_focus_nosleep.GetBool())
 		nMaxSleepTimeMS = 0;
-	spt_nosleep.ORIG_CInputSystem__SleepUntilInput(thisptr, edx, nMaxSleepTimeMS);
+	spt_nosleep.ORIG_CInputSystem__SleepUntilInput(thisptr, nMaxSleepTimeMS);
 }

--- a/spt/features/overlay.cpp
+++ b/spt/features/overlay.cpp
@@ -141,13 +141,18 @@ void Overlay::LoadFeature()
 #endif
 }
 
-HOOK_THISCALL(void, Overlay, CViewRender__RenderView, CViewSetup* cameraView, int nClearFlags, int whatToDraw)
+IMPL_HOOK_THISCALL(Overlay,
+                   void,
+                   CViewRender__RenderView,
+                   void*,
+                   CViewSetup* cameraView,
+                   int nClearFlags,
+                   int whatToDraw)
 {
-
 #ifdef SPT_HUD_TEXTONLY
 
 	spt_hud.renderView = cameraView;
-	spt_overlay.ORIG_CViewRender__RenderView(thisptr, edx, cameraView, nClearFlags, whatToDraw);
+	spt_overlay.ORIG_CViewRender__RenderView(thisptr, cameraView, nClearFlags, whatToDraw);
 
 #else
 
@@ -194,7 +199,7 @@ HOOK_THISCALL(void, Overlay, CViewRender__RenderView, CViewSetup* cameraView, in
 	else
 		ovr.mainView = cameraView;
 
-	ovr.ORIG_CViewRender__RenderView(thisptr, edx, cameraView, nClearFlags, whatToDraw);
+	ovr.ORIG_CViewRender__RenderView(thisptr, cameraView, nClearFlags, whatToDraw);
 	callDepth--;
 	if (callDepth == 1)
 		ovr.renderingOverlay = false;
@@ -202,12 +207,11 @@ HOOK_THISCALL(void, Overlay, CViewRender__RenderView, CViewSetup* cameraView, in
 #endif
 }
 
-HOOK_THISCALL(void, Overlay, CViewRender__RenderView_4044, CViewSetup* cameraView, bool drawViewmodel)
+IMPL_HOOK_THISCALL(Overlay, void, CViewRender__RenderView_4044, void*, CViewSetup* cameraView, bool drawViewmodel)
 {
 	spt_hud.renderView = cameraView;
-	spt_overlay.ORIG_CViewRender__RenderView_4044(thisptr, edx, cameraView, drawViewmodel);
+	spt_overlay.ORIG_CViewRender__RenderView_4044(thisptr, cameraView, drawViewmodel);
 }
-
 
 #ifndef SPT_HUD_TEXTONLY
 

--- a/spt/features/overlay.hpp
+++ b/spt/features/overlay.hpp
@@ -19,15 +19,24 @@ enum SkyboxVisibility_t;
 // Overlay hook stuff, could combine with overlay renderer as well
 class Overlay : public FeatureWrapper<Overlay>
 {
-
 public:
 	bool renderingOverlay = false;
 	// these point to the call stack, only valid while we're in RenderView()
 	CViewSetup* mainView = nullptr;
 	CViewSetup* overlayView = nullptr;
 
-	DECL_HOOK_THISCALL(void, CViewRender__RenderView, CViewSetup* cameraView, int nClearFlags, int whatToDraw);
-	DECL_HOOK_THISCALL(void, CViewRender__RenderView_4044, CViewSetup* cameraView, bool drawViewmodel);
+	DECL_HOOK_THISCALL(void,
+	                   CViewRender__RenderView,
+	                   void*,
+	                   CViewSetup* cameraView,
+	                   int nClearFlags,
+	                   int whatToDraw);
+
+	DECL_HOOK_THISCALL(void,
+	                   CViewRender__RenderView_4044,
+	                   void*,
+	                   CViewSetup* cameraView,
+	                   bool drawViewmodel);
 
 protected:
 	virtual void InitHooks() override;

--- a/spt/features/rng.cpp
+++ b/spt/features/rng.cpp
@@ -78,7 +78,7 @@ void RNGStuff::LoadFeature()
 
 void RNGStuff::UnloadFeature() {}
 
-HOOK_CDECL(void, RNGStuff, SetPredictionRandomSeed, void* usercmd)
+IMPL_HOOK_CDECL(RNGStuff, void, SetPredictionRandomSeed, void* usercmd)
 {
 	CUserCmd* ptr = reinterpret_cast<CUserCmd*>(usercmd);
 	if (ptr)
@@ -90,13 +90,18 @@ HOOK_CDECL(void, RNGStuff, SetPredictionRandomSeed, void* usercmd)
 }
 
 #ifdef OE
-HOOK_THISCALL(void, RNGStuff, CBasePlayer__InitVCollision)
+IMPL_HOOK_THISCALL(RNGStuff, void, CBasePlayer__InitVCollision, void*)
 {
-	spt_rng.ORIG_CBasePlayer__InitVCollision(thisptr, edx);
+	spt_rng.ORIG_CBasePlayer__InitVCollision(thisptr);
 #else
-HOOK_THISCALL(void, RNGStuff, CBasePlayer__InitVCollision, const Vector& vecAbsOrigin, const Vector& vecAbsVelocity)
+IMPL_HOOK_THISCALL(RNGStuff,
+                   void,
+                   CBasePlayer__InitVCollision,
+                   void*,
+                   const Vector& vecAbsOrigin,
+                   const Vector& vecAbsVelocity)
 {
-	spt_rng.ORIG_CBasePlayer__InitVCollision(thisptr, edx, vecAbsOrigin, vecAbsVelocity);
+	spt_rng.ORIG_CBasePlayer__InitVCollision(thisptr, vecAbsOrigin, vecAbsVelocity);
 #endif
 	// set the seed before any vphys sim happens, don't use GetInt() since that's casted from a float
 	if (y_spt_set_ivp_seed_on_load.GetString()[0] != '\0')

--- a/spt/features/rng.hpp
+++ b/spt/features/rng.hpp
@@ -20,9 +20,9 @@ protected:
 private:
 	DECL_HOOK_CDECL(void, SetPredictionRandomSeed, void* usercmd);
 #ifdef OE
-	DECL_HOOK_THISCALL(void, CBasePlayer__InitVCollision);
+	DECL_HOOK_THISCALL(void, CBasePlayer__InitVCollision, void*);
 #else
-	DECL_HOOK_THISCALL(void, CBasePlayer__InitVCollision, const Vector& vecAbsOrigin, const Vector& vecAbsVelocity);
+	DECL_HOOK_THISCALL(void, CBasePlayer__InitVCollision, void*, const Vector& vecAbsOrigin, const Vector& vecAbsVelocity);
 #endif
 
 	uint32_t* IVP_RAND_SEED = nullptr;

--- a/spt/features/saveloads.cpp
+++ b/spt/features/saveloads.cpp
@@ -35,7 +35,7 @@ Usage: \n\
 	}
 
 	int type = -1;
-	for (int i = 0; i < _saveloadTypes.size(); i++)
+	for (int i = 0; i < (int)_saveloadTypes.size(); i++)
 	{
 		if (strcmp(args.Arg(1), _saveloadTypes[i]) == 0)
 		{

--- a/spt/features/tas_new_record.cpp
+++ b/spt/features/tas_new_record.cpp
@@ -26,7 +26,7 @@ namespace patterns
 class TASRecordFeature : public FeatureWrapper<TASRecordFeature>
 {
 public:
-	DECL_HOOK_THISCALL(bool, CCommandBuffer__DequeueNextCommand);
+	DECL_HOOK_THISCALL(bool, CCommandBuffer__DequeueNextCommand, CCommandBuffer*);
 
 	bool recording = false;
 	int currentTick = 0;
@@ -313,14 +313,13 @@ void TASRecordFeature::LoadFeature()
 
 void TASRecordFeature::UnloadFeature() {}
 
-HOOK_THISCALL(bool, TASRecordFeature, CCommandBuffer__DequeueNextCommand)
+IMPL_HOOK_THISCALL(TASRecordFeature, bool, CCommandBuffer__DequeueNextCommand, CCommandBuffer*)
 {
-	bool rval = spt_tas_record.ORIG_CCommandBuffer__DequeueNextCommand(thisptr, edx);
+	bool rval = spt_tas_record.ORIG_CCommandBuffer__DequeueNextCommand(thisptr);
 
 	if (spt_tas_record.recording && rval)
 	{
-		CCommandBuffer* ptr = reinterpret_cast<CCommandBuffer*>(thisptr);
-		CCommand& cmd = const_cast<CCommand&>(ptr->GetCommand());
+		CCommand& cmd = const_cast<CCommand&>(thisptr->GetCommand());
 		if (IsRecordable(cmd))
 		{
 			RemoveKeycodes(cmd);

--- a/spt/features/visualizations/renderer/mesh_builder.hpp
+++ b/spt/features/visualizations/renderer/mesh_builder.hpp
@@ -187,7 +187,11 @@ private:
 	inline static bool cachedOffset = false;
 	inline static int cached_phys_obj_off;
 
-	DECL_MEMBER_THISCALL(int, CPhysicsCollision__CreateDebugMesh, const CPhysCollide* pCollide, Vector** outVerts);
+	DECL_MEMBER_THISCALL(int,
+	                     CPhysicsCollision__CreateDebugMesh,
+	                     class IPhysicsCollision*,
+	                     const CPhysCollide* pCollide,
+	                     Vector** outVerts);
 };
 
 inline CreateCollideFeature spt_collideToMesh;

--- a/spt/features/visualizations/renderer/mesh_renderer.hpp
+++ b/spt/features/visualizations/renderer/mesh_renderer.hpp
@@ -107,15 +107,20 @@ private:
 	} viewInfo;
 
 	DECL_MEMBER_CDECL(void, OnRenderStart);
-	DECL_HOOK_THISCALL(void, CRendering3dView__DrawOpaqueRenderables, int param);
-	DECL_HOOK_THISCALL(void, CRendering3dView__DrawTranslucentRenderables, bool bInSkybox, bool bShadowDepth);
+	DECL_HOOK_THISCALL(void, CRendering3dView__DrawOpaqueRenderables, CRendering3dView*, int param);
+
+	DECL_HOOK_THISCALL(void,
+	                   CRendering3dView__DrawTranslucentRenderables,
+	                   CRendering3dView*,
+	                   bool bInSkybox,
+	                   bool bShadowDepth);
 
 	bool Works() const;
 	void FrameCleanup();
 	void OnRenderViewPre_Signal(void* thisptr, CViewSetup* cameraView);
 	void SetupViewInfo(CRendering3dView* rendering3dView);
-	void OnDrawOpaques(void* renderingView);
-	void OnDrawTranslucents(void* renderingView);
+	void OnDrawOpaques(CRendering3dView* renderingView);
+	void OnDrawTranslucents(CRendering3dView* renderingView);
 };
 
 inline MeshRendererFeature spt_meshRenderer;

--- a/spt/features/visualizations/renderer/source files/create_collide.cpp
+++ b/spt/features/visualizations/renderer/source files/create_collide.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<Vector> CreateCollideFeature::CreateCollideMesh(const CPhysColli
 		return nullptr;
 	}
 	Vector* outVerts;
-	outNumTris = spt_collideToMesh.ORIG_CPhysicsCollision__CreateDebugMesh(nullptr, 0, pCollide, &outVerts) / 3;
+	outNumTris = spt_collideToMesh.ORIG_CPhysicsCollision__CreateDebugMesh(nullptr, pCollide, &outVerts) / 3;
 	return std::unique_ptr<Vector>(outVerts);
 }
 

--- a/spt/utils/signals.cpp
+++ b/spt/utils/signals.cpp
@@ -16,7 +16,7 @@ Gallant::Signal1<bool> SV_FrameSignal;
 Gallant::Signal2<void*, void*> ProcessMovementPost_Signal;
 Gallant::Signal2<void*, void*> ProcessMovementPre_Signal;
 Gallant::Signal2<void*, CViewSetup*> RenderViewPre_Signal;
-Gallant::Signal3<void*, int, int> SetSignonStateSignal;
+Gallant::Signal2<void*, int> SetSignonStateSignal;
 
 
 // Plugin callbacks

--- a/spt/utils/signals.hpp
+++ b/spt/utils/signals.hpp
@@ -20,7 +20,7 @@ extern Gallant::Signal1<bool> SV_FrameSignal;
 extern Gallant::Signal2<void*, void*> ProcessMovementPost_Signal;
 extern Gallant::Signal2<void*, void*> ProcessMovementPre_Signal;
 extern Gallant::Signal2<void*, CViewSetup*> RenderViewPre_Signal;
-extern Gallant::Signal3<void*, int, int> SetSignonStateSignal;
+extern Gallant::Signal2<void*, int> SetSignonStateSignal;
 
 // Plugin callbacks
 extern Gallant::Signal0<void> TickSignal;

--- a/thirdparty/json.hpp
+++ b/thirdparty/json.hpp
@@ -36,7 +36,7 @@ SOFTWARE.
 
 #include <algorithm> // all_of, find, for_each
 #include <cassert> // assert
-#include <ciso646> // and, not, or
+// #include <ciso646> // and, not, or
 #include <cstddef> // nullptr_t, ptrdiff_t, size_t
 #include <functional> // hash, less
 #include <initializer_list> // initializer_list
@@ -58,7 +58,7 @@ SOFTWARE.
 
 #include <algorithm> // transform
 #include <array> // array
-#include <ciso646> // and, not
+// #include <ciso646> // and, not
 #include <forward_list> // forward_list
 #include <iterator> // inserter, front_inserter, end
 #include <map> // map
@@ -2178,7 +2178,7 @@ class other_error : public exception
 // #include <nlohmann/detail/meta/cpp_future.hpp>
 
 
-#include <ciso646> // not
+// #include <ciso646> // not
 #include <cstddef> // size_t
 #include <type_traits> // conditional, enable_if, false_type, integral_constant, is_constructible, is_integral, is_same, remove_cv, remove_reference, true_type
 
@@ -2243,7 +2243,7 @@ constexpr T static_const<T>::value;
 // #include <nlohmann/detail/meta/type_traits.hpp>
 
 
-#include <ciso646> // not
+// #include <ciso646> // not
 #include <limits> // numeric_limits
 #include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
 #include <utility> // declval
@@ -2814,7 +2814,7 @@ struct is_constructible_tuple<T1, std::tuple<Args...>> : conjunction<std::is_con
 
 
 #include <array> // array
-#include <ciso646> // and
+// #include <ciso646> // and
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t
 #include <string> // string
@@ -3263,7 +3263,7 @@ constexpr const auto& from_json = detail::static_const<detail::from_json_fn>::va
 
 
 #include <algorithm> // copy
-#include <ciso646> // or, and, not
+// #include <ciso646> // or, and, not
 #include <iterator> // begin, end
 #include <string> // string
 #include <tuple> // tuple, get
@@ -9299,7 +9299,7 @@ template<typename BasicJsonType> struct internal_iterator
 // #include <nlohmann/detail/iterators/iter_impl.hpp>
 
 
-#include <ciso646> // not
+// #include <ciso646> // not
 #include <iterator> // iterator, random_access_iterator_tag, bidirectional_iterator_tag, advance, next
 #include <type_traits> // conditional, is_const, remove_const
 
@@ -12634,7 +12634,7 @@ class binary_writer
 #include <algorithm> // reverse, remove, fill, find, none_of
 #include <array> // array
 #include <cassert> // assert
-#include <ciso646> // and, or
+// #include <ciso646> // and, or
 #include <clocale> // localeconv, lconv
 #include <cmath> // labs, isfinite, isnan, signbit
 #include <cstddef> // size_t, ptrdiff_t
@@ -12650,7 +12650,7 @@ class binary_writer
 
 #include <array> // array
 #include <cassert> // assert
-#include <ciso646> // or, and, not
+// #include <ciso646> // or, and, not
 #include <cmath>   // signbit, isfinite
 #include <cstdint> // intN_t, uintN_t
 #include <cstring> // memcpy, memmove


### PR DESCRIPTION
HOOK macros:
 - you can now specify the thisptr type for `__thiscall` functions, it's no longer limited to `void*`
 - I removed the edx parameter from the thiscall functions by making the ORIG function `__thiscall` (as far as I tested everything still works)
 - the parameter order more closely matches the in-game deceleration order
 - renamed e.g. `HOOK_CDECL` to `IMPL_HOOK_CDECL`

I only changed this in places where the HOOK macros were used, I did not change any old-style manually typedef'd function pointers.

Example:
```c
// game function:
bool CCommandBuffer::DequeueNextCommand() {...}

// spt, what we did before:
HOOK_THISCALL(bool, TASRecordFeature, CCommandBuffer__DequeueNextCommand)
{
    bool rval = spt_tas_record.ORIG_CCommandBuffer__DequeueNextCommand(thisptr, edx);
    CCommandBuffer* ptr = reinterpret_cast<CCommandBuffer*>(thisptr);
    CCommand& cmd = const_cast<CCommand&>(ptr->GetCommand());
    ...
}

// spt, what we can do now:
IMPL_HOOK_THISCALL(TASRecordFeature, bool, CCommandBuffer__DequeueNextCommand, CCommandBuffer*)
{
    bool rval = spt_tas_record.ORIG_CCommandBuffer__DequeueNextCommand(thisptr); // no edx param
    CCommand& cmd = const_cast<CCommand&>(thisptr->GetCommand()); // can use thisptr directly
    ...
}
```

Other changes:
 - remove unsigned/signed warning in `saveloads.cpp`
 - commented out `#include <ciso646>` in `thirdpart/json.hpp` which caused a deprecated warning (this can also be fixed by updating json.hpp)
 - removed edx param from `SetSignonStateSignal`
 - ran clang-format on `features/fastload.cpp`