### PR TITLE
Fix and enhance camera control

### DIFF
--- a/spt/features/demo.cpp
+++ b/spt/features/demo.cpp
@@ -45,7 +45,7 @@ namespace patterns
 	PATTERNS(
 	    CDemoPlayer__StartPlayback,
 	    "5135",
-	    "83 EC 08 56 8B F1 8B 86 ?? ?? ?? ?? 8B 90 ?? ?? ?? ?? 8D 8E ?? ?? ?? ?? 57 FF D2",
+	    "53 55 56 57 8B F1 E8 ?? ?? ?? ?? 8B 3D ?? ?? ?? ??",
 	    "7197370",
 	    "55 8B EC 53 56 57 8B F9 C6 87 ?? ?? ?? ?? 01 E8 ?? ?? ?? ?? 8B 35 ?? ?? ?? ?? 68 ?? ?? ?? ?? 6A 00 C7 05 ?? ?? ?? ?? FF FF FF FF");
 	PATTERNS(CDemoFile__ReadConsoleCommand, "5135", "68 00 04 00 00 68 ?? ?? ?? ?? E8 ?? ?? ?? ?? B8 ?? ?? ?? ??");
@@ -53,7 +53,7 @@ namespace patterns
 
 void DemoStuff::InitHooks()
 {
-	HOOK_FUNCTION(engine, StopRecording);;
+	HOOK_FUNCTION(engine, StopRecording);
 	HOOK_FUNCTION(engine, CDemoPlayer__StartPlayback);
 	HOOK_FUNCTION(engine, Stop);
 	HOOK_FUNCTION(engine, CDemoFile__ReadConsoleCommand);
@@ -67,7 +67,6 @@ bool DemoStuff::ShouldLoadFeature()
 
 void DemoStuff::PreHook()
 {
-
 	// CDemoRecorder::StopRecording
 	if (ORIG_StopRecording)
 	{
@@ -149,7 +148,7 @@ void DemoStuff::PreHook()
 			Warning(
 			    "Record pattern had no matching clause for catching the demoplayer. y_spt_pause_demo_on_tick unavailable.\n");
 
-		DevMsg("Found demoplayer at %p, record is at %p.\n", pDemoplayer, ORIG_Record);
+		DevMsg("Found demoplayer at %p, record is at %p.\n", pDemoplayer, (void*)ORIG_Record);
 
 		if (ORIG_CDemoPlayer__StartPlayback)
 			DemoStartPlaybackSignal.Works = true;
@@ -276,8 +275,9 @@ void DemoStuff::OnSignonStateSignal(void* thisptr, int edx, int state)
 
 IMPL_HOOK_THISCALL(DemoStuff, bool, CDemoPlayer__StartPlayback, void*, const char* filename, bool as_time_demo)
 {
+	bool result = spt_demostuff.ORIG_CDemoPlayer__StartPlayback(thisptr, filename, as_time_demo);
 	DemoStartPlaybackSignal();
-	return spt_demostuff.ORIG_CDemoPlayer__StartPlayback(thisptr, filename, as_time_demo);
+	return result;
 }
 
 IMPL_HOOK_THISCALL(DemoStuff, const char*, CDemoFile__ReadConsoleCommand, void*)

--- a/spt/patterns_archive.cpp
+++ b/spt/patterns_archive.cpp
@@ -39,7 +39,7 @@ namespace patterns
 	    "BMS-0.9",
 	    "55 8B EC 8B 0D ?? ?? ?? ?? 56 8B 75 ?? 56 8B 01 8B 40 ?? FF D0 84 C0 75 ?? 56 68 ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 83 C4 08 5E 5D C3");
 
-		// Search for "FinishedMapLoad", one of two references to address
+	// Search for "FinishedMapLoad", one of two references to address
 	PATTERNS(CL_FullyConnected,
 	         "BMS-0.9",
 	         "55 8B EC 81 EC 14 04 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 ?? 56 68",
@@ -54,13 +54,13 @@ namespace patterns
 	         "80 3D ?? ?? ?? ?? 00 0F 85 ?? ?? ?? ?? E8 ?? ?? ?? ?? 6A 00 8B C8 8B 10 FF 92",
 	         "7671541",
 	         "80 3D ?? ?? ?? ?? 00 0F 85 ?? ?? ?? ?? E8 ?? ?? ?? ?? 6A 00 8B C8 8B 10 FF 92");
-		// Search for "Disconnect: %s\n", func below string
+	// Search for "Disconnect: %s\n", func below string
 	PATTERNS(Host_Disconnect,
 	         "BMS-0.9",
 	         "55 8B EC 80 3D ?? ?? ?? ?? 00 75 ?? FF 75 ?? B9 ?? ?? ?? ?? FF 75 ?? E8",
 	         "5135",
 	         "80 3D ?? ?? ?? ?? 00 75 ?? 8B 44 24 ?? 50 B9 ?? ?? ?? ?? E8 ?? ?? ?? ?? 6A 00 E8");
-		// Search for "Only the server may changelevel\n"
+	// Search for "Only the server may changelevel\n"
 	PATTERNS(Host_Changelevel,
 	         "BMS-0.9",
 	         "55 8B EC 81 EC 7C 03 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 ?? 83 3D ?? ?? ?? ?? 02");
@@ -121,6 +121,13 @@ namespace patterns
 	         "55 8B EC 56 FF 75 ?? 8B F1 8D 8E ?? ?? ?? ??");
 	PATTERNS(CDebugViewRender__Draw2DDebuggingInfo, "5135", "A1 ?? ?? ?? ?? 81 EC 9C 00 00 00");
 	PATTERNS(DecodeUserCmdFromBuffer, "dmomm", "81 EC BC 00 00 00 56 8B F1 8D 4C 24 ?? E8 ?? ?? ?? ?? 8D 44 24 ??");
+	PATTERNS(ClientModeShared__CreateMove,
+	         "5135",
+	         "E8 ?? ?? ?? ?? 85 C0 75 ?? B0 01 C2 08 00 8B 4C 24 ?? D9 44 24 ?? 8B 10",
+	         "1910503",
+	         "55 8B EC E8 ?? ?? ?? ?? 85 C0 75 ?? B0 01 5D C2 08 00 8B 4D ?? 8B 10",
+	         "7197370",
+	         "55 8B EC E8 ?? ?? ?? ?? 8B C8 85 C9 75 ?? B0 01 5D C2 08 00 8B 01");
 
 	/****************************** SERVER ******************************/
 
@@ -191,7 +198,7 @@ namespace patterns
 	         "83 EC 0C 56 8B F1 8B 56 ?? D9 82 ?? ?? ?? ?? 8D 8A ?? ?? ?? ??");
 
 	/****************************** VPHYSICS ******************************/
-	
+
 	PATTERNS(CPhysicsObject__GetPosition,
 	         "5135",
 	         "8B 49 08 81 EC 80 00 00 00 8D 04 24 50 E8 ?? ?? ?? ?? 8B 84 24 84 00 00 00 85 C0",
@@ -199,7 +206,6 @@ namespace patterns
 	         "55 8B EC 8B 49 08 81 EC 80 00 00 00 8D 45 80 50 E8 ?? ?? ?? ?? 8B 45 08 85 C0",
 	         "7462488",
 	         "55 8B EC 8B 49 ?? 8D 45 ?? 81 EC 80 00 00 00 50 E8 ?? ?? ?? ?? 8B 45 ??");
-
 
 	/****************************** DATACACHE ******************************/
 


### PR DESCRIPTION
![Screenshot 2023-02-15 232658](https://user-images.githubusercontent.com/72735402/219275235-d5321664-17e3-4016-93f0-e152bb38bbdd.png)

- Add `y_spt_cam_drive_speed`: Speed for moving in camera drive mode
- Add `y_spt_cam_path_interp`: More interpolation type

- Fix incorrect time offset when playing cinematic mode
  - Fix calculating the time offset at incorrect place
  - Fix hooking incorrect StartPlayBack in 5135
- Better looking interpolation path render
- Use MeshBuilder to render interpolation path
- Use PostButtonPressed/ReleasedEvent to block inputs
  - The old one uses CreateMove which will block all inputs including TAS inputs
  - The new one only blocks keyboard inputs, so now it's possible to use drive mode while playing the TAS script
- Rename some variables to camelCase
- `y_spt_cam_path_setkf`, `y_spt_cam_path_rmkf`, and `y_spt_cam_path_clear` can now be use when not playing demo.

Known problems:
- PostButtonPressed/ReleasedEvent cannot block mouse button inputs (mouse1~5, mwheelup/down)
- Ticks for interpolation path are still using debugOverlay. Those texts can sometimes stuck on the screen when `y_spt_cam_path_draw 0`. 