### PR TITLE
Disable autocomplete feature in Black Mesa

### DIFF
--- a/spt/features/autocomplete.cpp
+++ b/spt/features/autocomplete.cpp
@@ -1,4 +1,7 @@
 #include "stdafx.hpp"
+
+#ifndef BMS
+
 #include "..\feature.hpp"
 #include "..\utils\convar.hpp"
 #include "..\utils\game_detection.hpp"
@@ -83,3 +86,5 @@ void AutocompleteFeature::UnloadFeature()
 	if (execCommand)
 		execCommand->m_fnCompletionCallback = ORIG_execCompleteFunc;
 }
+
+#endif // !BMS


### PR DESCRIPTION
Autocomplete feature is broken in Black Mesa (0.9 and Definitive Edition) so I decided to disable it as per the feature creator @evanlin96069 's comment.

![image](https://user-images.githubusercontent.com/72971433/226209980-16542d5e-c8f7-4881-bb7b-896dfe037ae0.png)
