### PR TITLE
Sort datamap fields by offset

### DIFF
--- a/spt/features/ent_props.cpp
+++ b/spt/features/ent_props.cpp
@@ -64,7 +64,7 @@ void EntProps::WalkDatamap(std::string key)
 	if (result)
 		result->ExploreOffsets();
 	else
-		Msg("No datamap found with name %s\n", key.c_str());
+		Msg("No datamap found with name \"%s\"\n", key.c_str());
 }
 
 void EntProps::PrintDatamaps()

--- a/spt/utils/datamap_wrapper.cpp
+++ b/spt/utils/datamap_wrapper.cpp
@@ -34,42 +34,47 @@ namespace utils
 
 	void DatamapWrapper::ExploreOffsets()
 	{
-		auto map = _serverMap;
-		if (map)
+		for (int i = 0; i < 2; i++)
 		{
-			Msg("%s server map:\n", map->dataClassName);
-			ExploreOffsetsHelper(map, 0, "");
-			Msg("\n");
-		}
-		map = _clientMap;
-		if (map)
-		{
-			Msg("%s client map:\n", map->dataClassName);
-			ExploreOffsetsHelper(map, 0, "");
+			auto map = i == 0 ? _serverMap : _clientMap;
+			if (!map)
+				continue;
+
+			std::vector<std::pair<int, std::string>> vec;
+			ExploreOffsetsHelper(vec, map, 0, "");
+			std::sort(vec.begin(), vec.end());
+
+			Msg("%s %s map:\n", map->dataClassName, i == 0 ? "server" : "client");
+			for (const auto& [off, str] : vec)
+				Msg("\t%s : %d\n", str.c_str(), off);
 			Msg("\n");
 		}
 	}
 
-	void DatamapWrapper::ExploreOffsetsHelper(datamap_t* map, int prefixOffset, std::string prefix)
+	void DatamapWrapper::ExploreOffsetsHelper(std::vector<std::pair<int, std::string>>& outVec,
+	                                          datamap_t* map,
+	                                          int prefixOffset,
+	                                          const std::string& prefix)
 	{
 		if (map->baseMap)
-			ExploreOffsetsHelper(map->baseMap, prefixOffset, prefix);
+			ExploreOffsetsHelper(outVec, map->baseMap, prefixOffset, prefix);
 
 		for (int i = 0; i < map->dataNumFields; ++i)
 		{
-			auto typedescription = map->dataDesc[i];
+			auto& typedescription = map->dataDesc[i];
 
+			// ignore input & outputs
 			switch (typedescription.fieldType)
 			{
-				// Some weird stuff so ignore it
 			case FIELD_VOID:
-			case FIELD_CUSTOM:
 			case FIELD_FUNCTION:
-			case FIELD_TYPECOUNT:
+			case FIELD_INPUT:
 				continue;
 			default:
 				break;
 			}
+			if (typedescription.flags & (FTYPEDESC_INPUT | FTYPEDESC_OUTPUT))
+				continue;
 
 			int offset = typedescription.fieldOffset[0] + prefixOffset;
 			std::string prefixedName = prefix + typedescription.fieldName;
@@ -79,10 +84,10 @@ namespace utils
 				// Datamaps for "embedded" members (read: struct)
 				// The child fields will be named parentField.childField in the offset map
 			case FIELD_EMBEDDED:
-				ExploreOffsetsHelper(typedescription.td, offset, prefixedName + ".");
+				ExploreOffsetsHelper(outVec, typedescription.td, offset, prefixedName + ".");
 				break;
 			default:
-				Msg("\t%s : %d\n", prefixedName.c_str(), offset);
+				outVec.emplace_back(offset, prefixedName.c_str());
 				break;
 			}
 		}

--- a/spt/utils/datamap_wrapper.hpp
+++ b/spt/utils/datamap_wrapper.hpp
@@ -19,7 +19,10 @@ namespace utils
 		void ExploreOffsets();
 
 	private:
-		void ExploreOffsetsHelper(datamap_t* map, int prefixOffset, std::string prefix);
+		void ExploreOffsetsHelper(std::vector<std::pair<int, std::string>>& outVec,
+		                          datamap_t* map,
+		                          int prefixOffset,
+		                          const std::string& prefix);
 		void CacheOffsets();
 		void CacheOffsetsHelper(std::unordered_map<std::string, int>& offsetMap,
 		                        int prefixOffset,


### PR DESCRIPTION
Sorting by offset is very useful for fields that might not exist in the datamap so that you can find the closest field. I also changed `spt_datamap_walk` to print every field with an offset, the logic for this wasn't quite right before.

Before:

![image](https://user-images.githubusercontent.com/34390438/236552033-ee5a20ab-c0ff-403a-8c9c-880a6409addd.png)

After:

![image](https://user-images.githubusercontent.com/34390438/236549159-7e11539b-9628-4c60-bca0-0366f10f8152.png)