### PR TITLE
Add spt_noclip_noslowfly

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1190,7 +1190,7 @@ copy "$(TargetPath)" "$(IntDir)..\builds\$(TargetFileName)"</Command>
     <ClCompile Include="spt\features\game_fixes\free_oob.cpp" />
     <ClCompile Include="spt\features\game_fixes\hardlock.cpp" />
     <ClCompile Include="spt\features\game_fixes\multi_instance.cpp" />
-    <ClCompile Include="spt\features\game_fixes\noclip_nofix.cpp" />
+    <ClCompile Include="spt\features\game_fixes\noclip_fixes.cpp" />
     <ClCompile Include="spt\features\game_fixes\nosleep.cpp" />
     <ClCompile Include="spt\features\game_fixes\portal_nogroundsnap.cpp" />
     <ClCompile Include="spt\features\game_fixes\rng.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -325,7 +325,7 @@
     <ClCompile Include="spt\features\game_fixes\multi_instance.cpp">
       <Filter>spt\features\game_fixes</Filter>
     </ClCompile>
-    <ClCompile Include="spt\features\game_fixes\noclip_nofix.cpp">
+    <ClCompile Include="spt\features\game_fixes\noclip_fixes.cpp">
       <Filter>spt\features\game_fixes</Filter>
     </ClCompile>
     <ClCompile Include="spt\features\game_fixes\nosleep.cpp">


### PR DESCRIPTION
`spt_noclip_noslowfly` - Fix noclip slowfly.

 Sets the m_surfaceFriction to 1.0 every tick when noclip is enabled.

I think this fix is too small to be a new feature itself. So I added it in `noclip_nofix.cpp` and rename the file to `noclip_fixes.cpp`.
Although `portal_nogroundsnap.cpp` is also a noclip fix, it's kind of annoying to add all those `#ifndef OE` and `DoesGameLookLikePortal()`. So I didn't combine it into `noclip_fixes.cpp`.