### PR TITLE
Add spt_on_portalled_pause_for

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1208,6 +1208,7 @@ copy "$(TargetPath)" "$(IntDir)..\builds\$(TargetFileName)"</Command>
     <ClCompile Include="spt\features\overlay.cpp" />
     <ClCompile Include="spt\features\pause.cpp" />
     <ClCompile Include="spt\features\playerio.cpp" />
+    <ClCompile Include="spt\features\portalled_pause.cpp" />
     <ClCompile Include="spt\features\property_getter.cpp" />
     <ClCompile Include="spt\features\restart.cpp" />
     <ClCompile Include="spt\features\saveloads.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -343,6 +343,9 @@
     <ClCompile Include="spt\features\game_fixes\snapshot_overflow.cpp">
       <Filter>spt\features\game_fixes</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\portalled_pause.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/features/dmomm.cpp
+++ b/spt/features/dmomm.cpp
@@ -3,7 +3,7 @@
 #include "..\feature.hpp"
 #include "..\sptlib-wrapper.hpp"
 #include "..\utils\game_detection.hpp"
-#include "afterframes.hpp"
+#include "afterticks.hpp"
 #include "convar.hpp"
 #include "dbg.h"
 
@@ -111,10 +111,10 @@ void DMoMM::HOOKED_MiddleOfSlidingFunction_Func()
 		{
 			EngineConCmd("setpause");
 
-			afterframes_entry_t entry;
-			entry.framesLeft = pauseFor;
+			afterticks_entry_t entry;
+			entry.ticksLeft = pauseFor;
 			entry.command = "unpause";
-			spt_afterframes.AddAfterFramesEntry(entry);
+			spt_afterticks.AddAfterticksEntry(entry);
 		}
 	}
 }

--- a/spt/features/hops_hud.cpp
+++ b/spt/features/hops_hud.cpp
@@ -400,8 +400,9 @@ namespace ljstats
 class HopsHud : public FeatureWrapper<HopsHud>
 {
 public:
+	void OnTick();
+	void OnJump();
 	void OnGround(bool onground);
-	void Jump();
 	void CalculateAbhVel();
 	void DrawHopHud();
 	bool ShouldDraw();
@@ -425,13 +426,15 @@ private:
 	bool velNotCalced = true;
 	int lastHop = 0;
 	int displayHop = 0;
-	float percentage = 0;
-	float maxVel = 0;
-	float loss = 0;
+	float percentage = 0.0f;
+	float maxVel = 0.0f;
+	float loss = 0.0f;
 
 	// velocity hud
-	float prevHopVel = 0;
-	float hopVel = 0;
+	float prevHopVel = 0.0f;
+	float hopVel = 0.0f;
+	float prevVel = 0.0f;
+	float currVel = 0.0f;
 
 	vgui::HFont hopsFont = 0;
 };
@@ -491,18 +494,33 @@ void HopsHud::LoadFeature()
 	bool result = spt_hud_feat.AddHudDefaultGroup(
 	    HudCallback(std::bind(&HopsHud::DrawHopHud, this), std::bind(&HopsHud::ShouldDraw, this), false));
 
-	if (result && OngroundSignal.Works && JumpSignal.Works)
-	{
-		OngroundSignal.Connect(this, &HopsHud::OnGround);
-		JumpSignal.Connect(this, &HopsHud::Jump);
+	if (!result)
+		return;
 
-		InitConcommandBase(y_spt_jhud_hops);
-		InitConcommandBase(y_spt_jhud_velocity);
-		InitConcommandBase(y_spt_jhud_x);
-		InitConcommandBase(y_spt_jhud_y);
+	if (JumpSignal.Works)
+	{
+		if (TickSignal.Works)
+		{
+			TickSignal.Connect(this, &HopsHud::OnTick);
+			InitConcommandBase(y_spt_jhud_velocity);
+		}
+
+		if (OngroundSignal.Works)
+		{
+			OngroundSignal.Connect(this, &HopsHud::OnGround);
+			InitConcommandBase(y_spt_jhud_hops);
+		}
+		
+		if (TickSignal.Works || OngroundSignal.Works)
+		{
+			JumpSignal.Connect(this, &HopsHud::OnJump);
+			InitConcommandBase(y_spt_jhud_x);
+			InitConcommandBase(y_spt_jhud_y);
+		}
 	}
 
-	if (result && JumpSignal.Works && TickSignal.Works)
+	// ljstats
+	if (JumpSignal.Works && TickSignal.Works)
 	{
 		JumpSignal.Connect(ljstats::OnJump);
 		TickSignal.Connect(ljstats::OnTick);
@@ -564,19 +582,14 @@ void HopsHud::DrawHopHud()
 
 	if (y_spt_jhud_velocity.GetBool())
 	{
-		static float prev_vel = 0;
-		float vel = spt_playerio.GetPlayerVelocity().Length2D();
-
-		if (fabs(vel - prev_vel) < 0.01)
+		if (fabs(currVel - prevVel) < 0.01)
 			surface->DrawSetTextColor(white);
-		else if (vel > prev_vel)
+		else if (currVel > prevVel)
 			surface->DrawSetTextColor(blue);
 		else
 			surface->DrawSetTextColor(orange);
 
-		prev_vel = vel;
-
-		swprintf_s(buffer, BUFFER_SIZE, L"%d", (int)vel);
+		swprintf_s(buffer, BUFFER_SIZE, L"%d", (int)currVel);
 		DrawBuffer();
 
 		surface->DrawSetTextColor(white);
@@ -645,7 +658,16 @@ void HopsHud::DrawHopHud()
 	}
 }
 
-void HopsHud::Jump()
+void HopsHud::OnTick()
+{
+	if (!y_spt_jhud_velocity.GetBool())
+		return;
+
+	prevVel = currVel;
+	currVel = spt_playerio.GetPlayerVelocity().Length2D();
+}
+
+void HopsHud::OnJump()
 {
 	if (!y_spt_jhud_hops.GetBool() && !y_spt_jhud_velocity.GetBool())
 		return;
@@ -667,7 +689,7 @@ void HopsHud::Jump()
 
 void HopsHud::OnGround(bool onground)
 {
-	if (!y_spt_jhud_hops.GetBool() && !y_spt_jhud_velocity.GetBool())
+	if (!y_spt_jhud_hops.GetBool())
 		return;
 
 	if (!onground)

--- a/spt/features/portalled_pause.cpp
+++ b/spt/features/portalled_pause.cpp
@@ -1,0 +1,83 @@
+#include "stdafx.hpp"
+
+#if defined(SSDK2007) || defined(SSDK2013)
+
+#include "..\feature.hpp"
+#include "..\sptlib-wrapper.hpp"
+#include "afterframes.hpp"
+#include "ent_utils.hpp"
+#include "game_detection.hpp"
+
+ConVar spt_on_portalled_pause_for("spt_on_portalled_pause_for",
+                                  "0",
+                                  0,
+                                  "Whenever player portalled, pause for this many ticks.");
+
+// Pause on player portalled
+class PortalledPause : public FeatureWrapper<PortalledPause>
+{
+public:
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void InitHooks() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void UnloadFeature() override;
+
+private:
+	DECL_HOOK_THISCALL(void, TeleportTouchingEntity, void*, void* pOther);
+};
+
+static PortalledPause spt_portalled_pause_feat;
+
+namespace patterns
+{
+	PATTERNS(TeleportTouchingEntity,
+	         "5135",
+	         "81 EC 1C 01 00 00 55 8B E9 89 6C 24 ?? E8 ?? ?? ?? ?? 85 C0",
+	         "7197370",
+	         "55 8B EC 81 EC 28 01 00 00 56 8B F1");
+}
+
+bool PortalledPause::ShouldLoadFeature()
+{
+	return utils::DoesGameLookLikePortal();
+}
+
+void PortalledPause::InitHooks()
+{
+	HOOK_FUNCTION(server, TeleportTouchingEntity);
+}
+
+void PortalledPause::LoadFeature()
+{
+	if (ORIG_TeleportTouchingEntity)
+	{
+		InitConcommandBase(spt_on_portalled_pause_for);
+	}
+}
+
+void PortalledPause::UnloadFeature() {}
+
+IMPL_HOOK_THISCALL(PortalledPause, void, TeleportTouchingEntity, void*, void* pOther)
+{
+	spt_portalled_pause_feat.ORIG_TeleportTouchingEntity(thisptr, pOther);
+
+	if (pOther != utils::GetServerPlayer())
+		return;
+
+	const auto pauseFor = spt_on_portalled_pause_for.GetInt();
+	if (pauseFor > 0)
+	{
+		EngineConCmd("setpause");
+
+		afterframes_entry_t entry;
+		entry.framesLeft = pauseFor;
+		entry.command = "unpause";
+		spt_afterframes.AddAfterFramesEntry(entry);
+	}
+}
+
+#endif

--- a/spt/features/portalled_pause.cpp
+++ b/spt/features/portalled_pause.cpp
@@ -4,7 +4,7 @@
 
 #include "..\feature.hpp"
 #include "..\sptlib-wrapper.hpp"
-#include "afterframes.hpp"
+#include "afterticks.hpp"
 #include "ent_utils.hpp"
 #include "game_detection.hpp"
 
@@ -73,10 +73,10 @@ IMPL_HOOK_THISCALL(PortalledPause, void, TeleportTouchingEntity, void*, void* pO
 	{
 		EngineConCmd("setpause");
 
-		afterframes_entry_t entry;
-		entry.framesLeft = pauseFor;
+		afterticks_entry_t entry;
+		entry.ticksLeft = pauseFor;
 		entry.command = "unpause";
-		spt_afterframes.AddAfterFramesEntry(entry);
+		spt_afterticks.AddAfterticksEntry(entry);
 	}
 }
 


### PR DESCRIPTION
- `spt_on_portalled_pause_for` - Whenever player portalled, pause for this many ticks.

Small fix:
- Fix spt_jhud_velocity previous velocity not calculated on tick.