### PR TITLE
spt_noclip_persist, spt_turn commands, and DoImageSpaceMotionBlur fix, along with miscellanea

### DIFF
--- a/SDK/igamemovement.h
+++ b/SDK/igamemovement.h
@@ -54,6 +54,9 @@ public:
 	int				m_nButtons;			// Attack buttons.
 	int				m_nOldButtons;		// From host_client->oldbuttons;
 	float			m_flForwardMove;
+#if BMS
+	int				UNKNOWN001;
+#endif
 	float			m_flSideMove;
 	float			m_flUpMove;
 	
@@ -81,6 +84,10 @@ public:
 	const Vector	&GetAbsOrigin() const;
 
 private:
+#if BMS
+	int				UNKNOWN002;
+	int				UNKNOWN003;
+#endif
 	Vector			m_vecAbsOrigin;		// edict::origin
 };
 

--- a/spt/features/aim.cpp
+++ b/spt/features/aim.cpp
@@ -604,7 +604,7 @@ CON_COMMAND(spt_angchange_printqueue, "Print currently queued angle changes")
 {
     if (spt_aim.angChanges.empty())
     {
-        ConMsg("No angle changed queued.\n");
+        Msg("No angle changed queued.\n");
 	    return;
     }
 
@@ -624,7 +624,7 @@ CON_COMMAND(spt_angchange_printqueue, "Print currently queued angle changes")
         }
         str << "\n";
     }
-    ConMsg(str.str().c_str());
+    Msg(str.str().c_str());
 }
 
 void AimFeature::LoadFeature()

--- a/spt/features/aim.cpp
+++ b/spt/features/aim.cpp
@@ -413,7 +413,7 @@ CON_COMMAND(spt_turnangles, "Turns a number of degrees of pitch (down and up), a
 {
     if (args.ArgC() != 3)
     {
-        Msg("Usage: spt_addtoangles <degrees of pitch> <degrees of yaw>\n");
+        Msg("Usage: spt_turnangles <degrees of pitch> <degrees of yaw>\n");
         return;
     }
 

--- a/spt/features/aim.hpp
+++ b/spt/features/aim.hpp
@@ -11,14 +11,24 @@ typedef struct _angset_command
 	_angset_command() : angle(0.0f), set(false) {}
 } angset_command_t;
 
+typedef struct _angturn_command
+{
+	float old; // degrees to snap
+	float left; // degrees left in turn
+	_angturn_command() : left(0.0f) {}
+} angturn_command_t;
+
 class AimFeature : public FeatureWrapper<AimFeature>
 {
 public:
 	aim::ViewState viewState;
 	void HandleAiming(float* va, bool& yawChanged, const Strafe::StrafeInput& input);
 	bool DoAngleChange(float& angle, float target);
+	float DoAngleTurn(float& angle, float left);
 	void SetPitch(float pitch);
+	void TurnPitch(float add);
 	void SetYaw(float yaw);
+	void TurnYaw(float yaw);
 	void ResetPitchYawCommands();
 	void SetJump();
 	virtual void LoadFeature() override;
@@ -26,6 +36,7 @@ public:
 protected:
 private:
 	angset_command_t setPitch, setYaw;
+	angturn_command_t turnPitch, turnYaw;
 };
 
 extern AimFeature spt_aim;

--- a/spt/features/aim.hpp
+++ b/spt/features/aim.hpp
@@ -3,28 +3,30 @@
 #include "..\feature.hpp"
 #include "..\aim\aimstuff.hpp"
 #include "..\strafe\strafestuff.hpp"
+#include <deque>
 
-typedef struct _angset_command
+typedef int ANGCOMPONENT;
+enum ANGCHANGETYPE
 {
-	float angle;
-	bool set;
-	_angset_command() : angle(0.0f), set(false) {}
-} angset_command_t;
+	SET,
+	TURN
+};
 
-typedef struct _angturn_command
+typedef struct _angchange_command
 {
-	float old; // degrees to snap
-	float left; // degrees left in turn
-	_angturn_command() : left(0.0f) {}
-} angturn_command_t;
+public:
+	ANGCOMPONENT component;
+	ANGCHANGETYPE type;
+	float value;
+	_angchange_command() {}
+} angchange_command_t;
+
 
 class AimFeature : public FeatureWrapper<AimFeature>
 {
 public:
 	aim::ViewState viewState;
 	void HandleAiming(float* va, bool& yawChanged, const Strafe::StrafeInput& input);
-	bool DoAngleChange(float& angle, float target);
-	float DoAngleTurn(float& angle, float left);
 	void SetPitch(float pitch);
 	void TurnPitch(float add);
 	void SetYaw(float yaw);
@@ -35,8 +37,14 @@ public:
 
 protected:
 private:
-	angset_command_t setPitch, setYaw;
-	angturn_command_t turnPitch, turnYaw;
+	void AddChange(angchange_command_t change);
+	bool DoAngleChange(float& angle, float target);
+	float DoAngleTurn(float& angle, float left);
+	ConVar* cl_pitchup;
+	ConVar* cl_pitchdown;
+	bool IsPitchWithinLimits(float pitch);
+	float BoundPitch(float pitch);
+	std::deque<angchange_command_t> angChanges;
 };
 
 extern AimFeature spt_aim;

--- a/spt/features/aim.hpp
+++ b/spt/features/aim.hpp
@@ -15,10 +15,15 @@ enum ANGCHANGETYPE
 typedef struct _angchange_command
 {
 public:
-	ANGCOMPONENT component;
 	ANGCHANGETYPE type;
-	float value;
-	_angchange_command() {}
+	bool doYaw;
+	float yawValue;
+	bool doPitch;
+	float pitchValue;
+	_angchange_command() : 
+		yawValue(0.0f), doYaw(false),
+		pitchValue(0.0f), doPitch(false),
+		type(SET) {}
 } angchange_command_t;
 
 
@@ -31,9 +36,12 @@ public:
 	void TurnPitch(float add);
 	void SetYaw(float yaw);
 	void TurnYaw(float yaw);
+	void SetAngles(float pitch, float yaw);
+	void TurnAngles(float pitch, float yaw);
 	void ResetPitchYawCommands();
 	void SetJump();
 	virtual void LoadFeature() override;
+	std::deque<angchange_command_t> angChanges;
 
 protected:
 private:
@@ -44,7 +52,6 @@ private:
 	ConVar* cl_pitchdown;
 	bool IsPitchWithinLimits(float pitch);
 	float BoundPitch(float pitch);
-	std::deque<angchange_command_t> angChanges;
 };
 
 extern AimFeature spt_aim;

--- a/spt/features/game_fixes/bms_flashlight_fix.cpp
+++ b/spt/features/game_fixes/bms_flashlight_fix.cpp
@@ -11,7 +11,7 @@ static void BMSFlashLightFixCVarCallback(IConVar* pConVar, const char* pOldValue
 ConVar y_spt_bms_flashlight_fix("y_spt_bms_flashlight_fix",
 								"0",
 								0,
-								"Disables all extra movement on flashlight.",
+								"Disables all extra movement on the flashlight.",
 								BMSFlashLightFixCVarCallback);
 
 // Gives the option to disable all extra flashlight movement, including delay, swaying, and bobbing.

--- a/spt/features/game_fixes/noclip_fixes.cpp
+++ b/spt/features/game_fixes/noclip_fixes.cpp
@@ -5,6 +5,8 @@
 #include "convar.hpp"
 #include "game_detection.hpp"
 #include "signals.hpp"
+#include "..\autojump.hpp"
+#include "SDK\hl_movedata.h"
 
 #ifdef  OE
 static void NoclipNofixCVarCallback(ConVar* pConVar, const char* pOldValue);
@@ -13,40 +15,48 @@ static void NoclipNofixCVarCallback(IConVar* pConVar, const char* pOldValue, flo
 #endif
 
 ConVar y_spt_noclip_nofix("y_spt_noclip_nofix",
-						  "0",
-						  0,
-                          "Disables noclip's position fixing.",
+                          "0",
+                          0,
+                          "Stops noclip from fixing player's position after disabling.",
                           NoclipNofixCVarCallback);
 ConVar spt_noclip_noslowfly("spt_noclip_noslowfly", "0", 0, "Fix noclip slowfly.");
+ConVar spt_noclip_persist("spt_noclip_persist",
+                          "0",
+                          0,
+                          "When enabled, enabling noclip will make the player indefinitely float in the same direction and speed of movement.");
 
 // Noclip related fixes
 class NoclipFixesFeature : public FeatureWrapper<NoclipFixesFeature>
 {
 public:
-	void ToggleNoclipNofix(bool enabled);
+    void ToggleNoclipNofix(bool enabled);
 
 protected:
-	virtual bool ShouldLoadFeature() override;
+    virtual bool ShouldLoadFeature() override;
 
-	virtual void InitHooks() override;
+    virtual void InitHooks() override;
 
-	virtual void LoadFeature() override;
+    virtual void LoadFeature() override;
 
-	virtual void UnloadFeature() override;
+    virtual void UnloadFeature() override;
 
-	
-	// value replacements and single instruction overrides
-	// we'll just write the bytes ourselves...
+    
+    // value replacements and single instruction overrides
+    // we'll just write the bytes ourselves...
 private:
-	void OnTick();
+    void OnTick();
 
-	uintptr_t ORIG_Server__NoclipString = 0;
-	std::vector<patterns::MatchedPattern> MATCHES_Server__StringReferences;
+    // position fixing prevention
+    uintptr_t ORIG_Server__NoclipString = 0;
+    std::vector<patterns::MatchedPattern> MATCHES_Server__StringReferences;
+    DECL_BYTE_REPLACE(nofixJumpInsc, 6);
+    byte nofixInscCompare[4] = {0x84, 0xC0, 0x0F, 0x85};
+    int nofixJumpDistance = 0x0;
 
-	DECL_BYTE_REPLACE(Jump, 6);
-
-	byte inscCompare[4] = {0x84, 0xC0, 0x0F, 0x85};
-	int jmpDistance = 0x0;
+    // velocity persistence
+    uintptr_t ORIG_Server__gpGlobalsTargetString = 0;
+    CGlobalVarsBase* servergpGlobals = nullptr;
+    DECL_HOOK_THISCALL(void, CGameMovement__FullNoClipMove, void*, float factor, float maxacceleration);
 };
 
 static NoclipFixesFeature spt_noclipfixes;
@@ -57,108 +67,187 @@ static void NoclipNofixCVarCallback(ConVar* pConVar, const char* pOldValue)
 static void NoclipNofixCVarCallback(IConVar* pConVar, const char* pOldValue, float flOldValue)
 #endif
 {
-	spt_noclipfixes.ToggleNoclipNofix(((ConVar*)pConVar)->GetBool());
+    spt_noclipfixes.ToggleNoclipNofix(((ConVar*)pConVar)->GetBool());
 }
 
 namespace patterns
 {
-	PATTERNS(Server__NoclipString, "1", "6E 6F 63 6C 69 70 20 4F 46 46 0A 00");
-	PATTERNS(Server__StringReferences, "1", "68");
+    PATTERNS(Server__NoclipString, "1", "6E 6F 63 6C 69 70 20 4F 46 46 0A 00");
+    PATTERNS(Server__gpGlobalsTargetString, "1", "5B 25 30 33 64 5D 20 46 6F 75 6E 64 3A 20 25 73 2C 20 66 69 72 69 6E 67 20 28 25 73 29 0A 00");
+    PATTERNS(Server__StringReferences, "1", "68");
+
+    PATTERNS(CGameMovement__FullNoClipMove,
+             "BMS 0.9",
+             "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B ?? 89 6C 24 ?? 8B EC 83 EC 6C 56 8B F1",
+	         "HL2 5135",
+	         "83 EC ?? A1 ?? ?? ?? ?? D9 40 2C 56 D8 4C 24 ?? 8B F1 8D 4C 24 ?? 51 8B 4E 08");
 }
 
 bool NoclipFixesFeature::ShouldLoadFeature()
 {
-	return true;
+    return true;
 }
 
 void NoclipFixesFeature::InitHooks()
 {
-	FIND_PATTERN(server, Server__NoclipString);
-	FIND_PATTERN_ALL(server, Server__StringReferences);
+    FIND_PATTERN(server, Server__NoclipString);
+    FIND_PATTERN(server, Server__gpGlobalsTargetString);
+    FIND_PATTERN_ALL(server, Server__StringReferences);
+
+    HOOK_FUNCTION(server, CGameMovement__FullNoClipMove);
 }
 
 void NoclipFixesFeature::LoadFeature()
 {
-	if (spt_playerio.m_surfaceFriction.Found() && spt_playerio.m_MoveType.Found() && TickSignal.Works)
-	{
-		TickSignal.Connect(this, &NoclipFixesFeature::OnTick);
-		InitConcommandBase(spt_noclip_noslowfly);
-	}
+    if (spt_playerio.m_surfaceFriction.Found() && spt_playerio.m_MoveType.Found() && TickSignal.Works)
+    {
+        TickSignal.Connect(this, &NoclipFixesFeature::OnTick);
+        InitConcommandBase(spt_noclip_noslowfly);
+    }
 
-	if (!ORIG_Server__NoclipString || MATCHES_Server__StringReferences.empty())
-		return;
+    if (!ORIG_Server__NoclipString || MATCHES_Server__StringReferences.empty())
+        return;
 
-	for (auto match : MATCHES_Server__StringReferences)
-	{
-		if (*(uintptr_t*)(match.ptr + 1) != ORIG_Server__NoclipString)
-			continue;
+    bool nofixFound = ORIG_Server__NoclipString == 0;
+    bool gpGlobalsFound = ORIG_CGameMovement__FullNoClipMove == nullptr;
+    void* serverHandle; void* serverBase; size_t serverSize = 0; MemUtils::GetModuleInfo(L"server.dll", &serverHandle, &serverBase, &serverSize);;
+    for (auto match : MATCHES_Server__StringReferences)
+    {
+	    if (nofixFound && gpGlobalsFound)
+		    break;
 
-		/*
-		* After printing "noclip OFF\n", the game will do "if ( !TestEntityPosition( pPlayer ) )",
-		* which generally translates to
-		*	xx					PUSH pPlayer
-		*	E8 xx xx xx xx		CALL [TestEntityPosition]
-		*	~ noise ~
-		*	84 c0				TEST al, al
-		*	0f 85 xx xx 00 00	JNE [eof] <-- we'll asume its less than 0x10000 bytes away...
-		*/
-		byte* bytes = (byte*)match.ptr;
-		for (int i = 0; i <= 0x200; i++)
-		{
-			int jmpOff = *(int*)(bytes + i + 4);
-			if (jmpOff > 0x10000)
-				continue;
+	    uintptr_t strPtr = *(uintptr_t*)(match.ptr + 1);
 
-			if (memcmp((void*)(bytes + i), (void*)inscCompare, 4))
-				continue;
+        if (!nofixFound && strPtr == ORIG_Server__NoclipString)
+        {
+		    /*
+            * After printing "noclip OFF\n", the game will do "if ( !TestEntityPosition( pPlayer ) )",
+            * which generally translates to
+            *	xx					PUSH pPlayer
+            *	E8 xx xx xx xx		CALL [TestEntityPosition]
+            *	~ noise ~
+            *	84 c0				TEST al, al
+            *	0f 85 xx xx 00 00	JNE [eof] <-- we'll asume its less than 0x10000 bytes away...
+            */
+		    byte* bytes = (byte*)match.ptr;
+		    for (int i = 0; i <= 0x200; i++)
+		    {
+			    int jmpOff = *(int*)(bytes + i + 4);
+			    if (jmpOff > 0x10000)
+				    continue;
 
-			INIT_BYTE_REPLACE(Jump, (uintptr_t)(bytes + i + 2));
+			    if (memcmp((void*)(bytes + i), (void*)nofixInscCompare, 4))
+				    continue;
 
-			/*
-			* When we replace the instruction with a JMP, we replace the last byte with NOP,
-			* meaning the starting point of our jump is shifted up by 1 to that byte.
-			*/
-			jmpDistance = jmpOff + 1;
-			InitConcommandBase(y_spt_noclip_nofix);
-			return;
-		}
+			    INIT_BYTE_REPLACE(nofixJumpInsc, (uintptr_t)(bytes + i + 2));
 
-	}
+			    /*
+                * When we replace the instruction with a JMP, we replace the last byte with NOP,
+                * meaning the starting point of our jump is shifted up by 1 to that byte.
+                */
+			    nofixJumpDistance = jmpOff + 1;
+			    InitConcommandBase(y_spt_noclip_nofix);
+			    continue;
+		    }
+        }
+
+        if (!gpGlobalsFound && strPtr == ORIG_Server__gpGlobalsTargetString)
+        {
+		    /*
+            * For noclip persist velocity calculations, we'll need access to server's gpGlobals->frametime,  
+            * as that acts differently from client's gpGlobals.
+            * 
+            * We'll be relying on string references again, specifically the reference in FireTargets as
+            * that one is close to a string ref.
+            * DevMsg( 2, "[%03d] Found: %s, firing (%s)\n", gpGlobals->tickcount%1000, pTarget->GetDebugName(), targetName );
+            * 
+            * We'll start at the string push, then look back a small distance to find the mov instruction for 1000 for the
+            * modulo operation. We'll assume this is right after the mov of gpGlobals
+            *   A1 xx xx xx xx      MOV     eax, [gpGlobals]
+            *   ?? e8 03 00 00      MOV     ??, 0x3e8
+            *   ~ noise ~
+            *   68 xx xx xx xx      PUSH    [string]            
+            */
+
+            // look back 100 bytes
+		    const int LOOK_BACK_AMOUNT = 100;
+		    byte* bytes = (byte*)(match.ptr - LOOK_BACK_AMOUNT);
+		    for (int i = LOOK_BACK_AMOUNT - 1; i >= 0; i--)
+            {
+                if (*(int*)(bytes + i) == 0x3e8)
+                {
+				    for (int j = i; j >= 0; j--)
+                    {
+                        if (bytes[j] == 0xA1)
+                        {
+                            uintptr_t candidate = *(uintptr_t*)(bytes + j + 1);
+                            if (candidate >= (uintptr_t)serverBase && candidate <= ((uintptr_t)serverBase + serverSize))
+                            {
+                                servergpGlobals = *(CGlobalVarsBase**)candidate;
+                                gpGlobalsFound = true;
+                                InitConcommandBase(spt_noclip_persist);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 void NoclipFixesFeature::OnTick()
 {
-	if (!spt_noclip_noslowfly.GetBool())
-		return;
+    if (!spt_noclip_noslowfly.GetBool())
+        return;
 
-	if ((unsigned char)spt_playerio.m_MoveType.GetValue() == MOVETYPE_NOCLIP)
-	{
-		float* friction = spt_playerio.m_surfaceFriction.GetPtr();
-		if (!friction)
-			return;
-		*friction = 1.0f;
-	}
+    if ((unsigned char)spt_playerio.m_MoveType.GetValue() == MOVETYPE_NOCLIP)
+    {
+        float* friction = spt_playerio.m_surfaceFriction.GetPtr();
+        if (!friction)
+            return;
+        *friction = 1.0f;
+    }
 }
 
 void NoclipFixesFeature::UnloadFeature()
 {
-	DESTROY_BYTE_REPLACE(Jump);
+    DESTROY_BYTE_REPLACE(nofixJumpInsc);
+    servergpGlobals = nullptr;
 }
 
 
 void NoclipFixesFeature::ToggleNoclipNofix(bool enabled)
 {
-	if (PTR_Jump == 0)
-		return;
+    if (PTR_nofixJumpInsc == 0)
+        return;
 
-	if (enabled)
-	{
-		MemUtils::ReplaceBytes((void*)PTR_Jump, 1, new uint8[1]{0xE9});
-		MemUtils::ReplaceBytes((void*)(PTR_Jump + 1), 4, (uint8*)&jmpDistance);
-		MemUtils::ReplaceBytes((void*)(PTR_Jump + 5), 1, new uint8[1]{0x90});
-	}
-	else
-	{
-		UNDO_BYTE_REPLACE(Jump);
-	}
+    if (enabled)
+    {
+        MemUtils::ReplaceBytes((void*)PTR_nofixJumpInsc, 1, new uint8[1]{0xE9});
+        MemUtils::ReplaceBytes((void*)(PTR_nofixJumpInsc + 1), 4, (uint8*)&nofixJumpDistance);
+        MemUtils::ReplaceBytes((void*)(PTR_nofixJumpInsc + 5), 1, new uint8[1]{0x90});
+    }
+    else
+    {
+	    UNDO_BYTE_REPLACE(nofixJumpInsc);
+    }
+}
+
+IMPL_HOOK_THISCALL(NoclipFixesFeature, void, CGameMovement__FullNoClipMove, void*, float factor, float maxacceleration)
+{
+    if (!spt_noclip_persist.GetBool())
+    {
+	    spt_noclipfixes.ORIG_CGameMovement__FullNoClipMove(thisptr, factor, maxacceleration);
+	    return;
+    }
+
+    // copied from original function, slightly modified to remove factor
+
+    CHLMoveData* mv = (CHLMoveData*)(*((uintptr_t*)thisptr + spt_autojump.off_mv_ptr));
+    Vector out;
+	VectorMA(mv->GetAbsOrigin(), spt_noclipfixes.servergpGlobals->frametime, mv->m_vecVelocity, out);
+    mv->SetAbsOrigin(out);
+
+    return;
 }

--- a/spt/features/game_fixes/portal_nogroundsnap.cpp
+++ b/spt/features/game_fixes/portal_nogroundsnap.cpp
@@ -71,7 +71,7 @@ void PortalNoGroundSnapFeature::LoadFeature()
 	* The check we're looking for is one inserted in the middle of CategorizePosition:
 	* "if (player->GetGroundEntity() != NULL)".
 	* 
-	* We actually scan for another check a but below this, inside the if condition in the code,
+	* We actually scan for another check a bit below this, inside the if condition in the code,
 	* as it is more distinctive in assembly...
 	* 
 	* E8 xx xx xx xx		CALL [GetGroundEntity]

--- a/spt/features/game_fixes/visual_fixes.cpp
+++ b/spt/features/game_fixes/visual_fixes.cpp
@@ -39,6 +39,8 @@ protected:
 
 	virtual void InitHooks() override;
 
+	virtual void PreHook() override;
+
 	virtual void LoadFeature() override;
 
 	virtual void UnloadFeature() override;
@@ -83,7 +85,9 @@ namespace patterns
 	    "1910503",
 	    "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B 04 89 6C 24 04 8B EC A1 ?? ?? ?? ?? 81 EC ?? ?? ?? ?? 83 78 30 00 56 57 0F 84 ?? ?? ?? ?? 8B 0D",
 	    "missinginfo1_6",
-	    "55 8B EC A1 ?? ?? ?? ?? 81 EC ?? ?? ?? ?? 83 78 30 00 0F 84 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? 8B 11");
+	    "55 8B EC A1 ?? ?? ?? ?? 81 EC ?? ?? ?? ?? 83 78 30 00 0F 84 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? 8B 11",
+	    "BMS 0.9",
+	    "53 8B DC 83 EC 08 83 E4 F0 83 C4 04 55 8B 6B ?? 89 6C 24 ?? 8B EC 81 EC A8 00 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 ?? A1");
 	PATTERNS(
 	    CViewEffects__Fade,
 	    "dmomm-4104-5135",
@@ -137,7 +141,7 @@ bool VisualFixes::ShouldLoadFeature()
 	return true;
 }
 
-void VisualFixes::LoadFeature()
+void VisualFixes::PreHook()
 {
 	if (ORIG_DoImageSpaceMotionBlur)
 	{
@@ -163,12 +167,18 @@ void VisualFixes::LoadFeature()
 		case 5: // missinginfo1_6
 			pgpGlobals = *(uintptr_t**)((uintptr_t)ORIG_DoImageSpaceMotionBlur + 128);
 			break;
+		case 6: // BMS 0.9
+			pgpGlobals = *(uintptr_t**)((uintptr_t)ORIG_DoImageSpaceMotionBlur + 0x18C);
+			break;
 		}
 
 		DevMsg("[client dll] pgpGlobals is %p.\n", pgpGlobals);
 		InitConcommandBase(y_spt_motion_blur_fix);
 	}
+}
 
+void VisualFixes::LoadFeature()
+{
 	if (ORIG_CViewEffects__Fade)
 		InitConcommandBase(y_spt_disable_fade);
 

--- a/spt/features/saveloads.cpp
+++ b/spt/features/saveloads.cpp
@@ -9,89 +9,110 @@
 #include <format>
 
 static std::vector<const char*> _saveloadTypes = {"segment", "execute", "render"};
-static const char saveloads_usage[] =
+static const char saveloads_info[] = 
+    "Initiates a new save/load process.\n"
     "Arguments: spt_saveloads <type> <segment name> <start index> <end index> [<ticks to wait>] [<extra commands>].\n"
-    "  - <type> is the type of the save/load process, which can be\n"
-    "	- \"segment\" for full save/load segment creation. Saves and demos for each save/load will be made and named accordingly.\n"
-    "	- \"execute\" for save/load execution. The tool will only use 1 name for saves, and no demos will be made.\n"
-    "	- \"render\" for save/load segment rendering. Saves and demos will be loaded in order according to the specified naming format and then screenshotted.\n"
-    "	These will determine what set of commands will be executed.\n"
-    "  - <segment name> is the segment name, which will be used to name the saves and demos (format: <segment name>-<index>)\n"
-    "  - <start index> is the index from which the saves and demos will be named from.\n"
-    "  - <end index> is the index up to which SPT will process.\n"
-    "  - OPTIONAL: <ticks to wait> is the number of ticks to wait after a save is loaded before SPT executes the commands of the corresponding process type.\n\n"
-    "  - OPTIONAL: <extra commands> is a string containing extra commands to be executed every save/load \n\n"
-    "Usage: \n"
-    "  - Enter in the command.\n"
-    "  - Load the save from which the process should begin from. The save/load process will begin automatically.\n"
-    "  - Use \"spt_saveloads_stop\" at any time to stop the process.";
+    "\n"
+    "* Required arguments:\n"
+    "   - <type> determines the type of the save/load process. Valid values include:\n"
+    "      - 'segment': Full save/load segment creation, which will keep all saves and demos created by the process, and name all of them accordingly.\n"
+    "      - 'execute': Partial save/load execution, which will only generate 1 save file, and no demos. Essentially an RTA save/load session.\n"
+    "      - 'render':  Renders an existing save/load segment. Using the provided segment name, the process will load the saves of the save/load segment, and screenshot each one.\n"
+    "   - <segment name> determines the name that the process will use to refer to saves and demos of the save/load segment.\n"
+    "   - <start index> determines the starting index for saves and demos.\n"
+    "   - <end index> determines the ending index for saves and demos.\n"
+    "\n"
+    "* Optional arguments:\n"
+    "   - <ticks to wait> is the number of ticks to wait after a save is loaded before executing commands. Default value is 0.\n"
+    "   - <extra commands> determines the commands to be executed right after a save has finished loading. These commands are not deferred by the delay specified by ticks to wait.\n"
+    "\n"
+    "* Examples:\n"
+    "   - 'spt_saveloads segment 001-abc 0 100' will:\n"
+    "       - Do 101 save/loads.\n"
+    "       - Name created files '001-abc-000', '001-abc-001', and so on.\n"
+    "   - 'spt_saveloads execute 001-abc 0 100' will:\n"
+    "       - Do 101 save/loads.\n"
+    "       - Only create 1 save file called '001-abc'.\n"
+    "   - 'spt_saveloads render 001-abc 0 100' will:\n"
+    "       - Load the save '001-abc-000', then screenshot.\n"     
+    "       - Load the save '001-abc-001', then screenshot.\n"     
+    "       - ... repeat until '001-abc-100' is loaded and screenshotted.\n"     
+    "   - 'spt_saveloads segment 001-abc 0 100 100 \"+duck\"' will:\n"
+    "       - Do 101 save/loads.\n"
+    "       - Name created files '001-abc-000', '001-abc-001', and so on.\n"
+    "       - Right after a save is loaded, it will send the command '+duck', then wait 100 ticks before running save and demo commands."  
+    "\n"
+    "* Usage: \n"
+    "   - Enter in the command.\n"
+    "   - Load the save from which the process should begin from. The save/load process will begin automatically.\n"
+    "   - Use the 'spt_saveloads_stop' command at any time to stop the process.";
 
 // Feature that does automated save/loading operations, such as save/load segment creation or rendering
 class SaveloadsFeature : public FeatureWrapper<SaveloadsFeature>
 {
 public:
-	void Begin(int type_,
-	           const char* segName_,
-	           int startIndex_,
-	           int endIndex_,
-	           int ticksToWait_,
-	           const char* extra);
-	void Stop();
+    void Begin(int type_,
+               const char* segName_,
+               int startIndex_,
+               int endIndex_,
+               int ticksToWait_,
+               const char* extra);
+    void Stop();
 
 protected:
-	virtual bool ShouldLoadFeature() override;
-	virtual void LoadFeature() override;
-	//virtual void UnloadFeature() override;
+    virtual bool ShouldLoadFeature() override;
+    virtual void LoadFeature() override;
+    //virtual void UnloadFeature() override;
 
 private:
-	int type;
-	std::string prefixName;
-	int startIndex;
-	int endIndex;
-	int ticksToWait;
+    int type;
+    std::string prefixName;
+    int startIndex;
+    int endIndex;
+    int ticksToWait;
 
-	std::string extraCommands;
-	bool execute = false;
-	void OnSetSignonState(void* thisptr, int state);
+    std::string extraCommands;
+    bool execute = false;
+    void OnSetSignonState(void* thisptr, int state);
 };
 
 static SaveloadsFeature spt_saveloads;
 
-CON_COMMAND(y_spt_saveloads, "Begins an automated save/load process")
+CON_COMMAND(y_spt_saveloads, "Initiates a new save/load process. Enter this command without arguments for detailed help.")
 {
-	if (args.ArgC() < 4)
-	{
-		Msg("%s\n", saveloads_usage);
-		return;
-	}
+    if (args.ArgC() < 4)
+    {
+        Msg("%s\n", saveloads_info);
+        return;
+    }
 
-	int type = -1;
-	for (int i = 0; i < (int)_saveloadTypes.size(); i++)
-	{
-		if (strcmp(args.Arg(1), _saveloadTypes[i]) == 0)
-		{
-			type = i;
-			break;
-		}
-	}
+    int type = -1;
+    for (int i = 0; i < (int)_saveloadTypes.size(); i++)
+    {
+        if (strcmp(args.Arg(1), _saveloadTypes[i]) == 0)
+        {
+            type = i;
+            break;
+        }
+    }
 
-	if (type == -1)
-	{
-		type = 0;
-		Warning("SAVELOADS: Invalid save/load process type! Using \"segment\" instead.\n");
-	}
+    if (type == -1)
+    {
+        type = 0;
+        Warning("SAVELOADS: Invalid save/load process type! Using \"segment\" instead.\n");
+    }
 
-	spt_saveloads.Begin(type,
-	                    args.Arg(2),
-	                    atoi(args.Arg(3)),
-	                    atoi(args.Arg(4)),
-	                    args.ArgC() == 5 ? 0 : atoi(args.Arg(5)),
-	                    args.ArgC() == 6 ? nullptr : args.Arg(6));
+    spt_saveloads.Begin(type,
+                        args.Arg(2),
+                        atoi(args.Arg(3)),
+                        atoi(args.Arg(4)),
+                        args.ArgC() == 5 ? 0 : atoi(args.Arg(5)),
+                        args.ArgC() == 6 ? nullptr : args.Arg(6));
 }
 
 CON_COMMAND(y_spt_saveloads_stop, "Stops the current save/loading process.")
 {
-	spt_saveloads.Stop();
+    spt_saveloads.Stop();
 }
 
 ConVar y_spt_hud_saveloads_showcurindex("y_spt_hud_saveloads_showcurindex",
@@ -101,35 +122,35 @@ ConVar y_spt_hud_saveloads_showcurindex("y_spt_hud_saveloads_showcurindex",
 
 bool SaveloadsFeature::ShouldLoadFeature()
 {
-	return true;
+    return true;
 }
 
 void SaveloadsFeature::LoadFeature()
 {
-	if (!spt_afterticks.Works || !SetSignonStateSignal.Works)
-		return;
+    if (!spt_afterticks.Works || !SetSignonStateSignal.Works)
+        return;
 
-	//FinishRestoreSignal.Connect(this, &SaveloadsFeature::FinishRestore);
-	InitCommand(y_spt_saveloads);
-	InitCommand(y_spt_saveloads_stop);
+    //FinishRestoreSignal.Connect(this, &SaveloadsFeature::FinishRestore);
+    InitCommand(y_spt_saveloads);
+    InitCommand(y_spt_saveloads_stop);
 
 #ifdef SPT_HUD_ENABLED
-	AddHudCallback(
-	    "saveloads_showcurindex",
-	    [this](std::string)
-	    {
-		    if (execute)
-			    spt_hud_feat.DrawTopHudElement(L"SAVELOADS: %i / %i (%i left)",
-			                                   startIndex,
-			                                   endIndex,
-			                                   endIndex - startIndex);
-		    else
-			    spt_hud_feat.DrawTopHudElement(L"SAVELOADS: Not executing");
-	    },
-	    y_spt_hud_saveloads_showcurindex);
+    AddHudCallback(
+        "saveloads_showcurindex",
+        [this](std::string)
+        {
+            if (execute)
+                spt_hud_feat.DrawTopHudElement(L"SAVELOADS: %i / %i (%i left)",
+                                               startIndex,
+                                               endIndex,
+                                               endIndex - startIndex);
+            else
+                spt_hud_feat.DrawTopHudElement(L"SAVELOADS: Not executing");
+        },
+        y_spt_hud_saveloads_showcurindex);
 #endif
 
-	SetSignonStateSignal.Connect(this, &SaveloadsFeature::OnSetSignonState);
+    SetSignonStateSignal.Connect(this, &SaveloadsFeature::OnSetSignonState);
 }
 
 void SaveloadsFeature::Begin(int type_,
@@ -139,124 +160,121 @@ void SaveloadsFeature::Begin(int type_,
                              int ticksToWait_,
                              const char* extra)
 {
-	if (type_ > 2 || type_ < 0)
-	{
-		Warning("SAVELOADS: Invalid save/load process type! Not continuing.\n");
-		return;
-	}
+    if (type_ > 2 || type_ < 0)
+    {
+        Warning("SAVELOADS: Invalid save/load process type! Not continuing.\n");
+        return;
+    }
 
-	if (startIndex_ < 0 || endIndex_ < 0 || startIndex_ > endIndex_)
-	{
-		Warning("SAVELOADS: Invalid start and/or end index.\n");
-		return;
-	}
+    if (startIndex_ < 0 || endIndex_ < 0 || startIndex_ > endIndex_)
+    {
+        Warning("SAVELOADS: Invalid start and/or end index.\n");
+        return;
+    }
 
-	this->type = type_;
-	this->prefixName.assign(segName_);
-	this->startIndex = startIndex_;
-	this->endIndex = endIndex_;
-	this->ticksToWait = ticksToWait_;
-	this->extraCommands.assign(extra == nullptr ? "" : extra);
+    this->type = type_;
+    this->prefixName.assign(segName_);
+    this->startIndex = startIndex_;
+    this->endIndex = endIndex_;
+    this->ticksToWait = ticksToWait_;
+    this->extraCommands.assign(extra == nullptr ? "" : extra);
 
-	execute = true;
+    execute = true;
 
-	Msg("------\n\nSAVELOADS: Save/load process:\n\
-	- Type: %s\n\
-	- Segment name: \"%s\"\n\
-	- From index %i to index %i (%i save/loads)\n\
-	- Wait time before action: %i\n\
-	- Extra commands: \"%s\"\n\n\
+    Msg("------\n\nSAVELOADS: Save/load process:\n\
+    - Type: %s\n\
+    - Segment name: \"%s\"\n\
+    - From index %i to index %i (%i save/loads)\n\
+    - Wait time before action: %i\n\
+    - Extra commands: \"%s\"\n\n\
 Please load the save from which save/loading should begin.\n",
-	    _saveloadTypes[type_],
-	    segName_,
-	    startIndex_,
-	    endIndex_,
-	    endIndex_ - startIndex_ + 1,
-	    ticksToWait_,
-	    this->extraCommands.c_str());
-	Warning("Use \"spt_saveloads_stop\" to stop the process!!! You should bind it to something.\n");
-	Msg("\n------\n");
+        _saveloadTypes[type_],
+        segName_,
+        startIndex_,
+        endIndex_,
+        endIndex_ - startIndex_ + 1,
+        ticksToWait_,
+        this->extraCommands.c_str());
+    Warning("Use \"spt_saveloads_stop\" to stop the process!!! You should bind it to something.\n");
+    Msg("\n------\n");
 }
 
 void SaveloadsFeature::Stop()
 {
-	if (!execute)
-		return;
+    if (!execute)
+        return;
 
-	this->extraCommands.assign("");
-	execute = false;
-	;
-	spt_afterticks.ResetAfterticksQueue();
-	Warning("SAVELOADS: Save/load process stopped.\n");
+    this->extraCommands.assign("");
+    execute = false;
+    ;
+    spt_afterticks.ResetAfterticksQueue();
+    Warning("SAVELOADS: Save/load process stopped.\n");
 }
 
 void SaveloadsFeature::OnSetSignonState(void* thisptr, int state)
 {
-	static int lastSignOnState = state;
-	int cur = state;
+    static int lastSignOnState = state;
+    int cur = state;
 
-	if (lastSignOnState == cur)
-		return;
+    if (lastSignOnState == cur)
+        return;
 
-	lastSignOnState = cur;
+    lastSignOnState = cur;
 
-	if (cur != 6)
-		return;
+    if (cur != 6)
+        return;
 
-	if (!execute)
-		return;
+    if (!execute)
+        return;
 
-	std::string segName = std::format("{}-{:03d}", prefixName, startIndex);
-	std::string command;
+    std::string segName = std::format("{}-{:03d}", prefixName, startIndex);
+    std::string command;
 
-	EngineConCmd("unpause");
-	EngineConCmd(extraCommands.c_str());
+    EngineConCmd("unpause");
+    EngineConCmd(extraCommands.c_str());
 
-	switch (this->type)
-	{
-	case 0: // normal segment
+    switch (this->type)
+    {
+    case 0: // normal segment
 
-		EngineConCmd(std::format("record {}", segName).c_str());
-		command = std::format(
-		    "save {0};\
-spt_afterticks 20 \"echo #SAVE#\"; spt_afterticks 25 \"stop\";\
-spt_afterticks 30 \"load {0}\"",
-		    segName,
-		    extraCommands,
-		    prefixName);
-		break;
-	case 1: // normal save/load
-		command = std::format("save {2}; spt_afterticks 30 \"load {2}\"", segName, extraCommands, prefixName);
-		break;
-	case 2:                                     // screenshot
-		ticksToWait = MAX(ticksToWait, 20); // else we won't get any screenshots...
-		command =
-		    std::format("screenshot; {0}; spt_afterticks 30 \"load {0}\"", segName, extraCommands, prefixName);
-		break;
-	};
+        EngineConCmd(std::format("record {}", segName).c_str());
+        command = std::format(
+            "save {0}; spt_afterticks 20 \"echo #SAVE#\"; spt_afterticks 25 \"stop\"; spt_afterticks 30 \"load {0}\"",
+            segName,
+            extraCommands,
+            prefixName);
+        break;
+    case 1: // normal save/load
+        command = std::format("save {2}; spt_afterticks 30 \"load {2}\"", segName, extraCommands, prefixName);
+        break;
+    case 2: // screenshot
+        ticksToWait = MAX(ticksToWait, 20); // else we won't get any screenshots...
+        command = std::format("screenshot; {0}; spt_afterticks 30 \"load {0}\"", segName, extraCommands, prefixName);
+        break;
+    };
 
-	if (ticksToWait > 0)
-	{
-		afterticks_entry_t entry;
-		entry.command.assign(command);
-		entry.ticksLeft = ticksToWait;
+    if (ticksToWait > 0)
+    {
+        afterticks_entry_t entry;
+        entry.command.assign(command);
+        entry.ticksLeft = ticksToWait;
 
-		spt_afterticks.AddAfterticksEntry(entry);
-	}
-	else
-	{
-		EngineConCmd(command.c_str());
-	}
+        spt_afterticks.AddAfterticksEntry(entry);
+    }
+    else
+    {
+        EngineConCmd(command.c_str());
+    }
 
-	Warning("SAVELOADS: Processed segment %i, working until %i (%i left)\n",
-	        startIndex,
-	        endIndex,
-	        endIndex - startIndex);
+    Warning("SAVELOADS: Processed segment %i, working until %i (%i left)\n",
+            startIndex,
+            endIndex,
+            endIndex - startIndex);
 
-	startIndex++;
-	if (startIndex > endIndex)
-	{
-		execute = false;
-		Warning("SAVELOADS: Save/load process finished.\n");
-	}
+    startIndex++;
+    if (startIndex > endIndex)
+    {
+        execute = false;
+        Warning("SAVELOADS: Save/load process finished.\n");
+    }
 }


### PR DESCRIPTION
- Added `spt_noclip_persist`: makes the player indefinitely float at the speed and in the direction of movement before entering noclip. Potentially useful for voidclip routing.
- Added `spt_turn `commands: automated pitch and yaw viewangle turning. Potentially useful for more genuine tauboosting like in Black Mesa.
- Rewrote `spt_saveload`'s description to be more detailed with examples and clearer explanations.
- Fixed a bug where `DoImageSpaceMotionBlur`'s `pgpGlobals` was enumerated in `LoadFeature` through an offset from `ORIG` pointers, which no longer point to the original functions but rather the trampoline ones.
- Fixed `GameMovement` interface for Black Mesa.