### PR TITLE
spt_con_notify

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1180,6 +1180,7 @@ copy "$(TargetPath)" "$(IntDir)..\builds\$(TargetFileName)"</Command>
     <ClCompile Include="spt\features\boog.cpp" />
     <ClCompile Include="spt\features\camera.cpp" />
     <ClCompile Include="spt\features\collision_group.cpp" />
+    <ClCompile Include="spt\features\con_notify.cpp" />
     <ClCompile Include="spt\features\cvar.cpp" />
     <ClCompile Include="spt\features\demo.cpp" />
     <ClCompile Include="spt\features\dmomm.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -346,6 +346,9 @@
     <ClCompile Include="spt\features\portalled_pause.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\con_notify.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/features/con_notify.cpp
+++ b/spt/features/con_notify.cpp
@@ -1,0 +1,101 @@
+#include "stdafx.hpp"
+#include "..\feature.hpp"
+
+ConVar spt_con_notify_cvar("spt_con_notify", 
+                           "0", 
+                           0,
+                           "Enables or disables console notifying (printing of console text at the top left of the screen, like with developer 1)");
+
+ConVar* developer;
+
+namespace patterns
+{
+	PATTERNS(Con_ColorPrint, 
+             "BMS 0.9", 
+             "55 8B EC 83 EC 08 80 3D ?? ?? ?? ?? 00 0F 85");
+	PATTERNS(CConPanel__AddToNotify, 
+             "BMS 0.9", 
+             "55 8B EC 81 EC 30 08 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 ?? 80 3D ?? ?? ?? ?? 00");
+	PATTERNS(CConPanel__DrawNotify,
+	         "BMS 0.9",
+	         "55 8B EC 83 EC 3C 56 8B F1 C7 45 ?? 05 00 00 00");
+}
+
+// Feature description
+class ConNotify : public FeatureWrapper<ConNotify>
+{
+public:
+protected:
+    virtual bool ShouldLoadFeature() override;
+
+    virtual void InitHooks() override;
+
+    virtual void LoadFeature() override;
+
+private:
+    DECL_HOOK_CDECL(void, Con_ColorPrint, const Color& clr, char const* msg);
+	DECL_HOOK_THISCALL(void, CConPanel__AddToNotify, void*, const Color& clr, char const* msg);
+    DECL_HOOK_THISCALL(void, CConPanel__DrawNotify, void*);
+};
+
+static ConNotify spt_con_notify;
+
+bool ConNotify::ShouldLoadFeature()
+{
+    return true;
+}
+
+void ConNotify::InitHooks()
+{
+    HOOK_FUNCTION(engine, Con_ColorPrint);
+    HOOK_FUNCTION(engine, CConPanel__AddToNotify);
+    HOOK_FUNCTION(engine, CConPanel__DrawNotify);
+
+    developer = g_pCVar->FindVar("developer");
+}
+
+void ConNotify::LoadFeature()
+{
+    if (ORIG_CConPanel__AddToNotify == nullptr 
+        || ORIG_CConPanel__DrawNotify == nullptr
+	    || ORIG_Con_ColorPrint == nullptr 
+        || developer == nullptr)
+	    return;
+
+    InitConcommandBase(spt_con_notify_cvar);
+}
+
+// just turn on developer before entering these functions
+#define IMPL(funcName, ...) \
+{ \
+    if (!spt_con_notify_cvar.GetBool()) \
+    { \
+        spt_con_notify.ORIG_##funcName(__VA_ARGS__);\
+        return;\
+	} \
+ \
+    const char* devVal = developer->GetString(); \
+    char* oldDev = new char[strlen(devVal)]; \
+    strcpy(oldDev, devVal); \
+    developer->SetValue(true); \
+ \
+    spt_con_notify.ORIG_##funcName(__VA_ARGS__); \
+ \
+    developer->SetValue(oldDev); \
+    return;\
+}
+
+IMPL_HOOK_CDECL(ConNotify, void, Con_ColorPrint, const Color& clr, char const* msg) 
+{
+    IMPL(Con_ColorPrint, clr, msg);
+}
+
+IMPL_HOOK_THISCALL(ConNotify, void, CConPanel__AddToNotify, void*, const Color& clr, char const* msg)
+{
+    IMPL(CConPanel__AddToNotify, thisptr, clr, msg);
+}
+
+IMPL_HOOK_THISCALL(ConNotify, void, CConPanel__DrawNotify, void*)
+{
+    IMPL(CConPanel__DrawNotify, thisptr);
+}

--- a/spt/features/con_notify.cpp
+++ b/spt/features/con_notify.cpp
@@ -12,13 +12,19 @@ namespace patterns
 {
 	PATTERNS(Con_ColorPrint, 
              "BMS 0.9", 
-             "55 8B EC 83 EC 08 80 3D ?? ?? ?? ?? 00 0F 85");
+             "55 8B EC 83 EC 08 80 3D ?? ?? ?? ?? 00 0F 85", 
+             "5135", 
+             "83 EC 08 80 3D ?? ?? ?? ?? 00 0F 85");
 	PATTERNS(CConPanel__AddToNotify, 
              "BMS 0.9", 
-             "55 8B EC 81 EC 30 08 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 ?? 80 3D ?? ?? ?? ?? 00");
+             "55 8B EC 81 EC 30 08 00 00 A1 ?? ?? ?? ?? 33 C5 89 45 ?? 80 3D ?? ?? ?? ?? 00",
+             "5135", 
+             "81 EC 04 08 00 00 80 3D ?? ?? ?? ?? 00");
 	PATTERNS(CConPanel__DrawNotify,
 	         "BMS 0.9",
-	         "55 8B EC 83 EC 3C 56 8B F1 C7 45 ?? 05 00 00 00");
+	         "55 8B EC 83 EC 3C 56 8B F1 C7 45 ?? 05 00 00 00",
+	         "5135",
+	         "83 EC 08 55 57 8B F9");
 }
 
 // Feature description

--- a/spt/features/con_notify.cpp
+++ b/spt/features/con_notify.cpp
@@ -22,7 +22,7 @@ namespace patterns
 }
 
 // Feature description
-class ConNotify : public FeatureWrapper<ConNotify>
+class ConNotifyFeature : public FeatureWrapper<ConNotifyFeature>
 {
 public:
 protected:
@@ -38,14 +38,14 @@ private:
     DECL_HOOK_THISCALL(void, CConPanel__DrawNotify, void*);
 };
 
-static ConNotify spt_con_notify;
+static ConNotifyFeature spt_con_notify;
 
-bool ConNotify::ShouldLoadFeature()
+bool ConNotifyFeature::ShouldLoadFeature()
 {
     return true;
 }
 
-void ConNotify::InitHooks()
+void ConNotifyFeature::InitHooks()
 {
     HOOK_FUNCTION(engine, Con_ColorPrint);
     HOOK_FUNCTION(engine, CConPanel__AddToNotify);
@@ -54,7 +54,7 @@ void ConNotify::InitHooks()
     developer = g_pCVar->FindVar("developer");
 }
 
-void ConNotify::LoadFeature()
+void ConNotifyFeature::LoadFeature()
 {
     if (ORIG_CConPanel__AddToNotify == nullptr 
         || ORIG_CConPanel__DrawNotify == nullptr
@@ -85,17 +85,17 @@ void ConNotify::LoadFeature()
     return;\
 }
 
-IMPL_HOOK_CDECL(ConNotify, void, Con_ColorPrint, const Color& clr, char const* msg) 
+IMPL_HOOK_CDECL(ConNotifyFeature, void, Con_ColorPrint, const Color& clr, char const* msg) 
 {
     IMPL(Con_ColorPrint, clr, msg);
 }
 
-IMPL_HOOK_THISCALL(ConNotify, void, CConPanel__AddToNotify, void*, const Color& clr, char const* msg)
+IMPL_HOOK_THISCALL(ConNotifyFeature, void, CConPanel__AddToNotify, void*, const Color& clr, char const* msg)
 {
     IMPL(CConPanel__AddToNotify, thisptr, clr, msg);
 }
 
-IMPL_HOOK_THISCALL(ConNotify, void, CConPanel__DrawNotify, void*)
+IMPL_HOOK_THISCALL(ConNotifyFeature, void, CConPanel__DrawNotify, void*)
 {
     IMPL(CConPanel__DrawNotify, thisptr);
 }


### PR DESCRIPTION
- Added `spt_con_notify` which allows the viewing of console messages on the top of the screen without having to enable `developer` mode.