### PR TITLE
Add spt_drawline and other small fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,10 +29,10 @@ jobs:
           - {SDK: episode1, Configuration_2: ' OE'}
     steps:
       - name: Checkout SPT
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init -j $env:NUMBER_OF_PROCESSORS SPTLib SDK\${{ matrix.config.SDK }}
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: microsoft/setup-msbuild@v2
       - name: Build
         run: msbuild -m -nologo -p:Configuration="${{ matrix.Configuration }}${{ matrix.config.Configuration_2 }}" spt.sln
       - name: Get SPT DLL name
@@ -40,7 +40,7 @@ jobs:
         run: |
           $spt_filename = (Get-Item "${{ matrix.Configuration }}${{ matrix.config.Configuration_2 }}\spt*.dll").BaseName
           echo "spt_filename=$spt_filename" >> $env:GITHUB_OUTPUT
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.Configuration }}${{ matrix.config.Configuration_2 }} - ${{ steps.get_spt_filename.outputs.spt_filename }}
           path: ${{ matrix.Configuration }}${{ matrix.config.Configuration_2 }}\${{ steps.get_spt_filename.outputs.spt_filename }}.dll

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1226,6 +1226,7 @@ copy "$(TargetPath)" "$(IntDir)..\builds\$(TargetFileName)"</Command>
     <ClCompile Include="spt\features\tracing.cpp" />
     <ClCompile Include="spt\features\updater.cpp" />
     <ClCompile Include="spt\features\vag_searcher.cpp" />
+    <ClCompile Include="spt\features\visualizations\drawline.cpp" />
     <ClCompile Include="spt\features\visualizations\draw_ent_collides.cpp" />
     <ClCompile Include="spt\features\visualizations\draw_seams.cpp" />
     <ClCompile Include="spt\features\visualizations\draw_world_collides.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -352,6 +352,9 @@
     <ClCompile Include="spt\features\visualizations\oob_ents.cpp">
       <Filter>spt\features\visualizations</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\visualizations\drawline.cpp">
+      <Filter>spt\features\visualizations</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -24,6 +24,8 @@ ConVar spt_draw_world_collides(
     "    - white: displacement\n"
     "    - red: static prop");
 
+extern ConVar tas_pause;
+
 // this hidden cvar can be used to change the mask
 const std::string _g_default_mask_str = std::to_string(MASK_PLAYERSOLID | MASK_VISIBLE);
 ConVar spt_draw_world_collides_mask("spt_draw_world_collides_mask",
@@ -108,7 +110,7 @@ private:
 		// this does not work when we're in a vehicle, we'd want to use a modified version of CBasePlayer::CalcView
 		Vector eyePos = utils::GetPlayerEyePosition();
 		static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true, true> vangle;
-		QAngle eyeAng = *vangle.GetPtrPlayer();
+		QAngle eyeAng = tas_pause.GetBool() ? utils::GetPlayerEyeAngles() : *vangle.GetPtrPlayer();
 
 		// this transform may be slightly off since it uses client-side ents
 		auto env = GetEnvironmentPortal();

--- a/spt/features/visualizations/drawline.cpp
+++ b/spt/features/visualizations/drawline.cpp
@@ -1,0 +1,152 @@
+#include "stdafx.hpp"
+
+#include "renderer\mesh_renderer.hpp"
+
+#ifdef SPT_MESH_RENDERING_ENABLED
+
+#include <vector>
+
+// Draw the brushes from another map
+class DrawLine : public FeatureWrapper<DrawLine>
+{
+public:
+	struct LineInfo
+	{
+		Vector start, end;
+		color32 color;
+	};
+
+	void AddLine(LineInfo line);
+	void ClearLines();
+
+protected:
+	virtual bool ShouldLoadFeature() override;
+
+	virtual void InitHooks() override;
+
+	virtual void LoadFeature() override;
+
+	virtual void UnloadFeature() override;
+
+private:
+	void OnMeshRenderSignal(MeshRendererDelegate& mr);
+
+	bool should_recompute_meshes = false;
+	std::vector<LineInfo> lines;
+	std::vector<StaticMesh> meshes;
+};
+
+static DrawLine feat_drawline;
+
+CON_COMMAND(spt_drawline,
+            "Draws line between two 3D Points.\n"
+            "spt_drawline <x> <y> <z> <x> <y> <z> [r] [g] [b]\n"
+            "\"spt_drawline 0\" to clear all lines")
+{
+	int argc = args.ArgC();
+	if (argc == 2 && strcmp(args.Arg(1), "0") == 0)
+	{
+		feat_drawline.ClearLines();
+		return;
+	}
+
+	if (argc != 7 && argc != 10)
+	{
+		return Msg(
+		    "spt_drawline <x> <y> <z> <x> <y> <z> [r] [g] [b]\n"
+		    "\"spt_drawline 0\" to clear all lines\n");
+	}
+
+	float x0 = atof(args[1]);
+	float y0 = atof(args[2]);
+	float z0 = atof(args[3]);
+	float x1 = atof(args[4]);
+	float y1 = atof(args[5]);
+	float z1 = atof(args[6]);
+
+	uint8_t r = 255;
+	uint8_t g = 255;
+	uint8_t b = 255;
+
+	if (args.ArgC() == 10)
+	{
+		r = (uint8_t)atoi(args[7]);
+		g = (uint8_t)atoi(args[8]);
+		b = (uint8_t)atoi(args[9]);
+	}
+
+	feat_drawline.AddLine({
+	    {x0, y0, z0},
+	    {x1, y1, z1},
+	    {r, g, b, 255},
+	});
+}
+
+void DrawLine::AddLine(LineInfo line)
+{
+	should_recompute_meshes = true;
+	lines.push_back(line);
+}
+
+void DrawLine::ClearLines()
+{
+	meshes.clear();
+	lines.clear();
+}
+
+void DrawLine::OnMeshRenderSignal(MeshRendererDelegate& mr)
+{
+	if (std::any_of(meshes.begin(), meshes.end(), [](auto& mesh) { return !mesh.Valid(); }))
+		should_recompute_meshes = true;
+
+	if (should_recompute_meshes)
+	{
+		should_recompute_meshes = false;
+		meshes.clear();
+
+		auto linesIter = lines.begin();
+		const auto linesEnd = lines.end();
+		while (linesIter != linesEnd)
+		{
+			meshes.push_back(spt_meshBuilder.CreateStaticMesh(
+			    [&](MeshBuilderDelegate& mb)
+			    {
+				    for (; linesIter != linesEnd; linesIter++)
+					    if (!mb.AddLine((*linesIter).start,
+					                    (*linesIter).end,
+					                    LineColor((*linesIter).color, false)))
+						    break;
+			    }));
+		}
+	}
+
+	if (!meshes.empty())
+	{
+		for (const auto& mesh : meshes)
+		{
+			mr.DrawMesh(mesh,
+			            [](const CallbackInfoIn& infoIn, CallbackInfoOut& infoOut)
+			            { RenderCallbackZFightFix(infoIn, infoOut); });
+		}
+	}
+}
+
+bool DrawLine::ShouldLoadFeature()
+{
+	return true;
+}
+
+void DrawLine::InitHooks() {}
+
+void DrawLine::LoadFeature()
+{
+	if (spt_meshRenderer.signal.Works)
+	{
+		InitCommand(spt_drawline);
+		spt_meshRenderer.signal.Connect(this, &DrawLine::OnMeshRenderSignal);
+	}
+}
+
+void DrawLine::UnloadFeature() {}
+
+#endif

--- a/spt/features/visualizations/portal_placement.cpp
+++ b/spt/features/visualizations/portal_placement.cpp
@@ -314,7 +314,7 @@ void PortalPlacement::OnMeshRenderSignal(MeshRendererDelegate& mr)
 
 		size_t maxVerts, maxIndices;
 		GetMaxMeshSize(maxVerts, maxIndices, true);
-		const int maxCubesPerMesh = MIN(maxIndices / 36, maxVerts / 8);
+		const int maxCubesPerMesh = MIN(maxIndices / 36, maxVerts / 8) - 1;
 
 		for (size_t start = 0; start < ppGrid.unmergedPts.size(); start += maxCubesPerMesh)
 		{
@@ -329,7 +329,7 @@ void PortalPlacement::OnMeshRenderSignal(MeshRendererDelegate& mr)
 		UpdatePlacementInfo();
 		placementInfoUpdateRequested = false;
 	}
-	
+
 	if (!y_spt_draw_pp.GetBool())
 		return;
 
@@ -371,7 +371,7 @@ void PortalPlacement::RunPpGridIteration(MeshRendererDelegate& mr)
 
 	size_t maxVerts, maxIndices;
 	GetMaxMeshSize(maxVerts, maxIndices, false);
-	const size_t maxCubesPerMesh = MIN(maxIndices / 36, maxVerts / 8);
+	const size_t maxCubesPerMesh = MIN(maxIndices / 36, maxVerts / 8) - 1;
 
 	int gridWidth = ppGrid.gridWidth;
 	int numGridPts = gridWidth * gridWidth;
@@ -428,8 +428,15 @@ void PortalPlacement::RunPpGridIteration(MeshRendererDelegate& mr)
 		bool fizzle;
 
 		const int PORTAL_PLACED_BY_PLAYER = 2;
-		float placementResult = spt_tracing.ORIG_TraceFirePortal(
-		    pgun, bPortal2, ppGrid.camPos, dir, tr, placePos, placeAng, PORTAL_PLACED_BY_PLAYER, true);
+		float placementResult = spt_tracing.ORIG_TraceFirePortal(pgun,
+		                                                         bPortal2,
+		                                                         ppGrid.camPos,
+		                                                         dir,
+		                                                         tr,
+		                                                         placePos,
+		                                                         placeAng,
+		                                                         PORTAL_PLACED_BY_PLAYER,
+		                                                         true);
 
 		if (!tr.DidHit())
 			continue;
@@ -588,11 +595,11 @@ void PortalPlacement::LoadFeature()
 			    else if (mode == 2)
 			    {
 				    spt_hud_feat.DrawColorTopHudElement(blueTextColor,
-				                                   L"Portal1: %s",
-				                                   PlacementResultToString(spt_pp.p1));
+				                                        L"Portal1: %s",
+				                                        PlacementResultToString(spt_pp.p1));
 				    spt_hud_feat.DrawColorTopHudElement(orangeTextColor,
-				                                   L"Portal2: %s",
-				                                   PlacementResultToString(spt_pp.p2));
+				                                        L"Portal2: %s",
+				                                        PlacementResultToString(spt_pp.p2));
 			    }
 			    else
 			    {


### PR DESCRIPTION
`spt_drawline` - Draws line between two 3D Points.
Like `drawline` but with a color option and not debug overlay.
We can now harness the power of [Portal 2 tool](https://krzyhau.github.io/SeamshotCalculator/) by replacing the generated commands.

Other fixes:
Update some CI versions
Fix off-by-one error in pp grid.
Make spt_draw_world_collides update during tas_pause.