### PR TITLE
Isg in Black Mesa, hardlocking improvement, fastloading improvement

### DIFF
--- a/spt/features/game_fixes/fastload.cpp
+++ b/spt/features/game_fixes/fastload.cpp
@@ -3,19 +3,12 @@
 #include "..\generic.hpp"
 #include "signals.hpp"
 
-#ifdef BMS
-ConVar y_spt_fast_loads(
-    "y_spt_fast_loads",
-    "1",
-    0,
-    "Increases FPS and turns off rendering during loads to speed up load times. Values greater than one set fps_max to the value after loading.");
-#else
+
 ConVar y_spt_fast_loads(
     "y_spt_fast_loads",
     "0",
     0,
     "Increases FPS and turns off rendering during loads to potentially speed up long load times. Values greater than one set fps_max to the value after loading.");
-#endif
 
 // Speed up loads minimally
 class FastLoads : public FeatureWrapper<FastLoads>
@@ -23,6 +16,7 @@ class FastLoads : public FeatureWrapper<FastLoads>
 public:
 	ConVar* fps_max = nullptr;
 	ConVar* mat_norendering = nullptr;
+	float prevfps_max;
 	void TurnOnFastLoads();
 	void TurnOffFastLoads();
 
@@ -76,7 +70,7 @@ void FastLoads::TurnOffFastLoads()
 		}
 		else
 		{
-			fast_loads.fps_max->SetValue(300);
+			fast_loads.fps_max->SetValue(prevfps_max);
 		}
 		fast_loads.mat_norendering->SetValue(0);
 	}
@@ -86,6 +80,7 @@ void FastLoads::TurnOnFastLoads()
 {
 	if (y_spt_fast_loads.GetBool())
 	{
+		prevfps_max = fast_loads.fps_max->GetFloat();
 		fast_loads.fps_max->SetValue(0);
 		fast_loads.mat_norendering->SetValue(1);
 	}

--- a/spt/features/isg.cpp
+++ b/spt/features/isg.cpp
@@ -8,7 +8,6 @@
 
 #include "convar.hpp"
 
-#if defined(SSDK2007) || defined(SSDK2013) || defined(OE)
 
 ConVar y_spt_hud_isg("y_spt_hud_isg", "0", FCVAR_CHEAT, "Is the ISG flag set?\n");
 
@@ -20,7 +19,9 @@ namespace patterns
 	         "1910503",
 	         "C6 05 ?? ?? ?? ?? 01 4E 3B 75 ?? 7D ??",
 	         "DMoMM",
-	         "C6 05 ?? ?? ?? ?? 01 83 EE 01 3B 74 24 30 7D D5");
+	         "C6 05 ?? ?? ?? ?? 01 83 EE 01 3B 74 24 30 7D D5",
+	         "BMS-0.9",
+	         "C6 05 ?? ?? ?? ?? 01 4E 3B B5 ?? ?? ?? ?? 7D ?? 8B 8D ?? ?? ?? ?? 8B 9D ?? ?? ?? ?? 0F B7 85");
 }
 
 // This feature enables the ISG setting and HUD features
@@ -93,12 +94,3 @@ void ISGFeature::LoadFeature()
 }
 
 void ISGFeature::UnloadFeature() {}
-
-#else
-
-bool IsISGActive()
-{
-	return false;
-}
-
-#endif


### PR DESCRIPTION
- Isg pattern added for black mesa
- Hardlocking prevention expanded from just black mesa to other games, and instead of preventing `BroadcastMessage `entirely, just prevents the specific `Host_Error` call inside of it
- Default fastloading to 0 in all dlls, change it to restore old fps_max value by default