### PR TITLE
ImGui related fixes

### DIFF
--- a/spt/cvars.cpp
+++ b/spt/cvars.cpp
@@ -239,36 +239,22 @@ const char* WrangleLegacyCommandName(const char* name, bool useTempStorage, bool
 
 	size_t allocLen = newName ? strlen(newName) + 2 // ex: +y_spt_duckspam
 	                          : strlen(name) + 5;   // ex: tas_pause, +myprefix_something
+	AssertMsg(allocLen < SPT_MAX_CVAR_NAME_LEN, "spt: cvar name too long!");
 
-	// (re)allocate new string
-	char* allocStr;
-	if (useTempStorage)
-	{
-		if (allocLen > tmpLen)
-		{
-			delete[] tmpStr;
-			tmpStr = new char[allocLen];
-			tmpLen = allocLen;
-		}
-		allocStr = tmpStr;
-	}
-	else
-	{
-		allocStr = new char[allocLen];
-	}
+	static char tmpStorage[SPT_MAX_CVAR_NAME_LEN];
+	char* retStr = useTempStorage ? tmpStorage : new char[allocLen];
+	retStr[0] = name[0];
 
 	if (newName)
 	{
-		allocStr[0] = name[0];
-		strcpy(allocStr + 1, newName);
+		strcpy(retStr + 1, newName);
 	}
 	else
 	{
-		allocStr[0] = name[0];
-		strcpy(allocStr + plusMinus, "spt_");
-		strcat(allocStr, name + plusMinus);
+		strcpy(retStr + plusMinus, "spt_");
+		strcat(retStr, name + plusMinus);
 	}
-	return allocStr;
+	return retStr;
 }
 
 // Check if spt_ prefix is at the start. If not, create a new command and hide the old one with
@@ -306,7 +292,7 @@ static void HandleBackwardsCompatibility(FeatureCommand& featCmd, const char* cm
 	}
 
 	// After the push the featCmd reference can be invalid!!!
-	FeatureCommand newCmd = { featCmd.owner, newCommand, true, allocatedName, false };
+	FeatureCommand newCmd = {featCmd.owner, newCommand, true, allocatedName, false};
 	cmd_to_feature.push_back(newCmd);
 }
 

--- a/spt/cvars.hpp
+++ b/spt/cvars.hpp
@@ -2,6 +2,9 @@
 
 #include "convar.hpp"
 
+// max length including null terminator
+#define SPT_MAX_CVAR_NAME_LEN 64
+
 void Cvar_RegisterSPTCvars();
 void Cvar_UnregisterSPTCvars();
 void Cvar_InitConCommandBase(ConCommandBase& concommand, void* owner);
@@ -27,8 +30,8 @@ extern ConVar* _sv_bounce;
 extern ConVar* _sv_cheats;
 
 /*
-* Converts legacy SPT command names to new ones. Uses either a temporary string that is only
-* valid until the next call, or allocates a new string that must be deallocated manually.
+* Converts legacy SPT command names to new ones. Uses either a temporary string that is only valid
+* until the next call, or allocates a new string w/ new[] that must be deallocated manually.
 * 
 * Examples:
 * spt_hud_position -> spt_hud_position  (allocated=false)

--- a/spt/feature.hpp
+++ b/spt/feature.hpp
@@ -10,7 +10,7 @@
 
 /*
 * Prefer using DECL_STATIC_HOOK_XXX over DECL_HOOK_XXX.
-* The difference is that with the latter you can do:
+* The difference is that with the former you can do:
 * 
 * IMPL_HOOK_XXX(SptFeature, void, GameFn, int arg1) {
 *   ORIG_GameFn(arg1);

--- a/spt/features/updater.cpp
+++ b/spt/features/updater.cpp
@@ -254,16 +254,6 @@ std::string Updater::Request(const char* url)
 	return response;
 }
 
-static int GetPluginBuildNumber()
-{
-	// Use the way Source Engine calculates the build number to calculate SPT "build number"
-	int pluginBuildNumber = 0;
-	char sptVersion[12];
-	snprintf(sptVersion, sizeof sptVersion, SPT_VERSION);
-	pluginBuildNumber = utils::DateToBuildNumber(sptVersion);
-	return pluginBuildNumber;
-}
-
 bool Updater::FetchReleaseInfo()
 {
 	std::string data = Request("https://api.github.com/repos/YaLTeR/SourcePauseTool/releases/latest");
@@ -422,7 +412,6 @@ void Updater::UpdatePlugin()
 		return;
 	}
 
-
 	fs::copy(tmpPath, sptPath, ec);
 	if (ec)
 	{
@@ -475,7 +464,7 @@ int Updater::CheckUpdate()
 	}
 
 	int latestBuildNum = release.build;
-	int currentBuildNum = GetPluginBuildNumber();
+	int currentBuildNum = utils::DateToBuildNumber(SPT_VERSION);
 
 	DevMsg("Latest: %d\n", latestBuildNum);
 	DevMsg("Current: %d\n", currentBuildNum);

--- a/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
+++ b/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
@@ -167,10 +167,10 @@ void SptImGui::TextInputAutocomplete(const char* inputTextLabel,
 				* results. If we change this to a more generic (non ConCommand) based function,
 				* feed the textbox input directly to the autocomplete func instead of prefixing it.
 				*/
-			    static ImGuiTextBuffer tmpBuf;
-			    tmpBuf.Buf.clear();
-			    tmpBuf.appendf("%s %s", ud.cmdName, data->Buf);
-			    pd.nAutocomplete = ud.autocompleteFn(tmpBuf.Buf.Data, pd.autocomplete);
+			    static char tmpBuf[SPT_MAX_CVAR_NAME_LEN + COMMAND_COMPLETION_ITEM_LENGTH + 2];
+			    snprintf(tmpBuf, sizeof tmpBuf, "%s %s", ud.cmdName, data->Buf);
+			    tmpBuf[sizeof(tmpBuf) - 1] = '\0';
+			    pd.nAutocomplete = ud.autocompleteFn(tmpBuf, pd.autocomplete);
 			    size_t nTrim = strlen(ud.cmdName) + 1;
 			    for (int i = 0; i < pd.nAutocomplete; i++)
 				    memmove(pd.autocomplete[i], pd.autocomplete[i] + nTrim, data->BufSize - nTrim);


### PR DESCRIPTION
- Fix typo in comment [#339](https://github.com/YaLTeR/SourcePauseTool/pull/339#discussion_r1740200135)
- Remove unnecessary snprintf [#339](https://github.com/YaLTeR/SourcePauseTool/pull/339#discussion_r1739943880)
- Fix cvar name memory leak [#339](https://github.com/YaLTeR/SourcePauseTool/pull/339#discussion_r1739924776) & tidy code [#339](https://github.com/YaLTeR/SourcePauseTool/pull/339#discussion_r1739925464)

I've added the `SPT_MAX_CVAR_NAME_LEN` macro and set it to 64. The memory leak issue is present in many features that I wrote, so I'll go through those and make a separate PR.