### PR TITLE
Fix some memory leaks

### DIFF
--- a/spt/features/con_notify.cpp
+++ b/spt/features/con_notify.cpp
@@ -81,13 +81,14 @@ void ConNotifyFeature::LoadFeature()
 	} \
  \
     const char* devVal = developer->GetString(); \
-    char* oldDev = new char[strlen(devVal)]; \
+    char* oldDev = new char[strlen(devVal) + 1]; \
     strcpy(oldDev, devVal); \
     developer->SetValue(true); \
  \
     spt_con_notify.ORIG_##funcName(__VA_ARGS__); \
  \
     developer->SetValue(oldDev); \
+    delete[] oldDev; \
     return;\
 }
 

--- a/spt/features/game_fixes/noclip_fixes.cpp
+++ b/spt/features/game_fixes/noclip_fixes.cpp
@@ -230,9 +230,10 @@ void NoclipFixesFeature::ToggleNoclipNofix(bool enabled)
 
     if (enabled)
     {
-        MemUtils::ReplaceBytes((void*)PTR_nofixJumpInsc, 1, new uint8[1]{0xE9});
+        uint8 inst_jmp = 0xE9, inst_nop = 0x90;
+        MemUtils::ReplaceBytes((void*)PTR_nofixJumpInsc, 1, &inst_jmp);
         MemUtils::ReplaceBytes((void*)(PTR_nofixJumpInsc + 1), 4, (uint8*)&nofixJumpDistance);
-        MemUtils::ReplaceBytes((void*)(PTR_nofixJumpInsc + 5), 1, new uint8[1]{0x90});
+        MemUtils::ReplaceBytes((void*)(PTR_nofixJumpInsc + 5), 1, &inst_nop);
     }
     else
     {

--- a/spt/features/visualizations/imgui/imgui_interface.cpp
+++ b/spt/features/visualizations/imgui/imgui_interface.cpp
@@ -638,7 +638,7 @@ protected:
 			ImGui::DestroyContext();
 		case LoadState::None:
 		default:
-			ImGuiHudCvar::buffer.Buf.resize(0);
+			ImGuiHudCvar::buffer.Buf.clear();
 			windowCallbacks.clear();
 			nLeafMainWndCallbacks = 0;
 			nRegisteredLeafMainWndCallbacks = 0;


### PR DESCRIPTION
After @SirWillian pointed out the memory leak in my cvar name logic [#339](https://github.com/YaLTeR/SourcePauseTool/pull/339#discussion_r1739924776), I realized that I used static variables for amortized memory allocation costs a lot, and that could result in many other leaks.

## Key takeaways

Static/global variables are *okay* to not explicitly free, <ins>so long as they have a destructor</ins>; this is because the CRT will call those destructors for us. This means it is perfectly fine to have a static/global e.g. `std::vector`, but you need to explicitly free e.g. raw C-style arrays in `UnloadFeature` or something.

After looking for all occurrences of "new " I found a few leaks which I've fixed. Here was my approach to check to make sure those leaks were fixed and how I looked for other leaks:
- uncomment the new/delete operator overrides (to allow the CRT to track allocations)
- enable the VS diagnostic tools
- in `CSourcePauseTool::Load`, take a snapshot of the heap
- at the end of `_DllMainCRTStartup(reason=DLL_PROCESS_DETACH)`, take another snapshot
- check what memory allocations persisted

Obviously this only catches the allocations that actually happened (you need to run feature logic to catch any leaks), and I only tested some drawing features as well as the fixed features in the commit. There may be other leaks in some other features.