### PR TITLE
More stuff for the ImGui text HUD tab

### DIFF
--- a/spt/features/ent_props.cpp
+++ b/spt/features/ent_props.cpp
@@ -10,6 +10,8 @@
 #include "string_utils.hpp"
 #include "spt\utils\portal_utils.hpp"
 #include "SPTLib\patterns.hpp"
+#include "visualizations/imgui/imgui_interface.hpp"
+
 #include <string>
 #include <unordered_map>
 
@@ -445,7 +447,7 @@ void EntProps::LoadFeature()
 #if defined(SPT_HUD_ENABLED) && defined(SPT_PORTAL_UTILS)
 	if (utils::DoesGameLookLikePortal())
 	{
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "portal_bubble",
 		    [this](std::string)
 		    {
@@ -453,6 +455,9 @@ void EntProps::LoadFeature()
 			    spt_hud_feat.DrawTopHudElement(L"portal bubble: %d", in_bubble);
 		    },
 		    y_spt_hud_portal_bubble);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_portal_bubble);
 	}
 #endif
 

--- a/spt/features/hud.hpp
+++ b/spt/features/hud.hpp
@@ -73,6 +73,12 @@ public:
 	virtual bool ShouldLoadFeature() override;
 	bool GetFont(const std::string& fontName, vgui::HFont& fontOut);
 
+	// call from LoadFeature or later
+	bool LoadingSuccessful() const
+	{
+		return loadingSuccessful;
+	}
+
 protected:
 	virtual void InitHooks() override;
 	virtual void PreHook() override;

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -15,6 +15,7 @@
 #include "spt\utils\portal_utils.hpp"
 #include "spt\utils\convar.hpp"
 #include "..\strafe\strafestuff.hpp"
+#include "visualizations/imgui/imgui_interface.hpp"
 
 #ifdef SSDK2007
 #include "mathlib\vmatrix.h"
@@ -901,7 +902,7 @@ void PlayerIOFeature::LoadFeature()
 		{
 			TickSignal.Connect(this, &PlayerIOFeature::OnTick);
 
-			AddHudCallback(
+			bool hudEnabled = AddHudCallback(
 			    "accel",
 			    [this](std::string)
 			    {
@@ -913,76 +914,115 @@ void PlayerIOFeature::LoadFeature()
 				    spt_hud_feat.DrawTopHudElement(L"accel(xy): %.3f", accel.Length2D());
 			    },
 			    y_spt_hud_accel);
+
+			if (hudEnabled)
+				SptImGui::RegisterHudCvarCheckbox(y_spt_hud_accel);
 		}
 
-		AddHudCallback(
-		    "position",
-		    [this](std::string args)
-		    {
-			    int mode = (args == "") ? spt_hud_position.GetInt() : std::stoi(args);
-			    Vector pos = (mode == 1) ? m_vecAbsOrigin.GetValue() + m_vecViewOffset.GetValue()
-			                             : m_vecAbsOrigin.GetValue();
-			    int precision = (mode == 1) ? 2 : mode;
+		{
+			bool hudEnabled = AddHudCallback(
+			    "position",
+			    [this](std::string args)
+			    {
+				    int mode = (args == "") ? spt_hud_position.GetInt() : std::stoi(args);
+				    Vector pos = (mode == 1) ? m_vecAbsOrigin.GetValue() + m_vecViewOffset.GetValue()
+				                             : m_vecAbsOrigin.GetValue();
+				    int precision = (mode == 1) ? 2 : mode;
 
-			    spt_hud_feat.DrawTopHudElement(L"pos: %.*f %.*f %.*f",
-			                                   precision,
-			                                   pos.x,
-			                                   precision,
-			                                   pos.y,
-			                                   precision,
-			                                   pos.z);
-		    },
-		    spt_hud_position);
+				    spt_hud_feat.DrawTopHudElement(L"pos: %.*f %.*f %.*f",
+				                                   precision,
+				                                   pos.x,
+				                                   precision,
+				                                   pos.y,
+				                                   precision,
+				                                   pos.z);
+			    },
+			    spt_hud_position);
 
-		AddHudCallback(
-		    "angles",
-		    [this](std::string args)
-		    {
-			    int mode = (args == "") ? spt_hud_angles.GetInt() : std::stoi(args);
-			    QAngle ang = utils::GetPlayerEyeAngles();
-			    int precision = (mode < 2) ? 2 : mode;
+			if (hudEnabled)
+			{
+				SptImGui::RegisterHudCvarCallback(
+				    spt_hud_position,
+				    [](ConVar& cv)
+				    {
+					    const char* opts[] = {
+					        "Disabled",
+					        "Eye position",
+					        "Player position (high precision)",
+					    };
+					    SptImGui::CvarCombo(cv, "##pos", opts, ARRAYSIZE(opts));
+				    },
+				    false);
+			}
+		}
 
-			    spt_hud_feat.DrawTopHudElement(L"ang: %.*f %.*f %.*f",
-			                                   precision,
-			                                   ang.x,
-			                                   precision,
-			                                   ang.y,
-			                                   precision,
-			                                   ang.z);
-		    },
-		    spt_hud_angles);
+		{
+			bool hudEnabled = AddHudCallback(
+			    "angles",
+			    [this](std::string args)
+			    {
+				    int mode = (args == "") ? spt_hud_angles.GetInt() : std::stoi(args);
+				    QAngle ang = utils::GetPlayerEyeAngles();
+				    int precision = (mode < 2) ? 2 : mode;
 
-		AddHudCallback(
-		    "velocity",
-		    [this](std::string args)
-		    {
-			    int mode = (args == "") ? y_spt_hud_velocity.GetInt() : std::stoi(args);
-			    Vector currentVel = GetPlayerVelocity();
-			    if (mode != 2)
-				    spt_hud_feat.DrawTopHudElement(L"vel(xyz): %.3f %.3f %.3f",
-				                                   currentVel.x,
-				                                   currentVel.y,
-				                                   currentVel.z);
-			    if (mode != 3)
-				    spt_hud_feat.DrawTopHudElement(L"vel(xy): %.3f", currentVel.Length2D());
-		    },
-		    y_spt_hud_velocity);
+				    spt_hud_feat.DrawTopHudElement(L"ang: %.*f %.*f %.*f",
+				                                   precision,
+				                                   ang.x,
+				                                   precision,
+				                                   ang.y,
+				                                   precision,
+				                                   ang.z);
+			    },
+			    spt_hud_angles);
 
-		AddHudCallback(
-		    "velocity_angles",
-		    [this](std::string)
-		    {
-			    Vector currentVel = GetPlayerVelocity();
-			    QAngle angles;
-			    VectorAngles(currentVel, Vector(0, 0, 1), angles);
-			    spt_hud_feat.DrawTopHudElement(L"vel(p/y/r): %.3f %.3f %.3f", angles.x, angles.y, angles.z);
-		    },
-		    y_spt_hud_velocity_angles);
+			if (hudEnabled)
+				SptImGui::RegisterHudCvarCheckbox(spt_hud_angles);
+		}
+
+		{
+			bool hudEnabled = AddHudCallback(
+			    "velocity",
+			    [this](std::string args)
+			    {
+				    int mode = (args == "") ? y_spt_hud_velocity.GetInt() : std::stoi(args);
+				    Vector currentVel = GetPlayerVelocity();
+				    if (mode != 2)
+					    spt_hud_feat.DrawTopHudElement(L"vel(xyz): %.3f %.3f %.3f",
+					                                   currentVel.x,
+					                                   currentVel.y,
+					                                   currentVel.z);
+				    if (mode != 3)
+					    spt_hud_feat.DrawTopHudElement(L"vel(xy): %.3f", currentVel.Length2D());
+			    },
+			    y_spt_hud_velocity);
+
+			if (hudEnabled)
+				SptImGui::RegisterHudCvarCheckbox(y_spt_hud_velocity);
+		}
+
+		{
+			bool hudEnabled = AddHudCallback(
+			    "velocity_angles",
+			    [this](std::string)
+			    {
+				    Vector currentVel = GetPlayerVelocity();
+				    QAngle angles;
+				    VectorAngles(currentVel, Vector(0, 0, 1), angles);
+				    spt_hud_feat.DrawTopHudElement(L"vel(p/y/r): %.3f %.3f %.3f",
+				                                   angles.x,
+				                                   angles.y,
+				                                   angles.z);
+			    },
+			    y_spt_hud_velocity_angles);
+
+			if (hudEnabled)
+				SptImGui::RegisterHudCvarCheckbox(y_spt_hud_velocity_angles);
+		}
 
 #ifdef SPT_PORTAL_UTILS
 		if (utils::DoesGameLookLikePortal())
 		{
-			AddHudCallback(
+			bool hudEnabled = AddHudCallback(
 			    "ag_sg_tester",
 			    [this](std::string)
 			    {
@@ -992,6 +1032,9 @@ void PlayerIOFeature::LoadFeature()
 				    spt_hud_feat.DrawTopHudElement(L"ag sg: %s", result.c_str());
 			    },
 			    y_spt_hud_ag_sg_tester);
+
+			if (hudEnabled)
+				SptImGui::RegisterHudCvarCheckbox(y_spt_hud_ag_sg_tester);
 		}
 #endif
 #endif
@@ -1027,12 +1070,41 @@ void PlayerIOFeature::LoadFeature()
 		    y_spt_hud_flags);
 
 		if (hasHudFlags)
+		{
 			InitCommand(y_spt_hud_flags_filter);
+
+			SptImGui::RegisterHudCvarCallback(
+			    y_spt_hud_flags,
+			    [](ConVar& cv)
+			    {
+				    ImGui::BeginDisabled(!SptImGui::CvarCheckbox(y_spt_hud_flags, "enabled"));
+				    ImGui::TextUnformatted("Flag filter");
+				    ImGui::SameLine();
+				    SptImGui::HelpMarker("Can be set with %s.",
+				                         WrangleLegacyCommandName(y_spt_hud_flags_filter_command
+				                                                      .GetName(),
+				                                                  true,
+				                                                  nullptr));
+				    if (ImGui::Button("Enable all"))
+					    hud_flags_filter = ~((decltype(hud_flags_filter))0);
+				    ImGui::SameLine();
+				    if (ImGui::Button("Disable all"))
+					    hud_flags_filter = 0;
+				    for (size_t i = 0; i < ARRAYSIZE(FLAGS); i++)
+				    {
+					    bool flag = hud_flags_filter & (1 << i);
+					    if (ImGui::Checkbox(FLAGS[i], &flag))
+						    hud_flags_filter = (hud_flags_filter & ~(1 << i)) | (flag << i);
+				    }
+				    ImGui::EndDisabled();
+			    },
+			    true);
+		}
 	}
 
 	if (m_MoveType.Found())
 	{
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "moveflags",
 		    [this](std::string)
 		    {
@@ -1040,11 +1112,14 @@ void PlayerIOFeature::LoadFeature()
 			    DrawFlagsHud(L"Move type", MOVETYPE_FLAGS, ARRAYSIZE(MOVETYPE_FLAGS), flags);
 		    },
 		    y_spt_hud_moveflags);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_moveflags);
 	}
 
 	if (m_CollisionGroup.Found())
 	{
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "collisionflags",
 		    [this](std::string)
 		    {
@@ -1052,11 +1127,14 @@ void PlayerIOFeature::LoadFeature()
 			    DrawFlagsHud(L"Collision group", COLLISION_GROUPS, ARRAYSIZE(COLLISION_GROUPS), flags);
 		    },
 		    y_spt_hud_collisionflags);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_collisionflags);
 	}
 
 	if (m_MoveCollide.Found())
 	{
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "movecollideflags",
 		    [this](std::string)
 		    {
@@ -1064,6 +1142,9 @@ void PlayerIOFeature::LoadFeature()
 			    DrawFlagsHud(L"Move collide", MOVECOLLIDE_FLAGS, ARRAYSIZE(MOVECOLLIDE_FLAGS), flags);
 		    },
 		    y_spt_hud_movecollideflags);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_movecollideflags);
 	}
 #endif
 }

--- a/spt/features/saveloads.cpp
+++ b/spt/features/saveloads.cpp
@@ -4,6 +4,9 @@
 #include "signals.hpp"
 #include "convar.hpp"
 #include "..\features\afterticks.hpp"
+#include "spt\features\hud.hpp"
+#include "visualizations/imgui/imgui_interface.hpp"
+
 #include <format>
 
 static std::vector<const char*> _saveloadTypes = {"segment", "execute", "render"};
@@ -134,7 +137,7 @@ void SaveloadsFeature::LoadFeature()
 	InitCommand(y_spt_saveloads_stop);
 
 #ifdef SPT_HUD_ENABLED
-	AddHudCallback(
+	bool hudEnabled = AddHudCallback(
 	    "saveloads_showcurindex",
 	    [this](std::string)
 	    {
@@ -147,6 +150,9 @@ void SaveloadsFeature::LoadFeature()
 			    spt_hud_feat.DrawTopHudElement(L"SAVELOADS: Not executing");
 	    },
 	    y_spt_hud_saveloads_showcurindex);
+
+	if (hudEnabled)
+		SptImGui::RegisterHudCvarCheckbox(y_spt_hud_saveloads_showcurindex);
 #endif
 
 	SetSignonStateSignal.Connect(this, &SaveloadsFeature::OnSetSignonState);

--- a/spt/features/shadow.cpp
+++ b/spt/features/shadow.cpp
@@ -6,6 +6,7 @@
 #include "ent_utils.hpp"
 #include "ent_props.hpp"
 #include "playerio.hpp"
+#include "visualizations/imgui/imgui_interface.hpp"
 
 ConVar y_spt_hud_shadow_info("y_spt_hud_shadow_info",
                              "0",
@@ -73,7 +74,7 @@ void ShadowPosition::LoadFeature()
 	if (ORIG_GetShadowPosition)
 	{
 #ifdef SPT_HUD_ENABLED
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "shadow_info",
 		    [this](std::string)
 		    {
@@ -83,6 +84,9 @@ void ShadowPosition::LoadFeature()
 			    spt_hud_feat.DrawTopHudElement(L"shadow ang (pyr): %.3f %.3f %.3f", ang.x, ang.y, ang.z);
 		    },
 		    y_spt_hud_shadow_info);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_shadow_info);
 #endif
 	}
 

--- a/spt/features/tas.cpp
+++ b/spt/features/tas.cpp
@@ -12,6 +12,7 @@
 #include "interfaces.hpp"
 #include "tracing.hpp"
 #include "signals.hpp"
+#include "visualizations/imgui/imgui_interface.hpp"
 
 ConVar tas_strafe("tas_strafe", "0", FCVAR_TAS_RESET);
 ConVar tas_strafe_type(
@@ -309,7 +310,7 @@ void TASFeature::LoadFeature()
 
 		AfterFramesSignal.Connect(&scripts::g_TASReader, &scripts::SourceTASReader::OnAfterFrames);
 #ifdef SPT_HUD_ENABLED
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "script_progress",
 		    [this](std::string)
 		    {
@@ -318,6 +319,9 @@ void TASFeature::LoadFeature()
 			                                   scripts::g_TASReader.GetCurrentScriptLength());
 		    },
 		    y_spt_hud_script_progress);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_script_progress);
 #endif
 	}
 

--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -12,6 +12,7 @@
 #include "..\strafe\strafestuff.hpp"
 #include "portal_utils.hpp"
 #include "ent_props.hpp"
+#include "visualizations/imgui/imgui_interface.hpp"
 
 #include "model_types.h"
 
@@ -543,7 +544,7 @@ void Tracing::LoadFeature()
 #ifdef SPT_HUD_ENABLED
 	if (interfaces::engineTraceClient)
 	{
-		AddHudCallback(
+		bool hudEnabled = AddHudCallback(
 		    "oob",
 		    [](std::string)
 		    {
@@ -554,6 +555,9 @@ void Tracing::LoadFeature()
 			    spt_hud_feat.DrawTopHudElement(L"oob: %d", oob);
 		    },
 		    y_spt_hud_oob);
+
+		if (hudEnabled)
+			SptImGui::RegisterHudCvarCheckbox(y_spt_hud_oob);
 	}
 #endif
 }

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -109,19 +109,9 @@ private:
 		if (newVal != oldVal)
 			c.SetValue(newVal);
 
-		static char buf[16];
-		strncpy(buf, spt_draw_world_collides_mask.GetString(), sizeof buf);
-		buf[sizeof(buf) - 1] = '\0';
-		// this prolly depends on the font size, idk of a better way tho..
-		ImGui::PushItemWidth(ImGui::GetFontSize() * (sizeof(buf) - 1) * 0.6f);
-		ImGui::InputTextWithHint("##cvar_mask",
-		                         "enter integer mask",
-		                         buf,
-		                         sizeof buf,
-		                         ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsUppercase
-		                             | ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_AutoSelectAll);
-		ImGui::PopItemWidth();
-		spt_draw_world_collides_mask.SetValue(buf);
+		long long mask = strtoll(spt_draw_world_collides_mask.GetString(), nullptr, 10);
+		if (SptImGui::InputTextInteger("##cvar_mask", "enter integer mask", mask, 10))
+			spt_draw_world_collides_mask.SetValue((int)mask);
 		ImGui::SameLine();
 		SptImGui::CvarValue(spt_draw_world_collides_mask);
 

--- a/spt/features/visualizations/imgui/imgui_interface.cpp
+++ b/spt/features/visualizations/imgui/imgui_interface.cpp
@@ -7,6 +7,7 @@
 #include "interfaces.hpp"
 #include "spt/spt-serverplugin.hpp"
 #include "spt/utils/spt_vprof.hpp"
+#include "spt/features/hud.hpp"
 
 #include "thirdparty/imgui/imgui_internal.h"
 #include "thirdparty/imgui/imgui_impl_dx9.h"
@@ -414,6 +415,16 @@ private:
 	{
 		if (!open)
 			return;
+
+		// Maybe this callback should be in the HUD feature file? Something to think about..
+
+		extern ConVar y_spt_hud;
+		extern ConVar y_spt_hud_left;
+
+		ImGui::BeginDisabled(!SptImGui::CvarCheckbox(y_spt_hud, "enable text HUD"));
+		SptImGui::CvarCheckbox(y_spt_hud_left, "left HUD");
+		ImGui::Separator();
+
 		int i = 0;
 		for (auto& cvarInfo : hudCvars)
 		{
@@ -445,6 +456,8 @@ private:
 			ImGui::PopID();
 			i++;
 		}
+
+		ImGui::EndDisabled();
 	}
 
 	static void ReloadFontSize()
@@ -626,7 +639,10 @@ protected:
 		SptImGui::RegisterSectionCallback(SptImGuiGroup::Dev_ImGui, DevSectionCallback);
 		SptImGui::RegisterTabCallback(SptImGuiGroup::Settings, SettingsTabCallback);
 		SetupSettingsTabIniHandler();
-		SptImGui::RegisterTabCallback(SptImGuiGroup::Hud, HudTabCallback);
+#ifdef SPT_HUD_ENABLED
+		if (spt_hud_feat.LoadingSuccessful())
+			SptImGui::RegisterTabCallback(SptImGuiGroup::Hud, HudTabCallback);
+#endif
 	};
 
 	virtual void UnloadFeature()

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -274,6 +274,9 @@ public:
 	static int CvarCombo(ConVar& c, const char* label, const char* const* opts, size_t nOpts);
 	// same as internal imgui help marker - a tooltip with extra info (for cvars & commands)
 	static void HelpMarker(const char* fmt, ...);
+	// add a border around an item - this is just a table with a single row/column
+	static bool BeginBordered(const ImVec2& outer_size = {0.0f, 0.0f}, float inner_width = 0.0f);
+	static void EndBordered();
 
 	struct AutocompletePersistData
 	{

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -272,6 +272,8 @@ public:
 	static bool CvarCheckbox(ConVar& c, const char* label);
 	// a combo/dropdown box for a cvar with multiple integer options (does not use clipper - not optimized for huge lists), returns value of cvar
 	static int CvarCombo(ConVar& c, const char* label, const char* const* opts, size_t nOpts);
+	// a textbox for an integer in base 10 or 16, returns true if the value was modified
+	static bool InputTextInteger(const char* label, const char* hint, long long& val, int radix);
 	// same as internal imgui help marker - a tooltip with extra info (for cvars & commands)
 	static void HelpMarker(const char* fmt, ...);
 	// add a border around an item - this is just a table with a single row/column

--- a/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
+++ b/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
@@ -76,6 +76,22 @@ void SptImGui::HelpMarker(const char* fmt, ...)
 	va_end(va);
 }
 
+bool SptImGui::BeginBordered(const ImVec2& outer_size, float inner_width)
+{
+	if (ImGui::BeginTable("##table_border", 1, ImGuiTableFlags_BordersOuter, outer_size, inner_width))
+	{
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		return true;
+	}
+	return false;
+}
+
+void SptImGui::EndBordered()
+{
+	ImGui::EndTable();
+}
+
 void SptImGui::TextInputAutocomplete(const char* inputTextLabel,
                                      const char* popupId,
                                      AutocompletePersistData& persist,

--- a/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
+++ b/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
@@ -1,4 +1,5 @@
 #include <stdafx.hpp>
+#include <inttypes.h>
 #include "imgui_interface.hpp"
 #include "thirdparty/imgui/imgui_internal.h"
 
@@ -59,6 +60,22 @@ int SptImGui::CvarCombo(ConVar& c, const char* label, const char* const* opts, s
 	ImGui::SameLine();
 	SptImGui::CvarValue(c);
 	return val;
+}
+
+bool SptImGui::InputTextInteger(const char* label, const char* hint, long long& val, int radix)
+{
+	Assert(radix == 10 || radix == 16);
+	char buf[24];
+	const char* fmtSpecifier = radix == 10 ? "%" PRId64 : "%" PRIx64;
+	snprintf(buf, sizeof buf, fmtSpecifier, val);
+	ImGui::SetNextItemWidth(ImGui::GetFontSize() * (sizeof(buf) - 1) * 0.6f);
+	ImGuiInputTextFlags flags =
+	    ImGuiInputTextFlags_CharsUppercase | ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_AutoSelectAll;
+	flags |= radix == 10 ? ImGuiInputTextFlags_CharsDecimal : ImGuiInputTextFlags_CharsHexadecimal;
+	bool ret = ImGui::InputTextWithHint(label, hint, buf, sizeof buf, flags);
+	if (ret)
+		_snscanf_s(buf, sizeof buf, fmtSpecifier, &val);
+	return ret;
 }
 
 void SptImGui::HelpMarker(const char* fmt, ...)
@@ -222,7 +239,7 @@ void SptImGui::TextInputAutocomplete(const char* inputTextLabel,
 		return;
 	// nothing to autocomplete
 	if (persist.nAutocomplete == 0)
-		return; 
+		return;
 	/*
 	* - if the textbox is the active element display the popup
 	* - if the popup window is the nav window - great, keep it alive
@@ -233,7 +250,7 @@ void SptImGui::TextInputAutocomplete(const char* inputTextLabel,
 		return;
 	// 1 entry to autocomplete but it's the same as what user typed in the text box
 	if (persist.nAutocomplete == 1 && !strcmp(persist.autocomplete[0], persist.textInput))
-		return; 
+		return;
 
 	ImGui::SetNextWindowPos(ImVec2(ImGui::GetItemRectMin().x, ImGui::GetItemRectMax().y));
 	float nDisplayItems, framePadding;

--- a/spt/features/visualizations/oob_ents.cpp
+++ b/spt/features/visualizations/oob_ents.cpp
@@ -11,6 +11,7 @@
 #include "spt\features\ent_props.hpp"
 #include "spt\features\hud.hpp"
 #include "renderer\mesh_renderer.hpp"
+#include "imgui\imgui_interface.hpp"
 
 class HudOobEntsFeature : public FeatureWrapper<HudOobEntsFeature>
 {
@@ -70,8 +71,10 @@ void HudOobEntsFeature::LoadFeature()
 	if (!TickSignal.Works)
 		return;
 	TickSignal.Connect(this, &HudOobEntsFeature::OnTickSignal);
-	AddHudCallback(
+	bool hudEnabled = AddHudCallback(
 	    "hud oob ents", [this](std::string) { PrintEntsHud(); }, spt_hud_oob_ents);
+	if (hudEnabled)
+		SptImGui::RegisterHudCvarCheckbox(spt_hud_oob_ents);
 	InitCommand(spt_print_oob_ents);
 #ifdef SPT_MESH_RENDERING_ENABLED
 	if (spt_meshRenderer.signal.Works)


### PR DESCRIPTION
I added all of the `spt_hud` cvars to the HUD tab in ImGui except for ent_info. It looks like this now:
![Screenshot_24](https://github.com/user-attachments/assets/d8942074-d2c9-4902-bdbe-03f6b4b64a15)

Internally, the ImGui tab sorts cvars by their wrangled (legacy) name and `spt_hud` sorts by a custom sort key. Is it okay if I change the `spt_hud` logic to sort by name instead of using a sort key so that way they match up? We haven't been grouping the HUD cvars in any meaningful way so I think it should be fine to change the order.