### PR TITLE
ImGui ent props

### DIFF
--- a/spt/features/ent_props.hpp
+++ b/spt/features/ent_props.hpp
@@ -83,6 +83,8 @@ protected:
 	std::vector<patterns::MatchedPattern> clientPatterns;
 	std::vector<utils::DatamapWrapper*> wrappers;
 	std::unordered_map<std::string, utils::DatamapWrapper*> nameToMapWrapper;
+
+	static void ImGuiEntInfoCvarCallback(ConVar& var);
 };
 
 extern EntProps spt_entprops;

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -175,7 +175,6 @@ namespace SptImGuiGroup
 
 	// features that access game state
 	inline Tab GameIo{"Game IO", &Root};
-	inline Tab GameIo_EntProps{"Ent props", &GameIo};
 	inline Tab GameIo_ISG{"ISG", &GameIo};
 
 	// hud cvars - use the RegisterHudCvarXXX functions below to add cvars
@@ -264,10 +263,17 @@ public:
 
 	// SPT-related widgets
 
+	enum CvarValueFlags
+	{
+		CVF_NONE = 0,
+		CVF_ALWAYS_QUOTE = 1,
+		// TODO: copy/reset widgets
+	};
+
 	// a button for a ConCommand with no args, does NOT invoke the command (because of OE compat)
 	static bool CmdButton(const char* label, ConCommand& cmd);
 	// display cvar name & value, surrounds the value in quotes if it has a space (if the value already has quotes, too bad!)
-	static void CvarValue(const ConVar& c);
+	static void CvarValue(const ConVar& c, CvarValueFlags flags = CVF_NONE);
 	// a checkbox for a boolean cvar, returns value of cvar
 	static bool CvarCheckbox(ConVar& c, const char* label);
 	// a combo/dropdown box for a cvar with multiple integer options (does not use clipper - not optimized for huge lists), returns value of cvar

--- a/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
+++ b/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
@@ -13,12 +13,12 @@ bool SptImGui::CmdButton(const char* label, ConCommand& cmd)
 	return ret;
 }
 
-void SptImGui::CvarValue(const ConVar& c)
+void SptImGui::CvarValue(const ConVar& c, CvarValueFlags flags)
 {
 	const char* v = c.GetString();
 	const char* surround = "";
-	if (strchr(v, ' '))
-		surround = " ";
+	if ((flags & CVF_ALWAYS_QUOTE) || !*v || strchr(v, ' '))
+		surround = "\"";
 	ImGui::TextDisabled("(%s %s%s%s)", WrangleLegacyCommandName(c.GetName(), true, nullptr), surround, v, surround);
 	ImGui::SameLine();
 	HelpMarker("%s", c.GetHelpText());

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -36,6 +36,8 @@ namespace utils
 {
 	IClientEntity* GetClientEntity(int index)
 	{
+		if (index >= interfaces::entList->GetHighestEntityIndex())
+			return nullptr;
 		return interfaces::entList->GetClientEntity(index + 1);
 	}
 
@@ -318,31 +320,8 @@ namespace utils
 
 		while (i < argSize && entries < maxEntries)
 		{
-			bool readEntityIndex = false;
-
-			// Read entity index
-			if (args[i] == entSep)
-			{
-				++i;
-				readEntityIndex = true;
-			}
-			// Also read if at the start of the string. Note: does not increment the index since we're at the start of the string.
-			else if (i == 0)
-			{
-				readEntityIndex = true;
-			}
-			else if (args[i] == sep)
-			{
-				++i;
-			}
-			else // error occurred
-			{
-				i = argSize;
-				arr = (wchar_t*)L"error occurred in parsing";
-				entries = 1;
-				break;
-			}
-
+			bool readEntityIndex = i == 0 || args[i] == entSep;
+			i += i > 0 || entries > 0; // i is at a separtor from the previous loop, go to next char
 			int endIndex = i;
 
 			// Go to the next separator


### PR DESCRIPTION
This is meant to be merged after #345.

Changes:
- Added `spt_hud_ent_info` to the hud tab
- Change `utils::ClientEntity()` to return null for large indices because the game doesn't do that check for us and this can trigger a crash otherwise (the game does check for `index<0` though)
- Small tweaks to `utils::FillInfoArray()` to make it slightly more resilient to weird user input

I've tested this with a bunch of weird user input - to the best of my knowledge it syncs up with the `utils::FillInfoArray()` logic and gracefully handles weird edge cases. When the user interacts with the GUI, it sort of "normalizes" the cvar value to something slightly more sensible.

https://github.com/user-attachments/assets/34f7f2ad-2303-4d97-854b-0eb20ec22341

