### PR TITLE
A morbillion ImGui features

### DIFF
--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -7,6 +7,7 @@
 #include "dbg.h"
 #include "signals.hpp"
 #include "game_detection.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 #ifdef OE
 #include "mathlib.h"
@@ -187,6 +188,15 @@ void AutojumpFeature::LoadFeature()
 		else
 			// dmomm
 			off_player_ptr = 4;
+
+		SptImGuiGroup::Cheats_Jumping.RegisterUserCallback(
+		    []()
+		    {
+			    SptImGui::CvarCheckbox(y_spt_autojump, "##checkbox_autojump");
+			    SptImGui::CvarCheckbox(_y_spt_autojump_ensure_legit, "##checkbox_legit");
+			    const char* opts[] = {"Default", "ABH jumpboost", "OE jumpboost", "No jumpboost"};
+			    SptImGui::CvarCombo(y_spt_jumpboost, "jumpboost type", opts, ARRAYSIZE(opts));
+		    });
 	}
 	else
 	{
@@ -202,6 +212,8 @@ void AutojumpFeature::LoadFeature()
 	if (utils::DoesGameLookLikePortal() && ORIG_CGameMovement__AirMove && ORIG_CPortalGameMovement__AirMove)
 	{
 		InitConcommandBase(y_spt_aircontrol);
+		SptImGuiGroup::Cheats_HL2AirControl.RegisterUserCallback(
+		    []() { SptImGui::CvarCheckbox(y_spt_aircontrol, "##checkbox"); });
 	}
 }
 

--- a/spt/features/boog.cpp
+++ b/spt/features/boog.cpp
@@ -10,6 +10,7 @@
 #include "playerio.hpp"
 #include "signals.hpp"
 #include "game_detection.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 ConVar y_spt_hud_edgebug("y_spt_hud_edgebug",
                          "0",
@@ -177,6 +178,17 @@ void BoogFeature::LoadFeature()
 		{
 			InitConcommandBase(y_spt_hud_edgebug);
 			InitConcommandBase(y_spt_hud_edgebug_sec);
+
+			SptImGui::RegisterHudCvarCallback(
+			    y_spt_hud_edgebug,
+			    [](ConVar& var)
+			    {
+				    SptImGui::CvarCheckbox(y_spt_hud_edgebug, "##checkbox");
+				    SptImGui::CvarDouble(y_spt_hud_edgebug_sec,
+				                        "edgebug display time",
+				                        "enter time in seconds");
+			    },
+			    true);
 		}
 	}
 }

--- a/spt/features/con_notify.cpp
+++ b/spt/features/con_notify.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.hpp"
 #include "..\feature.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 ConVar spt_con_notify_cvar("spt_con_notify", 
                            "0", 
@@ -69,6 +70,8 @@ void ConNotifyFeature::LoadFeature()
 	    return;
 
     InitConcommandBase(spt_con_notify_cvar);
+    SptImGuiGroup::QoL_ConNotify.RegisterUserCallback(
+        []() { SptImGui::CvarCheckbox(spt_con_notify_cvar, "##checkbox"); });
 }
 
 // just turn on developer before entering these functions

--- a/spt/features/demo.cpp
+++ b/spt/features/demo.cpp
@@ -7,7 +7,7 @@
 #include "..\scripts\srctas_reader.hpp"
 #include "..\sptlib-wrapper.hpp"
 #include "..\utils\game_detection.hpp"
-#include "dbg.h"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 DemoStuff spt_demostuff;
 
@@ -360,4 +360,11 @@ void DemoStuff::LoadFeature()
 	{
 		InitConcommandBase(y_spt_demo_block_cmd);
 	}
+
+	SptImGuiGroup::QoL_Demo.RegisterUserCallback(
+	    []()
+	    {
+		    SptImGui::CvarCheckbox(y_spt_demo_block_cmd, "##checkbox");
+		    SptImGui::CvarInputTextInteger(y_spt_pause_demo_on_tick, "pause demo on tick", "enter tick value");
+	    });
 }

--- a/spt/features/game_fixes/fastload.cpp
+++ b/spt/features/game_fixes/fastload.cpp
@@ -2,7 +2,7 @@
 #include "..\feature.hpp"
 #include "..\generic.hpp"
 #include "signals.hpp"
-
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
 ConVar y_spt_fast_loads(
     "y_spt_fast_loads",
@@ -42,11 +42,13 @@ bool FastLoads::ShouldLoadFeature()
 
 void FastLoads::LoadFeature()
 {
-	if (SetSignonStateSignal.Works)
-	{
-		InitConcommandBase(y_spt_fast_loads);
-		SetSignonStateSignal.Connect(this, &FastLoads::OnLoad);
-	}
+	if (!SetSignonStateSignal.Works)
+		return;
+	InitConcommandBase(y_spt_fast_loads);
+	SetSignonStateSignal.Connect(this, &FastLoads::OnLoad);
+
+	SptImGuiGroup::QoL_FastLoads.RegisterUserCallback(
+	    []() { SptImGui::CvarInputTextInteger(y_spt_fast_loads, "fast loads value", "fps_max value"); });
 }
 
 void FastLoads::OnLoad(void* thisptr, int state)

--- a/spt/features/game_fixes/free_oob.cpp
+++ b/spt/features/game_fixes/free_oob.cpp
@@ -3,8 +3,9 @@
 #include "convar.hpp"
 #include "..\autojump.hpp"
 #include "interfaces.hpp"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
-#ifndef  OE
+#ifndef OE
 
 static void FreeOOBCVarCallback(IConVar* pConVar, const char* pOldValue, float flOldValue);
 
@@ -111,6 +112,8 @@ void FreeOobFeature::LoadFeature()
 				INIT_BYTE_REPLACE(SecondJump, cur);
 
 				InitConcommandBase(y_spt_free_oob);
+				SptImGuiGroup::Cheats_FreeOob.RegisterUserCallback(
+				    []() { SptImGui::CvarCheckbox(y_spt_free_oob, "##checkbox"); });
 				return;
 			}
 
@@ -139,4 +142,3 @@ void FreeOobFeature::Toggle(bool enabled)
 	}
 }
 #endif // ! OE
-

--- a/spt/features/game_fixes/multi_instance.cpp
+++ b/spt/features/game_fixes/multi_instance.cpp
@@ -1,27 +1,54 @@
 #include "stdafx.hpp"
 #ifdef _WIN32
+
 #include "..\feature.hpp"
+#include "signals.hpp"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 #include <Windows.h>
 
-CON_COMMAND(y_spt_release_mutex, "Releases \"hl2_singleton_mutex\" to enable running multiple instances.")
+static bool SptReleaseMutexImpl(const char** msg)
 {
 	HANDLE handle = OpenMutexA(SYNCHRONIZE, false, "hl2_singleton_mutex");
 	if (handle)
 	{
 		if (ReleaseMutex(handle))
-			Msg("Released hl2_singleton_mutex. You can start another instance now.\n");
+		{
+			*msg = "Released hl2_singleton_mutex. You can start another instance now.";
+			return true;
+		}
 		else
-			Warning("Failed to release hl2_singleton_mutex.\n");
+		{
+			*msg = "Failed to release hl2_singleton_mutex.";
+			return false;
+		}
 		CloseHandle(handle);
 	}
 	else
-		Warning("Failed to obtain hl2_singleton_mutex handle.\n");
+	{
+		*msg = "Failed to obtain hl2_singleton_mutex handle.";
+		return false;
+	}
+}
+
+CON_COMMAND(y_spt_release_mutex, "Releases \"hl2_singleton_mutex\" to enable running multiple instances.")
+{
+	const char* msg;
+	if (SptReleaseMutexImpl(&msg))
+		Msg("%s\n", msg);
+	else
+		Warning("%s\n", msg);
 }
 
 // spt_release_mutex
 class MultiInstance : public FeatureWrapper<MultiInstance>
 {
 public:
+	// I don't really understand why, but trying to release the mutex from
+	// within the ImGui callback doesn't work - do it from FrameSignal instead.
+	inline static const char* lastMsg = "N/A";
+	inline static bool lastResult = true;
+	inline static bool tryRelease = false;
+
 protected:
 	virtual bool ShouldLoadFeature() override;
 
@@ -30,6 +57,9 @@ protected:
 	virtual void LoadFeature() override;
 
 	virtual void UnloadFeature() override;
+
+private:
+	void OnFrameSignal();
 };
 
 static MultiInstance spt_multi_instance;
@@ -44,6 +74,33 @@ void MultiInstance::InitHooks() {}
 void MultiInstance::LoadFeature()
 {
 	InitCommand(y_spt_release_mutex);
+
+	bool imguiEnabled = SptImGuiGroup::QoL_MultiInstance.RegisterUserCallback(
+	    []()
+	    {
+		    if (ImGui::Button("Release HL2 mutex"))
+			    tryRelease = true;
+		    ImGui::SameLine();
+		    SptImGui::HelpMarker("Help text for %s:\n\n%s",
+		                         WrangleLegacyCommandName(y_spt_release_mutex_command.GetName(), true, nullptr),
+		                         y_spt_release_mutex_command.GetHelpText());
+		    ImGui::Text("Last result:");
+		    ImGui::SameLine();
+		    if (lastResult)
+			    ImGui::Text("%s", lastMsg);
+		    else
+			    ImGui::TextColored(SPT_IMGUI_WARN_COLOR_YELLOW, "%s", lastMsg);
+	    });
+
+	if (imguiEnabled)
+		FrameSignal.Connect(this, &MultiInstance::OnFrameSignal);
+}
+
+void MultiInstance::OnFrameSignal()
+{
+	if (tryRelease)
+		lastResult = SptReleaseMutexImpl(&lastMsg);
+	tryRelease = false;
 }
 
 void MultiInstance::UnloadFeature() {}

--- a/spt/features/game_fixes/noclip_fixes.cpp
+++ b/spt/features/game_fixes/noclip_fixes.cpp
@@ -7,6 +7,7 @@
 #include "signals.hpp"
 #include "..\autojump.hpp"
 #include "SDK\hl_movedata.h"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
 #ifdef OE
 static void NoclipNofixCVarCallback(ConVar* pConVar, const char* pOldValue);
@@ -201,6 +202,19 @@ void NoclipFixesFeature::LoadFeature()
             }
         }
     }
+
+    SptImGuiGroup::QoL_Noclip.RegisterUserCallback(
+        []()
+        {
+            SptImGui::CvarCheckbox(y_spt_noclip_nofix, "##checkbox_nofix");
+            SptImGui::CvarCheckbox(spt_noclip_noslowfly, "##checkbox_noslowfly");
+            SptImGui::CvarCheckbox(spt_noclip_persist, "##checkbox_persist");
+#ifndef OE
+            // whoever decided to put this in a different file deserves stale bread
+            extern ConVar y_spt_portal_no_ground_snap;
+            SptImGui::CvarCheckbox(y_spt_portal_no_ground_snap, "##checkbox_no_ground_snap");
+#endif
+        });
 }
 
 void NoclipFixesFeature::OnTick()

--- a/spt/features/game_fixes/nosleep.cpp
+++ b/spt/features/game_fixes/nosleep.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.hpp"
 #include "..\feature.hpp"
 #include "convar.hpp"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
 ConVar y_spt_focus_nosleep("y_spt_focus_nosleep", "0", 0, "Improves FPS while alt-tabbed.");
 
@@ -47,6 +48,8 @@ void NoSleepFeature::LoadFeature()
 	if (ORIG_CInputSystem__SleepUntilInput)
 	{
 		InitConcommandBase(y_spt_focus_nosleep);
+		SptImGuiGroup::QoL_NoSleep.RegisterUserCallback(
+		    []() { SptImGui::CvarCheckbox(y_spt_focus_nosleep, "##checkbox"); });
 	}
 }
 

--- a/spt/features/game_fixes/snapshot_overflow.cpp
+++ b/spt/features/game_fixes/snapshot_overflow.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.hpp"
 #include "..\feature.hpp"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
 ConVar spt_prevent_snapshot_overflow("spt_prevent_snapshot_overflow",
                                      "0",
@@ -83,6 +84,9 @@ protected:
 			    extern SnapshotOverflow spt_snapShotOverflow;
 			    spt_snapShotOverflow.SetOverwrite(((ConVar*)var)->GetBool());
 		    });
+
+		SptImGuiGroup::Cheats_SnapshotOverflow.RegisterUserCallback(
+		    []() { SptImGui::CvarCheckbox(spt_prevent_snapshot_overflow, "##checkbox"); });
 	};
 
 	virtual void UnloadFeature() override

--- a/spt/features/game_fixes/vag_crash.cpp
+++ b/spt/features/game_fixes/vag_crash.cpp
@@ -6,8 +6,7 @@
 #include "..\utils\game_detection.hpp"
 #include "..\cvars.hpp"
 #include "signals.hpp"
-
-#include "dbg.h"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
 ConVar y_spt_prevent_vag_crash(
     "y_spt_prevent_vag_crash",
@@ -66,6 +65,9 @@ void VAG::LoadFeature()
 	{
 		InitConcommandBase(y_spt_prevent_vag_crash);
 		VagCrashSignal.Works = true;
+
+		SptImGuiGroup::Cheats_VagCrash.RegisterUserCallback(
+			[]() { SptImGui::CvarCheckbox(y_spt_prevent_vag_crash, "##checkbox"); });
 	}
 	recursiveTeleportCount = 0;
 }

--- a/spt/features/game_fixes/visual_fixes.cpp
+++ b/spt/features/game_fixes/visual_fixes.cpp
@@ -4,7 +4,7 @@
 #include "convar.hpp"
 #include "ent_utils.hpp"
 #include "signals.hpp"
-#include "dbg.h"
+#include "..\visualizations\imgui\imgui_interface.hpp"
 
 typedef void(__cdecl* _DoImageSpaceMotionBlur)(void* view, int x, int y, int w, int h);
 typedef void(__fastcall* _CViewEffects__Fade)(void* thisptr, int edx, void* data);
@@ -22,13 +22,11 @@ ConVar y_spt_disable_tone_map_reset(
     FCVAR_ARCHIVE,
     "Prevents the tone map getting reset (during each load), useful for keeping colors the same between demos.");
 
-#ifndef OE
 // Implemented as a fix for https://github.com/MattMcNam/SetSequence
 ConVar y_spt_override_tpose("y_spt_override_tpose",
                             "0",
                             FCVAR_DONTRECORD,
                             "Override Chell's t-pose animation with the given sequence, use 17 for standing in air.");
-#endif
 
 ConVar spt_viewmodel_offset_x("spt_viewmodel_offset_x", "0.0", FCVAR_ARCHIVE, "The viewmodel offset from default in X");
 ConVar spt_viewmodel_offset_y("spt_viewmodel_offset_y", "0.0", FCVAR_ARCHIVE, "The viewmodel offset from default in Y");
@@ -222,6 +220,21 @@ void VisualFixes::LoadFeature()
 		InitConcommandBase(spt_viewmodel_offset_y);
 		InitConcommandBase(spt_viewmodel_offset_z);
 	}
+
+	SptImGuiGroup::QoL_Visual.RegisterUserCallback(
+	    []()
+	    {
+		    SptImGui::CvarCheckbox(y_spt_disable_fade, "##checkbox_fade");
+		    SptImGui::CvarCheckbox(y_spt_disable_shake, "##checkbox_shake");
+		    SptImGui::CvarCheckbox(y_spt_disable_tone_map_reset, "##checkbox_tone_map");
+		    SptImGui::CvarInputTextInteger(y_spt_override_tpose, "T-pose sequence override", "");
+
+		    ConVar* cvars[] = {&spt_viewmodel_offset_x, &spt_viewmodel_offset_y, &spt_viewmodel_offset_z};
+		    float f[ARRAYSIZE(cvars)];
+		    SptImGui::CvarsDragScalar(cvars, f, ARRAYSIZE(cvars), true, "viewmodel offset", 0.05f);
+		    ImGui::SameLine();
+		    SptImGui::HelpMarker("Can be set with spt_viewmodel_offset_x/y/z");
+	    });
 }
 
 void VisualFixes::UnloadFeature() {}

--- a/spt/features/hops_hud.cpp
+++ b/spt/features/hops_hud.cpp
@@ -12,6 +12,7 @@
 #include "signals.hpp"
 #include "playerio.hpp"
 #include "property_getter.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 #undef min
 #undef max
@@ -510,7 +511,7 @@ void HopsHud::LoadFeature()
 			OngroundSignal.Connect(this, &HopsHud::OnGround);
 			InitConcommandBase(y_spt_jhud_hops);
 		}
-		
+
 		if (TickSignal.Works || OngroundSignal.Works)
 		{
 			JumpSignal.Connect(this, &HopsHud::OnJump);
@@ -526,6 +527,27 @@ void HopsHud::LoadFeature()
 		TickSignal.Connect(ljstats::OnTick);
 		InitConcommandBase(y_spt_jhud_ljstats);
 	}
+
+	SptImGuiGroup::Hud_JHud.RegisterUserCallback(
+	    []()
+	    {
+		    bool hudVel = SptImGui::CvarCheckbox(y_spt_jhud_velocity, "##checkbox_vel");
+		    bool hudHops = SptImGui::CvarCheckbox(y_spt_jhud_hops, "##checkbox_hops");
+		    bool hudStats = SptImGui::CvarCheckbox(y_spt_jhud_ljstats, "##checkbox_stats");
+
+		    bool enablePos = hudVel || hudHops || hudStats;
+		    ImGui::BeginDisabled(!enablePos);
+		    ConVar* cvars[] = {&y_spt_jhud_x, &y_spt_jhud_y};
+		    float f[ARRAYSIZE(cvars)];
+		    ImGui::BeginGroup();
+		    SptImGui::CvarsDragScalar(cvars, f, ARRAYSIZE(cvars), true, "HUD pos");
+		    ImGui::SameLine();
+		    SptImGui::HelpMarker("Can be set with spt_jhud_x/y");
+		    ImGui::EndGroup();
+		    ImGui::EndDisabled();
+		    if (!enablePos)
+			    ImGui::SetItemTooltip("no jump HUD vars enabled");
+	    });
 }
 
 void HopsHud::UnloadFeature() {}

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -11,6 +11,7 @@
 #include "spt\utils\interfaces.hpp"
 #include "spt\utils\signals.hpp"
 #include "spt\utils\game_detection.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 #include "basehandle.h"
 #include "Color.h"
@@ -107,8 +108,15 @@ private:
 InputHud spt_ihud;
 
 ConVar y_spt_ihud("y_spt_ihud", "0", 0, "Draws movement inputs of client.");
-ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", 0, "Grid size of input HUD.");
-ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding", "2", 0, "Padding between grids of input HUD.");
+ConVar y_spt_ihud_grid_size("y_spt_ihud_grid_size", "60", 0, "Grid size of input HUD.", true, 15.f, false, 0.f);
+ConVar y_spt_ihud_grid_padding("y_spt_ihud_grid_padding",
+                               "2",
+                               0,
+                               "Padding between grids of input HUD.",
+                               true,
+                               0.f,
+                               false,
+                               0.f);
 ConVar y_spt_ihud_x("y_spt_ihud_x", "2", 0, "X position of input HUD.", true, 0.0f, true, 100.0f);
 ConVar y_spt_ihud_y("y_spt_ihud_y", "2", 0, "Y position of input HUD.", true, 0.0f, true, 100.0f);
 
@@ -601,6 +609,28 @@ void InputHud::LoadFeature()
 		InitConcommandBase(y_spt_ihud_grid_padding);
 		InitConcommandBase(y_spt_ihud_x);
 		InitConcommandBase(y_spt_ihud_y);
+
+		SptImGuiGroup::Hud_IHud.RegisterUserCallback(
+		    []()
+		    {
+			    ImGui::BeginDisabled(!SptImGui::CvarCheckbox(y_spt_ihud, "##enabled"));
+			    ConVar* var = &y_spt_ihud_grid_size;
+			    long long varVal;
+			    SptImGui::CvarsDragScalar(&var, &varVal, 1, false, "grid size");
+			    ImGui::SameLine();
+			    SptImGui::CmdHelpMarkerWithName(*var);
+			    var = &y_spt_ihud_grid_padding;
+			    SptImGui::CvarsDragScalar(&var, &varVal, 1, false, "grid padding");
+			    ImGui::SameLine();
+			    SptImGui::CmdHelpMarkerWithName(*var);
+
+			    ConVar* cvars[] = {&y_spt_ihud_x, &y_spt_ihud_y};
+			    float f[ARRAYSIZE(cvars)];
+			    SptImGui::CvarsDragScalar(cvars, f, ARRAYSIZE(cvars), true, "IHUD pos");
+			    ImGui::SameLine();
+			    SptImGui::HelpMarker("Can be set with spt_ihud_x/y");
+			    ImGui::EndDisabled();
+		    });
 	}
 
 	const int IN_ATTACK = (1 << 0);

--- a/spt/features/isg.cpp
+++ b/spt/features/isg.cpp
@@ -91,7 +91,7 @@ void ISGFeature::LoadFeature()
 	    "isg", [](std::string) { spt_hud_feat.DrawTopHudElement(L"isg: %d", IsISGActive()); }, y_spt_hud_isg);
 #endif
 
-	SptImGuiGroup::GameIo_ISG.RegisterUserCallback(ImGuiCallback);
+	SptImGuiGroup::Cheats_ISG.RegisterUserCallback(ImGuiCallback);
 	if (hudCallbackEnabled)
 		SptImGui::RegisterHudCvarCheckbox(y_spt_hud_isg);
 }

--- a/spt/features/isg.cpp
+++ b/spt/features/isg.cpp
@@ -51,7 +51,7 @@ protected:
 	virtual void UnloadFeature() override;
 
 private:
-	void ImGuiCallback(bool open);
+	static void ImGuiCallback();
 };
 
 static ISGFeature spt_isg;
@@ -91,7 +91,7 @@ void ISGFeature::LoadFeature()
 	    "isg", [](std::string) { spt_hud_feat.DrawTopHudElement(L"isg: %d", IsISGActive()); }, y_spt_hud_isg);
 #endif
 
-	SptImGui::RegisterTabCallback(SptImGuiGroup::GameIo_ISG, [this](bool open) { ImGuiCallback(open); });
+	SptImGuiGroup::GameIo_ISG.RegisterUserCallback(ImGuiCallback);
 	if (hudCallbackEnabled)
 		SptImGui::RegisterHudCvarCheckbox(y_spt_hud_isg);
 }
@@ -101,10 +101,8 @@ void ISGFeature::UnloadFeature()
 	ORIG_MiddleOfRecheck_ov_element = 0;
 }
 
-void ISGFeature::ImGuiCallback(bool open)
+void ISGFeature::ImGuiCallback()
 {
-	if (!open)
-		return;
 	if (ImGui::TreeNode("Info"))
 	{
 		ImGui::TextWrapped(
@@ -116,17 +114,17 @@ void ISGFeature::ImGuiCallback(bool open)
 	}
 
 	SptImGui::CvarCheckbox(y_spt_hud_isg, "Show ISG state in HUD");
-	ImGui::BeginDisabled(*isgFlagPtr);
+	ImGui::BeginDisabled(*spt_isg.isgFlagPtr);
 	if (ImGui::Button("Enable ISG"))
-		*isgFlagPtr = true;
+		*spt_isg.isgFlagPtr = true;
 	ImGui::EndDisabled();
 	ImGui::SameLine();
-	ImGui::BeginDisabled(!*isgFlagPtr);
+	ImGui::BeginDisabled(!*spt_isg.isgFlagPtr);
 	if (ImGui::Button("Disable ISG"))
-		*isgFlagPtr = false;
+		*spt_isg.isgFlagPtr = false;
 	ImGui::EndDisabled();
 	ImGui::SameLine();
-	ImGui::TextDisabled("ISG state: %d", *isgFlagPtr);
+	ImGui::TextDisabled("ISG state: %d", *spt_isg.isgFlagPtr);
 	ImGui::SameLine();
 	SptImGui::HelpMarker("Can be set with %s.",
 	                     WrangleLegacyCommandName(y_spt_set_isg_command.GetName(), true, nullptr));

--- a/spt/features/leafvis.cpp
+++ b/spt/features/leafvis.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.hpp"
 #include "..\feature.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 namespace patterns
 {
@@ -9,9 +10,9 @@ namespace patterns
 }
 
 ConVar y_spt_leafvis_index("y_spt_leafvis_index",
-                       "0",
-                       FCVAR_CHEAT,
-                       "Choose which BSP leaf mat_leafvis will use. Requires mat_leafvis to be set\n");
+                           "0",
+                           FCVAR_CHEAT,
+                           "Choose which BSP leaf mat_leafvis will use. Requires mat_leafvis to be set\n");
 
 // Enhance mat_leafvis by allowing you to choose the BSP leaf by index
 class LeafVisFeature : public FeatureWrapper<LeafVisFeature>
@@ -34,8 +35,37 @@ void LeafVisFeature::InitHooks()
 
 void LeafVisFeature::LoadFeature()
 {
-	if (ORIG_MiddleOfLeafVisBuild != nullptr)
+	if (ORIG_MiddleOfLeafVisBuild)
+	{
 		InitConcommandBase(y_spt_leafvis_index);
+
+		if (g_pCVar && g_pCVar->FindVar("mat_leafvis"))
+		{
+			SptImGuiGroup::Draw_Misc_LeafVis.RegisterUserCallback(
+			    []()
+			    {
+				    ConVar* mat_leafvis = g_pCVar->FindVar("mat_leafvis");
+				    ImGui::BeginDisabled(mat_leafvis->GetInt() != 1);
+					
+				    SptImGui::CvarInputTextInteger(y_spt_leafvis_index,
+				                                   "leaf index",
+				                                   "enter integer index");
+				    ImGui::EndDisabled();
+				    ImGui::Text("Edit mat_leafvis:");
+				    ImGui::SameLine();
+				    if (ImGui::Button("set to 0"))
+					    mat_leafvis->SetValue(0);
+				    ImGui::SameLine();
+				    if (ImGui::Button("set to 1"))
+					    mat_leafvis->SetValue(1);
+				    ImGui::SameLine();
+				    if (ImGui::Button("set to 2"))
+					    mat_leafvis->SetValue(2);
+				    ImGui::SameLine();
+				    SptImGui::CvarValue(*mat_leafvis, SptImGui::CVF_NO_WRANGLE);
+			    });
+		}
+	}
 }
 
 static __forceinline int GetLeafIndex()

--- a/spt/features/movement_vars.cpp
+++ b/spt/features/movement_vars.cpp
@@ -5,13 +5,14 @@
 #include "convar.hpp"
 #include "interfaces.hpp"
 #include "signals.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 static void Change_Maxspeed(CON_COMMAND_CALLBACK_ARGS);
 
 static ConVar* _cl_forwardspeed = nullptr;
 static ConVar* _cl_sidespeed = nullptr;
 static ConVar* _cl_backspeed = nullptr;
-static ConVar* _sv_maxspeed = nullptr;
+static ConVar* _sv_maxspeed_cvar = nullptr;
 
 ConVar spt_player_maxspeed(
     "spt_player_maxspeed",
@@ -29,14 +30,14 @@ static void Change_Maxspeed(CON_COMMAND_CALLBACK_ARGS)
 		SET_DEFAULT(_cl_forwardspeed);
 		SET_DEFAULT(_cl_sidespeed);
 		SET_DEFAULT(_cl_backspeed);
-		SET_DEFAULT(_sv_maxspeed);
+		SET_DEFAULT(_sv_maxspeed_cvar);
 	}
 	else
 	{
 		_cl_forwardspeed->SetValue(maxspeed);
 		_cl_sidespeed->SetValue(maxspeed);
 		_cl_backspeed->SetValue(maxspeed);
-		_sv_maxspeed->SetValue(maxspeed);
+		_sv_maxspeed_cvar->SetValue(maxspeed);
 	}
 }
 
@@ -66,13 +67,16 @@ void VarChanger::LoadFeature()
 		_cl_forwardspeed = g_pCVar->FindVar("cl_forwardspeed");
 		_cl_sidespeed = g_pCVar->FindVar("cl_sidespeed");
 		_cl_backspeed = g_pCVar->FindVar("cl_backspeed");
-		_sv_maxspeed = g_pCVar->FindVar("sv_maxspeed");
+		_sv_maxspeed_cvar = g_pCVar->FindVar("sv_maxspeed");
 	}
 
-	if (ProcessMovementPre_Signal.Works && _cl_forwardspeed && _cl_sidespeed && _cl_backspeed && _sv_maxspeed)
+	if (ProcessMovementPre_Signal.Works && _cl_forwardspeed && _cl_sidespeed && _cl_backspeed && _sv_maxspeed_cvar)
 	{
 		ProcessMovementPre_Signal.Connect(ProcessMovementPre);
 		InitConcommandBase(spt_player_maxspeed);
+		SptImGuiGroup::Cheats_MaxSpeed.RegisterUserCallback(
+		    []()
+		    { SptImGui::CvarDouble(spt_player_maxspeed, "override max speed value", "enter float value"); });
 	}
 }
 

--- a/spt/features/pause.cpp
+++ b/spt/features/pause.cpp
@@ -3,7 +3,7 @@
 #include "generic.hpp"
 #include "convar.hpp"
 #include "signals.hpp"
-#include "dbg.h"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 ConVar y_spt_pause("y_spt_pause", "0", FCVAR_ARCHIVE);
 
@@ -136,6 +136,17 @@ void PauseFeature::LoadFeature()
 		}
 
 		InitConcommandBase(y_spt_pause);
+
+		SptImGuiGroup::Cheats_Pause.RegisterUserCallback(
+		    [pause1_works, pause2_works]()
+		    {
+			    const char* opts[] = {
+			        "Disabled",
+			        pause1_works ? "Pause after load" : "N/A",
+			        pause2_works ? "Pause during load" : "N/A",
+			    };
+			    SptImGui::CvarCombo(y_spt_pause, "##combo", opts, ARRAYSIZE(opts));
+		    });
 	}
 }
 
@@ -150,7 +161,7 @@ void PauseFeature::SV_ActivateServer(bool result)
 
 	if (spt_generic.ORIG_SetPaused && pM_bLoadgame && pGameServer)
 	{
-		if ((y_spt_pause.GetInt() == 2) && *pM_bLoadgame)
+		if ((y_spt_pause.GetInt() >= 2) && *pM_bLoadgame)
 		{
 			spt_generic.ORIG_SetPaused((void*)pGameServer, 0, true);
 			DevMsg("Pausing...\n");

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -997,7 +997,16 @@ void PlayerIOFeature::LoadFeature()
 			    y_spt_hud_velocity);
 
 			if (hudEnabled)
-				SptImGui::RegisterHudCvarCheckbox(y_spt_hud_velocity);
+			{
+				SptImGui::RegisterHudCvarCallback(
+				    y_spt_hud_velocity,
+				    [](ConVar& var)
+				    {
+					    const char* opts[] = {"Disabled", "xyz & xy vel", "xy vel", "xyz vel"};
+					    SptImGui::CvarCombo(var, "##combo", opts, ARRAYSIZE(opts));
+				    },
+				    false);
+			}
 		}
 
 		{

--- a/spt/features/shadow.cpp
+++ b/spt/features/shadow.cpp
@@ -20,7 +20,7 @@ CON_COMMAND_F(y_spt_set_shadow_roll, "Sets the player's physics shadow roll in d
 		Warning("Must provide a roll in degrees.\n");
 		return;
 	}
-	spt_player_shadow.SetPlayerHavokPos(spt_playerio.m_vecAbsOrigin.GetValue(), QAngle(0, 0, atof(args.Arg(1))));
+	spt_player_shadow.SetPlayerHavokRoll(atof(args.Arg(1)));
 }
 
 ShadowPosition spt_player_shadow;
@@ -91,7 +91,22 @@ void ShadowPosition::LoadFeature()
 	}
 
 	if (ORIG_beam_object_to_new_position)
+	{
 		InitCommand(y_spt_set_shadow_roll);
+
+		SptImGuiGroup::Cheats_PlayerShadow.RegisterUserCallback(
+		    []()
+		    {
+			    static double df = 0.f;
+			    SptImGui::InputDouble("shadow roll in degrees", &df);
+			    ImGui::SameLine();
+			    if (ImGui::Button("set"))
+				    spt_player_shadow.SetPlayerHavokRoll((float)df);
+			    ImGui::SameLine();
+			    SptImGui::CmdHelpMarkerWithName(y_spt_set_shadow_roll_command);
+				SptImGui::CvarCheckbox(y_spt_hud_shadow_info, "##checkbox_hud");
+		    });
+	}
 }
 
 void ShadowPosition::GetPlayerHavokPos(Vector* worldPosition, QAngle* angles)
@@ -100,6 +115,11 @@ void ShadowPosition::GetPlayerHavokPos(Vector* worldPosition, QAngle* angles)
 		*worldPosition = spt_player_shadow.PlayerHavokPos;
 	if (angles)
 		*angles = spt_player_shadow.PlayerHavokAngles;
+}
+
+void ShadowPosition::SetPlayerHavokRoll(float roll)
+{
+	SetPlayerHavokPos(spt_playerio.m_vecAbsOrigin.GetValue(), QAngle{0, 0, roll});
 }
 
 void ShadowPosition::SetPlayerHavokPos(const Vector& worldPosition, const QAngle& angles)

--- a/spt/features/shadow.hpp
+++ b/spt/features/shadow.hpp
@@ -51,6 +51,7 @@ public:
 	*/
 
 	void GetPlayerHavokPos(Vector* worldPosition, QAngle* angles);
+	void SetPlayerHavokRoll(float roll);
 	void SetPlayerHavokPos(const Vector& worldPosition, const QAngle& angles);
 
 	/*

--- a/spt/features/timer.cpp
+++ b/spt/features/timer.cpp
@@ -1,56 +1,71 @@
 #include "stdafx.hpp"
+
+#include <chrono>
+
 #include "..\feature.hpp"
 #include "generic.hpp"
 #include "signals.hpp"
+#include "tickrate.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
 
 #include "convar.h"
+
+using chrono_timer = std::chrono::steady_clock;
+using chrono_precision = std::chrono::milliseconds;
 
 class Timer : public FeatureWrapper<Timer>
 {
 public:
 	void StartTimer()
 	{
+		if (timerRunning)
+			return;
 		timerRunning = true;
+		lastResumeTimeRta = chrono_timer::now();
 	}
 	void StopTimer()
 	{
+		if (!timerRunning)
+			return;
 		timerRunning = false;
+		partialAccumulatedTimeRta +=
+		    std::chrono::duration_cast<chrono_precision>(chrono_timer::now() - lastResumeTimeRta);
 	}
 	void ResetTimer()
 	{
 		ticksPassed = 0;
+		partialAccumulatedTimeRta = chrono_precision::zero();
 		timerRunning = false;
 	}
 	unsigned int GetTicksPassed() const
 	{
 		return ticksPassed;
 	}
+	double GetTimePassedRta() const
+	{
+		auto extra = timerRunning
+		                 ? std::chrono::duration_cast<chrono_precision>(chrono_timer::now() - lastResumeTimeRta)
+		                 : chrono_precision::zero();
+		constexpr double ratio = (double)chrono_precision::period::num / (double)chrono_precision::period::den;
+		return (partialAccumulatedTimeRta + extra).count() * ratio;
+	}
+	bool Running() const
+	{
+		return timerRunning;
+	}
 
 protected:
-	virtual bool ShouldLoadFeature() override;
-
-	virtual void InitHooks() override;
-
 	virtual void LoadFeature() override;
-
-	virtual void UnloadFeature() override;
 
 private:
 	void Tick();
 	int ticksPassed = 0;
+	chrono_precision partialAccumulatedTimeRta;
+	std::chrono::time_point<chrono_timer> lastResumeTimeRta;
 	bool timerRunning = false;
 };
 
 static Timer spt_timer;
-
-bool Timer::ShouldLoadFeature()
-{
-	return true;
-}
-
-void Timer::InitHooks() {}
-
-void Timer::UnloadFeature() {}
 
 void Timer::Tick()
 {
@@ -66,7 +81,10 @@ CON_COMMAND(y_spt_timer_start, "Starts the SPT timer.")
 CON_COMMAND(y_spt_timer_stop, "Stops the SPT timer and prints the current time.")
 {
 	spt_timer.StopTimer();
-	Warning("Current time (in ticks): %u\n", spt_timer.GetTicksPassed());
+	Warning("Elapsed game time: %u ticks (%.3fs)\nElapsed real time: %.3fs\n",
+	        spt_timer.GetTicksPassed(),
+	        spt_timer.GetTicksPassed() * spt_tickrate.GetTickrate(),
+	        spt_timer.GetTimePassedRta());
 }
 
 CON_COMMAND(y_spt_timer_reset, "Stops and resets the SPT timer.")
@@ -90,5 +108,33 @@ void Timer::LoadFeature()
 		InitCommand(y_spt_timer_stop);
 		InitCommand(y_spt_timer_reset);
 		InitCommand(y_spt_timer_print);
+
+		SptImGuiGroup::QoL_Timer.RegisterUserCallback(
+		    []()
+		    {
+			    unsigned int elapsedTicks = spt_timer.GetTicksPassed();
+			    double elapsedSecsRta = spt_timer.GetTimePassedRta();
+
+			    ImGui::BeginDisabled(spt_timer.Running());
+			    if (ImGui::Button(elapsedSecsRta > 0 ? "resume###start" : "start###start"))
+				    spt_timer.StartTimer();
+			    ImGui::EndDisabled();
+			    ImGui::BeginDisabled(!spt_timer.Running());
+			    ImGui::SameLine();
+			    if (ImGui::Button("pause"))
+				    spt_timer.StopTimer();
+			    ImGui::EndDisabled();
+			    ImGui::SameLine();
+			    if (ImGui::Button("reset"))
+				    spt_timer.ResetTimer();
+			    ImGui::SameLine();
+			    SptImGui::HelpMarker(
+			        "Can be triggered with spt_timer_start, spt_timer_stop, spt_timer_reset");
+
+			    ImGui::Text("Elapsed game time: %u ticks (%.3fs)",
+			                elapsedTicks,
+			                elapsedTicks * spt_tickrate.GetTickrate());
+			    ImGui::Text("Elapsed real time: %.3fs", elapsedSecsRta);
+		    });
 	}
 }

--- a/spt/features/visualizations/draw_ent_collides.cpp
+++ b/spt/features/visualizations/draw_ent_collides.cpp
@@ -116,7 +116,7 @@ protected:
 		    });
 		ClearCache();
 
-		SptImGui::RegisterSectionCallback(SptImGuiGroup::Draw_Collides_Ents, ImGuiCallback);
+		SptImGuiGroup::Draw_Collides_Ents.RegisterUserCallback(ImGuiCallback);
 	};
 
 	virtual void UnloadFeature() override
@@ -382,10 +382,8 @@ private:
 		}
 	}
 
-	static void ImGuiCallback(bool open)
+	static void ImGuiCallback()
 	{
-		if (!open)
-			return;
 		ConVar& c = spt_draw_ent_collides;
 		int oldVal = c.GetInt();
 		bool enabled = !!oldVal;

--- a/spt/features/visualizations/draw_line.cpp
+++ b/spt/features/visualizations/draw_line.cpp
@@ -26,7 +26,7 @@ protected:
 
 private:
 	void OnMeshRenderSignal(MeshRendererDelegate& mr);
-	static void ImGuiCallback(bool open);
+	static void ImGuiCallback();
 };
 
 static DrawLine feat_drawline;
@@ -111,11 +111,8 @@ void DrawLine::OnMeshRenderSignal(MeshRendererDelegate& mr)
 	}
 }
 
-void DrawLine::ImGuiCallback(bool open)
+void DrawLine::ImGuiCallback()
 {
-	if (!open)
-		return;
-
 	auto& lines = feat_drawline.lines;
 	bool& recompute = feat_drawline.should_recompute_meshes;
 
@@ -380,7 +377,7 @@ void DrawLine::LoadFeature()
 
 	InitCommand(spt_draw_line);
 	spt_meshRenderer.signal.Connect(this, &DrawLine::OnMeshRenderSignal);
-	SptImGui::RegisterTabCallback(SptImGuiGroup::Draw_Lines, ImGuiCallback);
+	SptImGuiGroup::Draw_Lines.RegisterUserCallback(ImGuiCallback);
 }
 
 #endif

--- a/spt/features/visualizations/draw_seams.cpp
+++ b/spt/features/visualizations/draw_seams.cpp
@@ -15,6 +15,7 @@
 #include "spt\features\generic.hpp"
 #include "spt\utils\portal_utils.hpp"
 #include "spt\utils\interfaces.hpp"
+#include "imgui\imgui_interface.hpp"
 
 ConVar y_spt_draw_seams("y_spt_draw_seams", "0", FCVAR_CHEAT, "Draws seamshot stuff");
 
@@ -27,6 +28,8 @@ protected:
 		{
 			InitConcommandBase(y_spt_draw_seams);
 			spt_meshRenderer.signal.Connect(this, &DrawSeamsFeature::OnMeshRenderSignal);
+			SptImGuiGroup::Draw_Misc_Seams.RegisterUserCallback(
+			    []() { SptImGui::CvarCheckbox(y_spt_draw_seams, "##checkbox"); });
 		}
 	}
 

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -65,7 +65,7 @@ protected:
 				    spt_DrawWorldCollides_feat.cache.Clear();
 		    });
 
-		SptImGui::RegisterSectionCallback(SptImGuiGroup::Draw_Collides_World, ImGuiCallback);
+		SptImGuiGroup::Draw_Collides_World.RegisterUserCallback(ImGuiCallback);
 	};
 
 	virtual void UnloadFeature() override
@@ -88,10 +88,8 @@ protected:
 	} cache;
 
 private:
-	static void ImGuiCallback(bool open)
+	static void ImGuiCallback()
 	{
-		if (!open)
-			return;
 		// copied from the draw world collides callback
 		ConVar& c = spt_draw_world_collides;
 		int oldVal = c.GetInt();

--- a/spt/features/visualizations/gui_game_detection.cpp
+++ b/spt/features/visualizations/gui_game_detection.cpp
@@ -11,7 +11,7 @@ class GameDetectionFeatureGui : public FeatureWrapper<GameDetectionFeatureGui>
 protected:
 	virtual void LoadFeature()
 	{
-		SptImGui::RegisterSectionCallback(SptImGuiGroup::Dev_GameDetection, ImGuiCallback);
+		SptImGuiGroup::Dev_GameDetection.RegisterUserCallback(ImGuiCallback);
 	}
 
 private:
@@ -28,10 +28,8 @@ private:
 		ImGui::EndDisabled();
 	}
 
-	static void ImGuiCallback(bool open)
+	static void ImGuiCallback()
 	{
-		if (!open)
-			return;
 		using namespace utils;
 		ImGui::Text("Detected game build number: %d", GetBuildNumber());
 		ImGuiTableFlags tableFlags =

--- a/spt/features/visualizations/imgui/imgui_interface.cpp
+++ b/spt/features/visualizations/imgui/imgui_interface.cpp
@@ -333,6 +333,7 @@ private:
 				{
 					imguiStyle = style;
 					reloadImguiStyle = true;
+					ImGui::MarkIniSettingsDirty();
 				}
 				if (selected)
 					ImGui::SetItemDefaultFocus();
@@ -632,7 +633,7 @@ protected:
 		SetupSettingsTabIniHandler();
 #ifdef SPT_HUD_ENABLED
 		if (spt_hud_feat.LoadingSuccessful())
-			SptImGuiGroup::Hud.RegisterUserCallback(TextHudTabCallback);
+			SptImGuiGroup::Hud_TextHud.RegisterUserCallback(TextHudTabCallback);
 #endif
 	};
 

--- a/spt/features/visualizations/imgui/imgui_interface.cpp
+++ b/spt/features/visualizations/imgui/imgui_interface.cpp
@@ -158,21 +158,24 @@ private:
 			showMainWindow = true;
 			ImGui::SetNextWindowFocus();
 		}
-		bool hasBegin = showMainWindow;
-		bool beginReturn =
-		    hasBegin && ImGui::Begin(SptImGuiGroup::Root.name, &showMainWindow, ImGuiWindowFlags_MenuBar);
-		if (beginReturn && ImGui::BeginMenuBar())
+		else if (!showMainWindow)
 		{
-			if (ImGui::BeginMenu("Menu"))
-			{
-				ImGui::MenuItem("About SPT", NULL, &showAboutWindow);
-				ImGui::EndMenu();
-			}
-			ImGui::EndMenuBar();
+			return;
 		}
-		SptImGuiGroup::Root.Draw();
-		if (hasBegin)
-			ImGui::End();
+		if (ImGui::Begin(SptImGuiGroup::Root.name, &showMainWindow, ImGuiWindowFlags_MenuBar))
+		{
+			if (ImGui::BeginMenuBar())
+			{
+				if (ImGui::BeginMenu("Menu"))
+				{
+					ImGui::MenuItem("About SPT", NULL, &showAboutWindow);
+					ImGui::EndMenu();
+				}
+				ImGui::EndMenuBar();
+			}
+			SptImGuiGroup::Root.Draw();
+		}
+		ImGui::End();
 	}
 
 	static void AboutWindowCallback()
@@ -930,7 +933,10 @@ namespace SptImGuiGroup
 						ImGui::Text("This tab doesn't have an associated callback!");
 					if (!allRegistered && SptImGuiFeature::drawNonRegisteredCallbacks)
 						ImGui::PopStyleColor();
-					child->Draw();
+					// keep the tab bar at the top of the window
+					if (ImGui::BeginChild("##tab"))
+						child->Draw();
+					ImGui::EndChild();
 					ImGui::EndTabItem();
 				}
 				else if (!allRegistered && SptImGuiFeature::drawNonRegisteredCallbacks)

--- a/spt/features/visualizations/map_overlay.cpp
+++ b/spt/features/visualizations/map_overlay.cpp
@@ -38,7 +38,7 @@ protected:
 
 private:
 	void OnMeshRenderSignal(MeshRendererDelegate& mr);
-	static void ImGuiCallback(bool open);
+	static void ImGuiCallback();
 
 	std::vector<StaticMesh> meshes;
 };
@@ -273,11 +273,8 @@ void MapOverlay::OnMeshRenderSignal(MeshRendererDelegate& mr)
 	}
 }
 
-void MapOverlay::ImGuiCallback(bool open)
+void MapOverlay::ImGuiCallback()
 {
-	if (!open)
-		return;
-
 	static SptImGui::AutocompletePersistData acPersist;
 	static bool ztest = true;
 
@@ -348,7 +345,7 @@ void MapOverlay::LoadFeature()
 		return;
 	InitCommand(spt_draw_map_overlay);
 	spt_meshRenderer.signal.Connect(this, &MapOverlay::OnMeshRenderSignal);
-	SptImGui::RegisterTabCallback(SptImGuiGroup::Draw_MapOverlay, ImGuiCallback);
+	SptImGuiGroup::Draw_MapOverlay.RegisterUserCallback(ImGuiCallback);
 }
 
 void MapOverlay::UnloadFeature() {}

--- a/spt/features/visualizations/oob_ents.cpp
+++ b/spt/features/visualizations/oob_ents.cpp
@@ -81,6 +81,19 @@ void HudOobEntsFeature::LoadFeature()
 	{
 		InitConcommandBase(spt_draw_oob_ents);
 		spt_meshRenderer.signal.Connect(this, &HudOobEntsFeature::DrawEntsPos);
+
+		SptImGuiGroup::Draw_Misc_OobEnts.RegisterUserCallback(
+		    []()
+		    {
+			    const char* opts[] = {
+			        "Disabled",
+			        "OOB entities",
+			        "OOB entities + no z-test",
+			        "All entities + no z-test",
+			    };
+			    SptImGui::CvarCombo(spt_draw_oob_ents, "entity position indicator", opts, ARRAYSIZE(opts));
+			    SptImGui::CvarCheckbox(spt_hud_oob_ents, "##checkbox");
+		    });
 	}
 #endif
 }

--- a/spt/features/visualizations/portal_placement.cpp
+++ b/spt/features/visualizations/portal_placement.cpp
@@ -144,8 +144,8 @@ private:
 	                         bool& fizzle, // out
 	                         CBaseCombatWeapon* portalGun) const;
 
-	static void ImGuiGunPlacementCallback(bool open);
-	static void ImGuiGridPlacementCallback(bool open);
+	static void ImGuiGunPlacementCallback();
+	static void ImGuiGridPlacementCallback();
 	static void ImGuiTextHudPortalPlacementCallback(ConVar& var);
 };
 
@@ -630,10 +630,8 @@ void PortalPlacement::LoadFeature()
 			InitConcommandBase(y_spt_draw_pp_grid_ms_per_frame);
 
 			spt_meshRenderer.signal.Connect(this, &PortalPlacement::OnMeshRenderSignal);
-			SptImGui::RegisterSectionCallback(SptImGuiGroup::Draw_PpPlacement_Gun,
-			                                  ImGuiGunPlacementCallback);
-			SptImGui::RegisterSectionCallback(SptImGuiGroup::Draw_PpPlacement_Grid,
-			                                  ImGuiGridPlacementCallback);
+			SptImGuiGroup::Draw_PpPlacement_Gun.RegisterUserCallback(ImGuiGunPlacementCallback);
+			SptImGuiGroup::Draw_PpPlacement_Grid.RegisterUserCallback(ImGuiGridPlacementCallback);
 			if (hudCallbackEnabled)
 				SptImGui::RegisterHudCvarCallback(y_spt_hud_portal_placement,
 				                                  ImGuiTextHudPortalPlacementCallback,
@@ -749,11 +747,8 @@ void PortalPlacement::PostPlacementChecks(QAngle& placedAngles,
 	}
 }
 
-void PortalPlacement::ImGuiGunPlacementCallback(bool open)
+void PortalPlacement::ImGuiGunPlacementCallback()
 {
-	if (!open)
-		return;
-
 	ImGui::BeginDisabled(!SptImGui::CvarCheckbox(y_spt_draw_pp, "Draw portal placement"));
 	SptImGui::CvarCheckbox(y_spt_draw_pp_blue, "Draw for blue portal");
 	SptImGui::CvarCheckbox(y_spt_draw_pp_orange, "Draw for orange portal");
@@ -763,11 +758,8 @@ void PortalPlacement::ImGuiGunPlacementCallback(bool open)
 	ImGuiTextHudPortalPlacementCallback(y_spt_hud_portal_placement);
 }
 
-void PortalPlacement::ImGuiGridPlacementCallback(bool open)
+void PortalPlacement::ImGuiGridPlacementCallback()
 {
-	if (!open)
-		return;
-
 	ConCommand& cmd = y_spt_draw_pp_grid_command;
 	const char* wrangledName = WrangleLegacyCommandName(cmd.GetName(), true, nullptr);
 	if (ImGui::Button("Clear grid"))

--- a/spt/features/visualizations/renderer/internal/mesh_renderer.cpp
+++ b/spt/features/visualizations/renderer/internal/mesh_renderer.cpp
@@ -131,7 +131,7 @@ void MeshRendererFeature::LoadFeature()
 	RenderViewPre_Signal.Connect(&g_meshRendererInternal, &MeshRendererInternal::OnRenderViewPre_Signal);
 	InitConcommandBase(y_spt_draw_mesh_debug);
 	InitCommand(y_spt_destroy_all_static_meshes);
-	SptImGui::RegisterSectionCallback(SptImGuiGroup::Dev_Mesh, MeshRendererFeature::ImGuiCallback);
+	SptImGuiGroup::Dev_Mesh.RegisterUserCallback(MeshRendererFeature::ImGuiCallback);
 }
 
 void MeshRendererFeature::UnloadFeature()
@@ -142,10 +142,8 @@ void MeshRendererFeature::UnloadFeature()
 	StaticMesh::DestroyAll();
 }
 
-void MeshRendererFeature::ImGuiCallback(bool open)
+void MeshRendererFeature::ImGuiCallback()
 {
-	if (!open)
-		return;
 	extern ConVar y_spt_draw_mesh_examples;
 	SptImGui::CvarCheckbox(y_spt_draw_mesh_examples, "Draw mesh examples");
 

--- a/spt/features/visualizations/renderer/mesh_renderer.hpp
+++ b/spt/features/visualizations/renderer/mesh_renderer.hpp
@@ -137,7 +137,7 @@ private:
 	                   bool bInSkybox,
 	                   bool bShadowDepth);
 
-	static void ImGuiCallback(bool open);
+	static void ImGuiCallback();
 };
 
 inline MeshRendererFeature spt_meshRenderer;


### PR DESCRIPTION
GUI Changes:
- Added QoL & cheat tab
- Added IHUD/JHUD tabs in addition to text HUD tab
- Added misc section to drawing tab
- Updated spt_hud_velocity HUD cvar to be a drop-down instead of a checkbox
- The tab callbacks in the main window are now in a child window (independent scrolling region)

Internal changes:
- Added RTA time to timer feature (this is so that you can tell if the feature is actually on when using it in ImGui)
- Removed the 'open' bool param from the main window ImGui callbacks - it's really inconvenient if the user has to check for it all the time and doesn't use it 95% of the time

The distinction between the QoL & the Cheats tab is pretty muddy. Some of that may be organized differently or shifted around in the future ¯\\_(ツ)_/¯.

Independent scrolling region:
![image](https://github.com/user-attachments/assets/78bf2dc0-e8e3-4b52-a6ea-2e1408ca43c0)

QoL tab:
![image](https://github.com/user-attachments/assets/ee51d960-fd56-488a-a4b6-0f191a6394d2)

Cheats tab:
![image](https://github.com/user-attachments/assets/0b4a9274-e8a5-467a-84f8-c18890d64a78)
