### PR TITLE
Add support for multi-dot extensions in convar file autocomplete

### DIFF
--- a/spt/utils/convar.cpp
+++ b/spt/utils/convar.cpp
@@ -92,11 +92,18 @@ int FileAutoCompleteList::AutoCompletionFunc(AUTOCOMPLETION_FUNCTION_PARAMS)
 		for (auto& p : fs::directory_iterator(dir, ec))
 		{
 			if (fs::is_directory(p.status()))
-				completions.push_back(completionPath + p.path().filename().string() + '/');
-			else if (p.path().extension() == extension)
 			{
-				std::string completion(completionPath + p.path().stem().string());
-				completions.push_back(completion);
+				completions.push_back(completionPath + p.path().filename().string() + '/');
+			}
+			else
+			{
+				// don't use extension() & stem() to support extensions with multiple dots
+				std::string filename = p.path().filename().string();
+				if (filename.size() > extension.size() && filename.ends_with(extension))
+				{
+					std::string stem = filename.substr(0, filename.size() - extension.size());
+					completions.push_back(completionPath + stem);
+				}
 			}
 		}
 	}

--- a/spt/utils/convar.hpp
+++ b/spt/utils/convar.hpp
@@ -150,7 +150,7 @@ public:
 
 private:
 	const char* subDirectory;
-	const char* extension;
+	std::string extension;
 	std::filesystem::path prevPath;
 };
 


### PR DESCRIPTION
I was going to use the .sptr.xz extension for player trace files but the std file extension logic only checks the right-most dot