### PR TITLE
Move CreateCollideFeature to features folder

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1189,6 +1189,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\features\camera.cpp" />
     <ClCompile Include="spt\features\collision_group.cpp" />
     <ClCompile Include="spt\features\con_notify.cpp" />
+    <ClCompile Include="spt\features\create_collide.cpp" />
     <ClCompile Include="spt\features\cvar.cpp" />
     <ClCompile Include="spt\features\demo.cpp" />
     <ClCompile Include="spt\features\dmomm.cpp" />
@@ -1249,7 +1250,6 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\features\visualizations\mesh_test.cpp" />
     <ClCompile Include="spt\features\visualizations\oob_ents.cpp" />
     <ClCompile Include="spt\features\visualizations\portal_placement.cpp" />
-    <ClCompile Include="spt\features\visualizations\renderer\internal\create_collide.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\internal\materials_manager.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\internal\mesh_builder.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\internal\mesh_construction.cpp" />
@@ -1441,6 +1441,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\features\afterticks.hpp" />
     <ClInclude Include="spt\features\aim.hpp" />
     <ClInclude Include="spt\features\autojump.hpp" />
+    <ClInclude Include="spt\features\create_collide.hpp" />
     <ClInclude Include="spt\features\cvar.hpp" />
     <ClInclude Include="spt\features\demo.hpp" />
     <ClInclude Include="spt\features\ent_props.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -274,9 +274,6 @@
     <ClCompile Include="spt\features\movement_vars.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
-    <ClCompile Include="spt\features\visualizations\renderer\internal\create_collide.cpp">
-      <Filter>spt\features\visualizations\renderer\internal</Filter>
-    </ClCompile>
     <ClCompile Include="spt\features\visualizations\renderer\internal\materials_manager.cpp">
       <Filter>spt\features\visualizations\renderer\internal</Filter>
     </ClCompile>
@@ -399,6 +396,9 @@
     </ClCompile>
     <ClCompile Include="spt\features\game_fixes\caption_fix.cpp">
       <Filter>spt\features\game_fixes</Filter>
+    </ClCompile>
+    <ClCompile Include="spt\features\create_collide.cpp">
+      <Filter>spt\features</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -738,9 +738,6 @@
     <ClInclude Include="spt\features\visualizations\renderer\internal\vector_slice.hpp">
       <Filter>spt\features\visualizations\renderer\internal</Filter>
     </ClInclude>
-    <ClInclude Include="spt\features\visualizations\renderer\create_collide.hpp">
-      <Filter>spt\features\visualizations\renderer</Filter>
-    </ClInclude>
     <ClInclude Include="spt\features\visualizations\renderer\mesh_builder.hpp">
       <Filter>spt\features\visualizations\renderer</Filter>
     </ClInclude>
@@ -827,6 +824,9 @@
     </ClInclude>
     <ClInclude Include="spt\features\visualizations\imgui\imgui_styles.hpp">
       <Filter>spt\features\visualizations\imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\features\create_collide.hpp">
+      <Filter>spt\features</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/spt/features/create_collide.hpp
+++ b/spt/features/create_collide.hpp
@@ -12,7 +12,7 @@
 
 class CPhysCollide;
 class IPhysicsObject;
-class CBaseEntity;
+class IServerEntity;
 
 // a simple interface to get the vertices of physics models
 class CreateCollideFeature : public FeatureWrapper<CreateCollideFeature>
@@ -27,13 +27,13 @@ public:
 
 	// you'll need to transform the verts using either pEnt's matrix or the matrix from the phys obj;
 	// only creates a mesh using GetPhysObj(), not GetPhysObjList()
-	std::unique_ptr<Vector> CreateEntMesh(const CBaseEntity* pEnt, int& outNumTris);
+	std::unique_ptr<Vector> CreateEntMesh(const IServerEntity* pEnt, int& outNumTris);
 
 	// can be used after InitHooks()
-	IPhysicsObject* GetPhysObj(const CBaseEntity* pEnt);
+	IPhysicsObject* GetPhysObj(const IServerEntity* pEnt);
 
 	// calls VPhysicsGetObjectList(), used when pEnt has multiple vphys objects; see note about spheres above
-	int GetPhysObjList(const CBaseEntity* pEnt, IPhysicsObject** pList, int maxElems);
+	int GetPhysObjList(const IServerEntity* pEnt, IPhysicsObject** pList, int maxElems);
 
 protected:
 	virtual void InitHooks();

--- a/spt/features/visualizations/draw_ent_collides.cpp
+++ b/spt/features/visualizations/draw_ent_collides.cpp
@@ -11,8 +11,8 @@
 
 #include "spt\utils\interfaces.hpp"
 #include "spt\features\ent_props.hpp"
+#include "spt\features\create_collide.hpp"
 #include "renderer\mesh_renderer.hpp"
-#include "renderer\create_collide.hpp"
 #include "imgui\imgui_interface.hpp"
 
 #ifdef SPT_MESH_RENDERING_ENABLED

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -8,9 +8,8 @@
 #include "spt\utils\portal_utils.hpp"
 #include "spt\features\tracing.hpp"
 #include "spt\features\generic.hpp"
-#include "spt\features\generic.hpp"
+#include "spt\features\create_collide.hpp"
 #include "renderer\mesh_renderer.hpp"
-#include "renderer\create_collide.hpp"
 #include "imgui\imgui_interface.hpp"
 
 #ifdef SPT_MESH_RENDERING_ENABLED

--- a/spt/features/visualizations/sg-collide-vis.cpp
+++ b/spt/features/visualizations/sg-collide-vis.cpp
@@ -14,7 +14,7 @@
 #include "spt\utils\game_detection.hpp"
 #include "spt\utils\signals.hpp"
 #include "spt\features\ent_props.hpp"
-#include "renderer\create_collide.hpp"
+#include "spt\features\create_collide.hpp"
 
 using interfaces::engine_server;
 
@@ -141,7 +141,7 @@ public:
 
 		struct CachedEnt
 		{
-			CBaseEntity* pEnt;
+			IServerEntity* pEnt;
 			IPhysicsObject* pPhysObj;
 			StaticMesh mesh;
 			CachedEntFlags flags;
@@ -519,7 +519,7 @@ public:
 			edict_t* ed = interfaces::engine_server->PEntityOfEntIndex(i);
 			if (!ed || !ed->GetIServerEntity())
 				continue;
-			CBaseEntity* pEnt = ed->GetIServerEntity()->GetBaseEntity();
+			IServerEntity* pEnt = ed->GetIServerEntity();
 			auto pCp = (CCollisionProperty*)((uint32_t)pEnt + portalFieldOffs.m_Collision);
 			bool collisionSolid = pCp->IsSolid();
 
@@ -549,7 +549,7 @@ public:
 		}
 	}
 
-	void DrawSingleEntity(MeshRendererDelegate& mr, CBaseEntity* pEnt, int entIndex, CachedEntFlags entFlags)
+	void DrawSingleEntity(MeshRendererDelegate& mr, IServerEntity* pEnt, int entIndex, CachedEntFlags entFlags)
 	{
 		if (!pEnt || entFlags == CEF_NONE || entFlags == CEF_IS_CLONE)
 			return;


### PR DESCRIPTION
I originally put the create collide feature in the renderer because that's the only place where I used it. But it has nothing to do with rendering and it now has utilities like getting all the vphysics objects from an entity which is not rendering-specific. I'll probably end up using this feature to simplify the shadow feature in the future.