### PR TITLE
Entity list

### DIFF
--- a/Tests/hl2 - 5135/test/001-c17_02-2,115s.srctas
+++ b/Tests/hl2 - 5135/test/001-c17_02-2,115s.srctas
@@ -1,5 +1,5 @@
 save 000-c17_02-0,12s-Rama
-settings y_spt_autojump 1; exec tashelp; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings y_spt_autojump 1; exec tashelp; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 
 vars

--- a/Tests/hl2 - 5135/test/001-canals01_tas.srctas
+++ b/Tests/hl2 - 5135/test/001-canals01_tas.srctas
@@ -1,7 +1,7 @@
 save 000-canals_01-0,12s-Rama
 settings y_spt_autojump 1
 playspeed 1
-settings tas_strafe_use_tracing 0; exec tashelp; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings tas_strafe_use_tracing 0; exec tashelp; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 
 vars

--- a/Tests/hl2 - 5135/test/006-canals01_tas.srctas
+++ b/Tests/hl2 - 5135/test/006-canals01_tas.srctas
@@ -1,5 +1,5 @@
 save 005-canals01-0,39s
-settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 vars
 frames

--- a/Tests/hl2 - 5135/test/006-coast07_tas.srctas
+++ b/Tests/hl2 - 5135/test/006-coast07_tas.srctas
@@ -1,5 +1,5 @@
 save 005-coast_05-6,255
-settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 vars
 frames

--- a/Tests/hl2 - 5135/test/008-coast10_tas.srctas
+++ b/Tests/hl2 - 5135/test/008-coast10_tas.srctas
@@ -1,5 +1,5 @@
 save 007-coast09_tas
-settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 vars
 frames

--- a/Tests/hl2 - 5135/test/010-coast12_tas.srctas
+++ b/Tests/hl2 - 5135/test/010-coast12_tas.srctas
@@ -1,5 +1,5 @@
 save 009-coast11_tas
-settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 vars
 frames

--- a/Tests/hl2 - 5135/test/021-prison01_tas.srctas
+++ b/Tests/hl2 - 5135/test/021-prison01_tas.srctas
@@ -1,5 +1,5 @@
 save 020-9
-settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1
+settings y_spt_autojump 1; exec tashelp; tas_strafe_use_tracing 0; cl_mouseenable 0; _y_spt_afterframes_await_legacy 1; spt_tas_strafe_version 7
 playspeed 16
 vars
 frames

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -448,7 +448,7 @@ del "$(OutDir)spt-version.obj"</Command>
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>spt\utils;thirdparty\curl\include;.;SDK\episode1_new\include\common;SDK\episode1_new\include\public;SDK\episode1_new\include\public\tier0;SDK\episode1_new\include\public\tier1;SDK\episode1_new\include\game\server;SDK\episode1_new\include\game\client;SDK\episode1_new\include\game\shared;SPTLib\Windows\minhook\include;SPTLib\Windows\Minhook\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>spt\utils;thirdparty\curl\include;.;SDK\episode1_new\include\common;SDK\episode1_new\include\public;SDK\episode1_new\include\public\tier0;SDK\episode1_new\include\public\tier1;SDK\episode1_new\include\game_shared;SPTLib\Windows\minhook\include;SPTLib\Windows\Minhook\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OE;WIN32;_WIN32;_DEBUG;DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions);TARGET_NAME="$(TargetName).dll"</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
@@ -855,7 +855,7 @@ del "$(OutDir)spt-version.obj"</Command>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>spt\utils;thirdparty\curl\include;.;SDK\episode1_new\include\common;SDK\episode1_new\include\public;SDK\episode1_new\include\public\tier0;SDK\episode1_new\include\public\tier1;SDK\episode1_new\include\game\server;SDK\episode1_new\include\game\client;SDK\episode1_new\include\game\shared;SPTLib\Windows\minhook\include;SPTLib\Windows\Minhook\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>spt\utils;thirdparty\curl\include;.;SDK\episode1_new\include\common;SDK\episode1_new\include\public;SDK\episode1_new\include\public\tier0;SDK\episode1_new\include\public\tier1;SDK\episode1_new\include\game_shared;SPTLib\Windows\minhook\include;SPTLib\Windows\Minhook\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OE;WIN32;_WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;sptONLY;_MBCS;%(PreprocessorDefinitions);TARGET_NAME="$(TargetName).dll"</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
@@ -1362,6 +1362,8 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\strafe\strafestuff.cpp" />
     <ClCompile Include="spt\utils\convar.cpp" />
     <ClCompile Include="spt\utils\datamap_wrapper.cpp" />
+    <ClCompile Include="spt\utils\ent_list_client.cpp" />
+    <ClCompile Include="spt\utils\ent_list_server.cpp" />
     <ClCompile Include="spt\utils\ent_utils.cpp" />
     <ClCompile Include="spt\utils\file.cpp" />
     <ClCompile Include="spt\utils\game_detection.cpp" />
@@ -1496,6 +1498,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\utils\convar.hpp" />
     <ClInclude Include="spt\utils\custom_interfaces.hpp" />
     <ClInclude Include="spt\utils\datamap_wrapper.hpp" />
+    <ClInclude Include="spt\utils\ent_list.hpp" />
     <ClInclude Include="spt\utils\ent_utils.hpp" />
     <ClInclude Include="spt\utils\file.hpp" />
     <ClInclude Include="spt\utils\game_detection.hpp" />

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1367,6 +1367,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\utils\ent_utils.cpp" />
     <ClCompile Include="spt\utils\file.cpp" />
     <ClCompile Include="spt\utils\game_detection.cpp" />
+    <ClCompile Include="spt\utils\map_utils.cpp" />
     <ClCompile Include="spt\utils\math.cpp" />
     <ClCompile Include="spt\utils\portal_utils.cpp" />
     <ClCompile Include="spt\utils\signals.cpp" />
@@ -1504,6 +1505,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\utils\game_detection.hpp" />
     <ClInclude Include="spt\utils\interfaces.hpp" />
     <ClInclude Include="spt\utils\ivp_maths.hpp" />
+    <ClInclude Include="spt\utils\map_utils.hpp" />
     <ClInclude Include="spt\utils\math.hpp" />
     <ClInclude Include="spt\utils\portal_utils.hpp" />
     <ClInclude Include="spt\utils\signals.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -406,6 +406,9 @@
     <ClCompile Include="spt\features\create_collide.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
+    <ClCompile Include="spt\utils\map_utils.cpp">
+      <Filter>spt\utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">
@@ -836,6 +839,9 @@
     </ClInclude>
     <ClInclude Include="spt\features\create_collide.hpp">
       <Filter>spt\features</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\utils\map_utils.hpp">
+      <Filter>spt\utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -397,6 +397,12 @@
     <ClCompile Include="spt\features\game_fixes\caption_fix.cpp">
       <Filter>spt\features\game_fixes</Filter>
     </ClCompile>
+    <ClCompile Include="spt\utils\ent_list_client.cpp">
+      <Filter>spt\utils</Filter>
+    </ClCompile>
+    <ClCompile Include="spt\utils\ent_list_server.cpp">
+      <Filter>spt\utils</Filter>
+    </ClCompile>
     <ClCompile Include="spt\features\create_collide.cpp">
       <Filter>spt\features</Filter>
     </ClCompile>
@@ -824,6 +830,9 @@
     </ClInclude>
     <ClInclude Include="spt\features\visualizations\imgui\imgui_styles.hpp">
       <Filter>spt\features\visualizations\imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\utils\ent_list.hpp">
+      <Filter>spt\utils</Filter>
     </ClInclude>
     <ClInclude Include="spt\features\create_collide.hpp">
       <Filter>spt\features</Filter>

--- a/spt/aim/aimstuff.cpp
+++ b/spt/aim/aimstuff.cpp
@@ -7,12 +7,11 @@
 #include "ent_utils.hpp"
 #include "spt/sptlib-wrapper.hpp"
 #include "spt\features\game_fixes\rng.hpp"
+#include "spt\features\tas.hpp"
 #include "..\spt-serverplugin.hpp"
 
 #undef max
 #undef min
-
-extern ConVar tas_strafe_vectorial_offset;
 
 namespace aim
 {

--- a/spt/features/aim.cpp
+++ b/spt/features/aim.cpp
@@ -37,7 +37,7 @@ void AimFeature::HandleAiming(float* va, bool& yawChanged, const Strafe::StrafeI
 		}
 		else
 		{
-			IClientEntity* ent = utils::GetClientEntity(viewState.targetID);
+			IClientEntity* ent = utils::spt_clientEntList.GetEnt(viewState.targetID);
 			if (!ent)
 			{
 				spt_aim.viewState.state = aim::ViewState::AimState::NO_AIM;
@@ -167,7 +167,7 @@ CON_COMMAND(tas_aim, "Aims at an angle")
 
 	if (cone >= 0)
 	{
-		if (!utils::playerEntityAvailable())
+		if (!utils::spt_clientEntList.GetPlayer())
 		{
 			Warning(
 			    "Trying to apply nospread while map not loaded in! Wait until map is loaded before issuing spt_tas_aim with spread cone set.\n");
@@ -258,6 +258,9 @@ CON_COMMAND(tas_aim_ent, "Aim at the absolute origin of a entity with offsets (o
 
 	spt_aim.viewState.state = aim::ViewState::AimState::ENTITY;
 	spt_aim.viewState.targetID = std::atoi(args.Arg(1));
+	extern ConVar tas_strafe_version;
+	if (tas_strafe_version.GetInt() < 8)
+		spt_aim.viewState.targetID += 1; // backwards compat for old entity index logic
 
 	if (frames == -1)
 	{
@@ -320,7 +323,8 @@ CON_COMMAND(_y_spt_setangle,
 		target.y = atof(args.Arg(2));
 		target.z = atof(args.Arg(3));
 
-		Vector player_origin = spt_playerio.GetPlayerEyePos();
+		extern ConVar tas_strafe_version;
+		Vector player_origin = spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8);
 		Vector diff = (target - player_origin);
 		QAngle angles;
 		VectorAngles(diff, angles);

--- a/spt/features/aim.cpp
+++ b/spt/features/aim.cpp
@@ -6,6 +6,7 @@
 #include "math.hpp"
 #include "playerio.hpp"
 #include "signals.hpp"
+#include "tas.hpp"
 
 #undef min
 #undef max
@@ -258,7 +259,6 @@ CON_COMMAND(tas_aim_ent, "Aim at the absolute origin of a entity with offsets (o
 
 	spt_aim.viewState.state = aim::ViewState::AimState::ENTITY;
 	spt_aim.viewState.targetID = std::atoi(args.Arg(1));
-	extern ConVar tas_strafe_version;
 	if (tas_strafe_version.GetInt() < 8)
 		spt_aim.viewState.targetID += 1; // backwards compat for old entity index logic
 
@@ -323,7 +323,6 @@ CON_COMMAND(_y_spt_setangle,
 		target.y = atof(args.Arg(2));
 		target.z = atof(args.Arg(3));
 
-		extern ConVar tas_strafe_version;
 		Vector player_origin = spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8);
 		Vector diff = (target - player_origin);
 		QAngle angles;

--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -8,6 +8,7 @@
 #include "signals.hpp"
 #include "game_detection.hpp"
 #include "visualizations\imgui\imgui_interface.hpp"
+#include "tas.hpp"
 
 #ifdef OE
 #include "mathlib.h"
@@ -25,8 +26,6 @@ ConVar y_spt_jumpboost("y_spt_jumpboost",
                        "2 = OE movement mechanic.\n"
                        "3 = No jumpboost. (multiplayer mode movement)");
 ConVar y_spt_aircontrol("y_spt_aircontrol", "0", FCVAR_CHEAT, "Enables HL2 air control.");
-
-extern ConVar tas_log;
 
 namespace patterns
 {

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -637,7 +637,7 @@ void Camera::HandleDriveEntityMode(bool active)
 	if (!active)
 		return;
 
-	IClientEntity* ent = utils::GetClientEntity(driveEntInfo.entIndex);
+	IClientEntity* ent = utils::spt_clientEntList.GetEnt(driveEntInfo.entIndex);
 	driveEntExists = !!(ent);
 	if (!driveEntExists)
 	{

--- a/spt/features/collision_group.cpp
+++ b/spt/features/collision_group.cpp
@@ -2,6 +2,7 @@
 #include "ent_utils.hpp"
 #include "..\feature.hpp"
 #include "visualizations\imgui\imgui_interface.hpp"
+#include "spt\utils\ent_list.hpp"
 
 namespace patterns
 {
@@ -54,7 +55,7 @@ CON_COMMAND_F(y_spt_set_collision_group,
 		return;
 	}
 
-	auto playerPtr = utils::GetServerPlayer();
+	auto playerPtr = utils::spt_serverEntList.GetPlayer();
 	if (!playerPtr)
 	{
 		Warning("Server player not available\n");
@@ -80,6 +81,10 @@ void CollisionGroup::LoadFeature()
 
 void CollisionGroup::ImGuiCallback()
 {
+	auto playerPtr = utils::spt_serverEntList.GetPlayer();
+	ImGui::BeginDisabled(!playerPtr);
+	ImGui::BeginGroup();
+
 	const char* groups[LAST_SHARED_COLLISION_GROUP] = {
 	    STR(COLLISION_GROUP_NONE),
 	    STR(COLLISION_GROUP_DEBRIS),
@@ -121,10 +126,9 @@ void CollisionGroup::ImGuiCallback()
 		ImGui::EndCombo();
 	}
 	ImGui::SameLine();
-	auto playerPtr = utils::GetServerPlayer();
-	ImGui::BeginDisabled(!playerPtr);
 	if (ImGui::Button("set"))
 		spt_collisiongroup.ORIG_SetCollisionGroup(playerPtr, val);
+	ImGui::EndGroup();
 	ImGui::EndDisabled();
 	if (!playerPtr)
 		ImGui::SetItemTooltip("server player not available");

--- a/spt/features/create_collide.cpp
+++ b/spt/features/create_collide.cpp
@@ -68,8 +68,8 @@ std::unique_ptr<Vector> CreateCollideFeature::CreatePhysObjMesh(const IPhysicsOb
 
 IPhysicsObject* CreateCollideFeature::GetPhysObj(const IServerEntity* pEnt)
 {
-	static utils::CachedField<IPhysicsObject*, "CBaseEntity", "m_CollisionGroup", true, false, sizeof(int)> fPhys;
-	return pEnt && fPhys.Exists() ? *fPhys.GetPtr(pEnt) : nullptr;
+	static utils::CachedField<IPhysicsObject*, "CBaseEntity", "m_pPhysicsObject", true> fPhys;
+	return fPhys.GetValueOrDefault(pEnt);
 }
 
 int CreateCollideFeature::GetPhysObjList(const IServerEntity* pEnt, IPhysicsObject** pList, int maxElems)
@@ -77,7 +77,7 @@ int CreateCollideFeature::GetPhysObjList(const IServerEntity* pEnt, IPhysicsObje
 	if (!pEnt || !pList || getVPhysObjListVirtualOff <= 0)
 		return 0;
 
-	static utils::CachedField<string_t, "CBaseEntity", "m_iClassname", true, false> classNameField{};
+	static utils::CachedField<string_t, "CBaseEntity", "m_iClassname", true> classNameField{};
 
 	if (!classNameField.Exists())
 		return 0;
@@ -104,7 +104,7 @@ int CreateCollideFeature::GetPhysObjList(const IServerEntity* pEnt, IPhysicsObje
 	}
 
 	// actually m_VehiclePhysics.m_pOuter
-	static utils::CachedField<CBaseHandle, "CPropVehicle", "m_VehiclePhysics.m_controls.throttle", true, false, -8>
+	static utils::CachedField<CBaseHandle, "CPropVehicle", "m_VehiclePhysics.m_controls.throttle", true, -8>
 	    vehicleOuterField{};
 
 	if (isVehicle)

--- a/spt/features/create_collide.cpp
+++ b/spt/features/create_collide.cpp
@@ -66,17 +66,6 @@ std::unique_ptr<Vector> CreateCollideFeature::CreatePhysObjMesh(const IPhysicsOb
 	return CreateCollideMesh(pPhysObj->GetCollide(), outNumTris);
 }
 
-std::unique_ptr<Vector> CreateCollideFeature::CreateEntMesh(const IServerEntity* pEnt, int& outNumTris)
-{
-	IPhysicsObject* pPhysObj = GetPhysObj(pEnt);
-	if (!pPhysObj)
-	{
-		outNumTris = 0;
-		return nullptr;
-	}
-	return CreatePhysObjMesh(pPhysObj, outNumTris);
-}
-
 IPhysicsObject* CreateCollideFeature::GetPhysObj(const IServerEntity* pEnt)
 {
 	static utils::CachedField<IPhysicsObject*, "CBaseEntity", "m_CollisionGroup", true, false, sizeof(int)> fPhys;

--- a/spt/features/create_collide.hpp
+++ b/spt/features/create_collide.hpp
@@ -22,13 +22,13 @@ public:
 	std::unique_ptr<Vector> CreateCollideMesh(const CPhysCollide* pCollide, int& outNumTris);
 
 	// you'll need to transform these verts by applying a matrix you can create with pPhysObj->GetPosition();
-	// if this returns a sphere (pPhysObj->GetSphereRadius() > 0) then this return an empty mesh
+	// if the object is a sphere (pPhysObj->GetSphereRadius() > 0) then this return an empty mesh
 	std::unique_ptr<Vector> CreatePhysObjMesh(const IPhysicsObject* pPhysObj, int& outNumTris);
 
 	// can be used after InitHooks()
 	IPhysicsObject* GetPhysObj(const IServerEntity* pEnt);
 
-	// calls VPhysicsGetObjectList(), used when pEnt has multiple vphys objects; see note about spheres above
+	// calls VPhysicsGetObjectList(), used when pEnt has multiple vphys objects
 	int GetPhysObjList(const IServerEntity* pEnt, IPhysicsObject** pList, int maxElems);
 
 protected:

--- a/spt/features/create_collide.hpp
+++ b/spt/features/create_collide.hpp
@@ -25,10 +25,6 @@ public:
 	// if this returns a sphere (pPhysObj->GetSphereRadius() > 0) then this return an empty mesh
 	std::unique_ptr<Vector> CreatePhysObjMesh(const IPhysicsObject* pPhysObj, int& outNumTris);
 
-	// you'll need to transform the verts using either pEnt's matrix or the matrix from the phys obj;
-	// only creates a mesh using GetPhysObj(), not GetPhysObjList()
-	std::unique_ptr<Vector> CreateEntMesh(const IServerEntity* pEnt, int& outNumTris);
-
 	// can be used after InitHooks()
 	IPhysicsObject* GetPhysObj(const IServerEntity* pEnt);
 

--- a/spt/features/ent_props.cpp
+++ b/spt/features/ent_props.cpp
@@ -12,6 +12,7 @@
 #include "SPTLib\patterns.hpp"
 #include "visualizations/imgui/imgui_interface.hpp"
 #include "thirdparty/imgui/imgui_internal.h"
+#include "spt/utils/ent_list.hpp"
 
 #include <string>
 #include <unordered_map>
@@ -105,25 +106,6 @@ int EntProps::GetPlayerOffset(const std::string& key, bool server)
 		return playermap->GetClientOffset(key);
 }
 
-void* EntProps::GetPlayer(bool server)
-{
-	if (server)
-	{
-		if (!interfaces::engine_server)
-			return nullptr;
-
-		auto edict = interfaces::engine_server->PEntityOfEntIndex(1);
-		if (!edict || (uint32_t)edict == 0xFFFFFFFF)
-			return nullptr;
-
-		return edict->GetUnknown();
-	}
-	else
-	{
-		return interfaces::entList->GetClientEntity(1);
-	}
-}
-
 int EntProps::GetFieldOffset(const std::string& mapKey, const std::string& key, bool server)
 {
 	auto map = GetDatamapWrapper(mapKey);
@@ -195,8 +177,8 @@ static bool DoesMapLookValid(datamap_t* map, uint8_t* moduleStart, std::size_t l
 
 PropMode EntProps::ResolveMode(PropMode mode)
 {
-	auto svplayer = GetPlayer(true);
-	auto clplayer = GetPlayer(false);
+	auto svplayer = utils::spt_serverEntList.GetPlayer();
+	auto clplayer = utils::spt_clientEntList.GetPlayer();
 
 	switch (mode)
 	{
@@ -402,9 +384,62 @@ CON_COMMAND(y_spt_canjb, "Tests if player can jumpbug on a given height, with th
 		Msg("No, missed by %.6f in %d ticks.\n", can.landingHeight - height, can.ticks);
 }
 
-CON_COMMAND(y_spt_print_ents, "Prints all client entity indices and their corresponding classes.")
+CON_COMMAND(y_spt_print_ents, "Prints all entity indices and their corresponding classes.")
 {
-	utils::PrintAllClientEntities();
+	auto& serverEnts = utils::spt_serverEntList.GetEntList();
+	auto& clientEnts = utils::spt_clientEntList.GetEntList();
+
+	if (serverEnts.empty() && clientEnts.empty())
+	{
+		Msg("no entities\n");
+		return;
+	}
+
+	auto serverIt = serverEnts.cbegin();
+	auto clientIt = clientEnts.cbegin();
+
+	for (;;)
+	{
+		bool hasServerEnt = serverIt < serverEnts.cend();
+		bool hasClientEnt = clientIt < clientEnts.cend();
+		if (!hasServerEnt && !hasClientEnt)
+			break;
+
+		CBaseHandle serverHandle = hasServerEnt ? (**serverIt).GetRefEHandle() : CBaseHandle{};
+		CBaseHandle clientHandle = hasClientEnt ? (**clientIt).GetRefEHandle() : CBaseHandle{};
+		const char* serverName = hasServerEnt ? utils::spt_serverEntList.NetworkClassName(*serverIt) : "<null>";
+		serverName = serverName ? serverName : "<null>";
+		const char* clientName = hasClientEnt ? utils::spt_clientEntList.NetworkClassName(*clientIt) : "<null>";
+		clientName = clientName ? clientName : "<null>";
+
+		if (serverHandle.GetEntryIndex() == clientHandle.GetEntryIndex())
+		{
+			Msg("[%4d] SERVER (serial %5d) : %s, CLIENT (serial %5d) : %s\n",
+			    serverHandle.GetEntryIndex(),
+			    serverHandle.GetSerialNumber(),
+			    serverName,
+			    clientHandle.GetSerialNumber(),
+			    clientName);
+			++serverIt;
+			++clientIt;
+		}
+		else if (serverHandle.GetEntryIndex() < clientHandle.GetEntryIndex())
+		{
+			Msg("[%4d] SERVER (serial %5d) : %s\n",
+			    serverHandle.GetEntryIndex(),
+			    serverHandle.GetSerialNumber(),
+			    serverName);
+			++serverIt;
+		}
+		else
+		{
+			Msg("[%4d] CLIENT (serial %5d) : %s\n",
+			    clientHandle.GetEntryIndex(),
+			    clientHandle.GetSerialNumber(),
+			    clientName);
+			++clientIt;
+		}
+	}
 }
 
 CON_COMMAND(y_spt_print_ent_props, "Prints all props for a given entity index.")
@@ -443,10 +478,7 @@ void EntProps::LoadFeature()
 		bool hudEnabled = AddHudCallback(
 		    "portal_bubble",
 		    [this](std::string)
-		    {
-			    int in_bubble = GetEnvironmentPortal() != NULL;
-			    spt_hud_feat.DrawTopHudElement(L"portal bubble: %d", in_bubble);
-		    },
+		    { spt_hud_feat.DrawTopHudElement(L"portal bubble: %d", !!utils::GetEnvironmentPortal()); },
 		    y_spt_hud_portal_bubble);
 
 		if (hudEnabled)
@@ -556,7 +588,7 @@ void EntProps::ImGuiEntInfoCvarCallback(ConVar& var)
 			SptImGui::BeginBordered();
 
 			long long entIndex = atoll(oldVal + i);
-			IClientEntity* ent = utils::GetClientEntity(entIndex);
+			IClientEntity* ent = utils::spt_clientEntList.GetEnt(entIndex);
 			nRegexesForEnt = 0;
 
 			if (SptImGui::InputTextInteger("entity index,", "", entIndex, 10))
@@ -584,7 +616,7 @@ void EntProps::ImGuiEntInfoCvarCallback(ConVar& var)
 				* Jump ahead to the next entity. Note that we still entered the ID & indent scope
 				* for this entity - that will be popped in the next loop. This jump means that the
 				* newVal will not get any data (including the index) associated with this entity.
-				* There does cause one broken frame because the button for the ent deletion must
+				* This does cause one broken frame because the button for the ent deletion must
 				* exist but I don't draw the regexes for that entity. This is fixable but I cbf.
 				*/
 				while (nextSepIdx < len && oldVal[nextSepIdx] != ENT_SEPARATOR)
@@ -655,18 +687,18 @@ void EntProps::ImGuiEntInfoCvarCallback(ConVar& var)
 
 void** _InternalPlayerField::GetServerPtr() const
 {
-	auto serverplayer = reinterpret_cast<uintptr_t>(spt_entprops.GetPlayer(true));
+	auto serverplayer = utils::spt_serverEntList.GetPlayer();
 	if (serverplayer && serverOffset != utils::INVALID_DATAMAP_OFFSET)
-		return reinterpret_cast<void**>(serverplayer + serverOffset);
+		return reinterpret_cast<void**>(reinterpret_cast<uint32_t>(serverplayer) + serverOffset);
 	else
 		return nullptr;
 }
 
 void** _InternalPlayerField::GetClientPtr() const
 {
-	auto clientPlayer = reinterpret_cast<uintptr_t>(spt_entprops.GetPlayer(false));
+	auto clientPlayer = utils::spt_clientEntList.GetPlayer();
 	if (clientPlayer && clientOffset != utils::INVALID_DATAMAP_OFFSET)
-		return reinterpret_cast<void**>(clientPlayer + clientOffset);
+		return reinterpret_cast<void**>(reinterpret_cast<uint32_t>(clientPlayer) + clientOffset);
 	else
 		return nullptr;
 }

--- a/spt/features/ent_props.hpp
+++ b/spt/features/ent_props.hpp
@@ -136,11 +136,10 @@ namespace utils
 
 	/*
 	* A small wrapper of spt_entprops.GetFieldOffset() that caches the offset.
-	* Always asserts that the field exists. Optionally, calls Error() if it does not.
-	* additionalOffset can be used when the exact field you're looking for does not exist;
+	* AdditionalOffset can be used when the exact field you're looking for does not exist;
 	* you can instead reference a nearby field and add an offset from that in bytes.
 	*/
-	template<typename T, _tstring map, _tstring field, bool server, bool error = false, int additionalOffset = 0>
+	template<typename T, _tstring map, _tstring field, bool server, int additionalOffset = 0>
 	struct CachedField
 	{
 		int _off = INVALID_DATAMAP_OFFSET;
@@ -150,24 +149,7 @@ namespace utils
 			if (_off != INVALID_DATAMAP_OFFSET)
 				return _off + additionalOffset;
 			_off = spt_entprops.GetFieldOffset(map.val, field.val, server);
-			if (_off == INVALID_DATAMAP_OFFSET)
-			{
-				char errStr[256];
-				snprintf(errStr,
-				         sizeof(errStr),
-				         "spt: %s::%s (%s) does not exist",
-				         map.val,
-				         field.val,
-				         (server) ? "server" : "client");
-				AssertMsg1(0, "%s", errStr);
-				if (error)
-					Error("%s", errStr);
-				return INVALID_DATAMAP_OFFSET;
-			}
-			else
-			{
-				return _off + additionalOffset;
-			}
+			return _off == INVALID_DATAMAP_OFFSET ? INVALID_DATAMAP_OFFSET : _off + additionalOffset;
 		}
 
 		bool Exists()
@@ -182,7 +164,6 @@ namespace utils
 			return reinterpret_cast<T*>(reinterpret_cast<uint32_t>(ent) + _off + additionalOffset);
 		}
 
-		template<typename = std::enable_if_t<!error>>
 		T& GetValueOrDefault(const void* ent, T def = T{})
 		{
 			T* ptr = GetPtr(ent);
@@ -196,7 +177,6 @@ namespace utils
 			return GetPtr(utils::spt_clientEntList.GetPlayer());
 		}
 
-		template<typename = std::enable_if_t<!error>>
 		T& GetValueOrDefaultPlayer(T def = T{})
 		{
 			T* ptr = GetPtrPlayer();

--- a/spt/features/game_fixes/visual_fixes.cpp
+++ b/spt/features/game_fixes/visual_fixes.cpp
@@ -5,6 +5,7 @@
 #include "ent_utils.hpp"
 #include "signals.hpp"
 #include "..\visualizations\imgui\imgui_interface.hpp"
+#include "spt\utils\ent_list.hpp"
 
 typedef void(__cdecl* _DoImageSpaceMotionBlur)(void* view, int x, int y, int w, int h);
 typedef void(__fastcall* _CViewEffects__Fade)(void* thisptr, int edx, void* data);
@@ -291,7 +292,7 @@ void __cdecl VisualFixes::HOOKED_ResetToneMapping(float value)
 #ifndef OE
 void __fastcall VisualFixes::HOOKED_C_BaseAnimating__SetSequence(void* thisptr, int edx, int nSequence)
 {
-	if (nSequence == 0 && thisptr == utils::GetPlayer()) // t-pose player
+	if (nSequence == 0 && thisptr == utils::spt_clientEntList.GetPlayer()) // t-pose player
 		nSequence = y_spt_override_tpose.GetInt();
 	spt_visual_fixes.ORIG_C_BaseAnimating__SetSequence(thisptr, edx, nSequence);
 }

--- a/spt/features/generic.cpp
+++ b/spt/features/generic.cpp
@@ -302,7 +302,7 @@ void __fastcall GenericFeature::HOOKED_ControllerMove(void* thisptr, int edx, fl
 
 	spt_tas.Strafe();
 
-	if (utils::playerEntityAvailable())
+	if (utils::spt_clientEntList.GetPlayer())
 	{
 		OngroundSignal(spt_playerio.IsGroundEntitySet());
 		AdjustAngles();

--- a/spt/features/hops_hud.cpp
+++ b/spt/features/hops_hud.cpp
@@ -860,14 +860,13 @@ void HopsHud::CalculateAbhVel()
 {
 	auto vel = spt_playerio.GetPlayerVelocity().Length2D();
 	auto ducked = spt_playerio.m_fFlags.GetValue() & FL_DUCKING;
-	auto sprinting = spt_propertyGetter.GetProperty<bool>(0, "m_fIsSprinting");
 	auto vars = spt_playerio.GetMovementVars();
 
 	float modifier;
 
 	if (ducked)
 		modifier = 0.1;
-	else if (sprinting)
+	else if (spt_propertyGetter.GetProperty<bool>(1, "m_fIsSprinting"))
 		modifier = 0.5;
 	else
 		modifier = 1;

--- a/spt/features/ihud.cpp
+++ b/spt/features/ihud.cpp
@@ -845,7 +845,7 @@ void InputHud::DrawInputHud()
 			// Movement
 			Vector movement = inputMovement;
 			int movementSpeed = movement.Length();
-			float maxSpeed = spt_propertyGetter.GetProperty<float>(0, "m_flMaxspeed");
+			float maxSpeed = spt_propertyGetter.GetProperty<float>(1, "m_flMaxspeed");
 			movement /= movementSpeed > maxSpeed ? movementSpeed : maxSpeed;
 
 			// Draw

--- a/spt/features/ipc-spt.cpp
+++ b/spt/features/ipc-spt.cpp
@@ -210,7 +210,7 @@ CON_COMMAND(y_spt_ipc_ent, "Outputs entity data to IPC client.\n")
 	nlohmann::json msg;
 	msg["type"] = "ent";
 	int index = std::atoi(args.Arg(1));
-	auto ent = utils::GetClientEntity(index);
+	auto ent = utils::spt_clientEntList.GetEnt(index);
 
 	if (!ent)
 	{
@@ -243,7 +243,7 @@ CON_COMMAND(y_spt_ipc_properties, "Outputs entity properties to IPC client.\n")
 	nlohmann::json msg;
 	msg["type"] = "ent";
 	int index = std::atoi(args.Arg(1));
-	auto ent = utils::GetClientEntity(index);
+	auto ent = utils::spt_clientEntList.GetEnt(index);
 
 	if (!ent)
 	{

--- a/spt/features/overlay.hpp
+++ b/spt/features/overlay.hpp
@@ -16,6 +16,8 @@ enum SkyboxVisibility_t;
 #include "view_shared.h"
 #endif
 
+#include "spt\utils\ent_list.hpp"
+
 // Overlay hook stuff, could combine with overlay renderer as well
 class Overlay : public FeatureWrapper<Overlay>
 {
@@ -37,6 +39,8 @@ public:
 	                   void*,
 	                   CViewSetup* cameraView,
 	                   bool drawViewmodel);
+
+	const utils::PortalInfo* GetOverlayPortal();
 
 protected:
 	virtual void InitHooks() override;

--- a/spt/features/pause.cpp
+++ b/spt/features/pause.cpp
@@ -4,10 +4,9 @@
 #include "convar.hpp"
 #include "signals.hpp"
 #include "visualizations\imgui\imgui_interface.hpp"
+#include "tas.hpp"
 
 ConVar y_spt_pause("y_spt_pause", "0", FCVAR_ARCHIVE);
-
-extern ConVar tas_pause;
 
 // spt_pause stuff
 class PauseFeature : public FeatureWrapper<PauseFeature>

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -48,14 +48,6 @@ ConVar y_spt_hud_vars("y_spt_hud_vars", "0", FCVAR_CHEAT, "Turns on the movement
 ConVar y_spt_hud_velocity("y_spt_hud_velocity", "0", FCVAR_CHEAT, "Turns on the velocity hud.");
 ConVar y_spt_hud_velocity_angles("y_spt_hud_velocity_angles", "0", FCVAR_CHEAT, "Display velocity Euler angles.");
 
-extern ConVar tas_force_airaccelerate;
-extern ConVar tas_force_onground;
-extern ConVar tas_force_wishspeed_cap;
-extern ConVar tas_reset_surface_friction;
-extern ConVar tas_strafe_jumptype;
-extern ConVar tas_strafe_use_tracing;
-extern ConVar tas_strafe_version;
-
 namespace patterns
 {
 	PATTERNS(

--- a/spt/features/playerio.hpp
+++ b/spt/features/playerio.hpp
@@ -35,7 +35,7 @@ public:
 	bool GetFlagsDucking();
 	Strafe::PlayerData GetPlayerData();
 	Vector GetPlayerVelocity();
-	Vector GetPlayerEyePos();
+	Vector GetPlayerEyePos(bool newVersion);
 	double GetDuckJumpTime();
 	bool IsGroundEntitySet();
 	bool TryJump();

--- a/spt/features/portalled_pause.cpp
+++ b/spt/features/portalled_pause.cpp
@@ -7,6 +7,7 @@
 #include "afterticks.hpp"
 #include "ent_utils.hpp"
 #include "game_detection.hpp"
+#include "spt\utils\ent_list.hpp"
 
 ConVar spt_on_portalled_pause_for("spt_on_portalled_pause_for",
                                   "0",
@@ -65,7 +66,7 @@ IMPL_HOOK_THISCALL(PortalledPause, void, TeleportTouchingEntity, void*, void* pO
 {
 	spt_portalled_pause_feat.ORIG_TeleportTouchingEntity(thisptr, pOther);
 
-	if (pOther != utils::GetServerPlayer())
+	if (pOther != utils::spt_serverEntList.GetPlayer())
 		return;
 
 	const auto pauseFor = spt_on_portalled_pause_for.GetInt();

--- a/spt/features/property_getter.cpp
+++ b/spt/features/property_getter.cpp
@@ -1,8 +1,10 @@
 #include "stdafx.hpp"
 
-#include "property_getter.hpp"
 #include <vector>
+
+#include "property_getter.hpp"
 #include "ent_utils.hpp"
+#include "spt\utils\ent_list.hpp"
 
 PropMap PropertyGetterFeature::FindOffsets(IClientEntity* ent)
 {
@@ -42,7 +44,7 @@ int PropertyGetterFeature::GetOffset(int entindex, const std::string& key)
 
 RecvProp* PropertyGetterFeature::GetRecvProp(int entindex, const std::string& key)
 {
-	auto ent = utils::GetClientEntity(entindex);
+	auto ent = utils::spt_clientEntList.GetEnt(entindex);
 	std::string className = ent->GetClientClass()->m_pNetworkName;
 
 	if (classToOffsetsMap.find(className) == classToOffsetsMap.end())

--- a/spt/features/property_getter.hpp
+++ b/spt/features/property_getter.hpp
@@ -10,6 +10,7 @@
 #include "icliententity.h"
 #include "icliententitylist.h"
 #include "ent_utils.hpp"
+#include "spt\utils\ent_list.hpp"
 
 #define INVALID_OFFSET -1
 
@@ -37,7 +38,7 @@ public:
 	template<typename T>
 	T GetProperty(int entindex, const std::string& key)
 	{
-		auto ent = utils::GetClientEntity(entindex);
+		auto ent = utils::spt_clientEntList.GetEnt(entindex);
 
 		if (!ent)
 			return T();

--- a/spt/features/shadow.cpp
+++ b/spt/features/shadow.cpp
@@ -158,7 +158,7 @@ void ShadowPosition::SetPlayerHavokPos(const Vector& worldPosition, const QAngle
 IPhysicsPlayerController* ShadowPosition::GetPlayerController()
 {
 	constexpr int fOff = -3 * (int)sizeof(void*);
-	static utils::CachedField<IPhysicsPlayerController*, "CBasePlayer", "m_oldOrigin", true, true, fOff> fCont;
+	static utils::CachedField<IPhysicsPlayerController*, "CBasePlayer", "m_oldOrigin", true, fOff> fCont;
 	auto ppController = fCont.GetPtrPlayer();
 	return ppController ? *ppController : nullptr;
 }

--- a/spt/features/tas.cpp
+++ b/spt/features/tas.cpp
@@ -100,7 +100,7 @@ ConVar tas_force_onground(
     FCVAR_TAS_RESET,
     "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 ConVar tas_strafe_version("tas_strafe_version",
-                          "7",
+                          "8",
                           FCVAR_TAS_RESET,
                           "Strafe version. For backwards compatibility with old scripts.");
 

--- a/spt/features/tas.cpp
+++ b/spt/features/tas.cpp
@@ -140,8 +140,6 @@ ConVar tas_script_savestates("tas_script_savestates", "1", 0, "Enables/disables 
 ConVar tas_script_onsuccess("tas_script_onsuccess", "", 0, "Commands to be executed when a search concludes.\n");
 ConVar y_spt_hud_script_progress("y_spt_hud_script_progress", "0", FCVAR_CHEAT, "Turns on the script progress hud.\n");
 
-extern ConVar tas_anglespeed;
-
 TASFeature spt_tas;
 
 bool TASFeature::ShouldLoadFeature()

--- a/spt/features/tas.hpp
+++ b/spt/features/tas.hpp
@@ -1,6 +1,44 @@
 #pragma once
 #include "..\feature.hpp"
 
+extern ConVar tas_strafe;
+extern ConVar tas_strafe_type;
+extern ConVar tas_strafe_dir;
+extern ConVar tas_strafe_scale;
+extern ConVar tas_strafe_yaw;
+extern ConVar tas_strafe_buttons;
+extern ConVar tas_strafe_vectorial;
+extern ConVar tas_strafe_vectorial_increment;
+extern ConVar tas_strafe_vectorial_offset;
+extern ConVar tas_strafe_vectorial_snap;
+extern ConVar tas_strafe_allow_jump_override;
+extern ConVar tas_strafe_capped_limit;
+extern ConVar tas_strafe_hull_is_line;
+extern ConVar tas_strafe_use_tracing;
+extern ConVar tas_force_airaccelerate;
+extern ConVar tas_force_wishspeed_cap;
+extern ConVar tas_reset_surface_friction;
+extern ConVar tas_force_onground;
+extern ConVar tas_strafe_version;
+extern ConVar tas_strafe_afh_length;
+extern ConVar tas_strafe_afh;
+extern ConVar tas_strafe_lgagst;
+extern ConVar tas_strafe_lgagst_minspeed;
+extern ConVar tas_strafe_lgagst_fullmaxspeed;
+extern ConVar tas_strafe_lgagst_min;
+extern ConVar tas_strafe_lgagst_max;
+extern ConVar tas_strafe_jumptype;
+extern ConVar tas_strafe_autojb;
+extern ConVar tas_script_printvars;
+extern ConVar tas_script_savestates;
+extern ConVar tas_script_onsuccess;
+extern ConVar y_spt_hud_script_progress;
+
+// these live in other cpp files
+extern ConVar tas_anglespeed;
+extern ConVar tas_pause;
+extern ConVar tas_log;
+
 // Enables TAS strafing and view related functionality
 class TASFeature : public FeatureWrapper<TASFeature>
 {

--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -13,6 +13,7 @@
 #include "portal_utils.hpp"
 #include "ent_props.hpp"
 #include "visualizations/imgui/imgui_interface.hpp"
+#include "spt\utils\ent_list.hpp"
 
 #include "model_types.h"
 
@@ -167,7 +168,7 @@ void Tracing::TracePlayerBBoxForGround(const Vector& start,
 		                               end,
 		                               mins,
 		                               maxs,
-		                               utils::GetServerPlayer(),
+		                               utils::spt_serverEntList.GetPlayer(),
 		                               fMask,
 		                               collisionGroup,
 		                               pm);
@@ -196,7 +197,7 @@ void Tracing::TracePlayerBBoxForGround(const Vector& start,
 		                               end,
 		                               mins,
 		                               maxs,
-		                               utils::GetServerPlayer(),
+		                               utils::spt_serverEntList.GetPlayer(),
 		                               fMask,
 		                               collisionGroup,
 		                               pm);
@@ -207,7 +208,7 @@ void Tracing::TracePlayerBBoxForGround(const Vector& start,
 		                              end,
 		                              mins,
 		                              maxs,
-		                              utils::GetServerPlayer(),
+		                              utils::spt_serverEntList.GetPlayer(),
 		                              fMask,
 		                              collisionGroup,
 		                              pm);
@@ -291,7 +292,7 @@ IMPL_HOOK_FASTCALL(Tracing,
 
 CBaseCombatWeapon* Tracing::GetActiveWeapon()
 {
-	auto player = utils::GetServerPlayer();
+	auto player = utils::spt_serverEntList.GetPlayer();
 	if (!player)
 		return nullptr;
 
@@ -347,11 +348,8 @@ float Tracing::TraceTransformFirePortal(trace_t& tr,
 	Vector transformedPos = startPos;
 	QAngle transformedAngles = startAngles;
 	Vector vDirection;
-	IClientEntity* env = GetEnvironmentPortal();
-	if (env)
-	{
-		transformThroughPortal(env, startPos, startAngles, transformedPos, transformedAngles);
-	}
+	const utils::PortalInfo* env = utils::GetEnvironmentPortal();
+	transformThroughPortal(env, startPos, startAngles, transformedPos, transformedAngles);
 	AngleVectors(transformedAngles, &vDirection);
 
 	const int PORTAL_PLACED_BY_PLAYER = 2;
@@ -540,7 +538,7 @@ static const char find_seam_shot_help[] =
 
 CON_COMMAND(y_spt_find_seam_shot, find_seam_shot_help)
 {
-	auto player = utils::GetServerPlayer();
+	auto player = utils::spt_serverEntList.GetPlayer() ;
 	if (!player)
 	{
 		Msg("Cannot find server player.\n");

--- a/spt/features/tracing.hpp
+++ b/spt/features/tracing.hpp
@@ -27,6 +27,8 @@ class ITraceFilter;
 #include "SDK\cmodel_private.h"
 #pragma pop_macro("ENGINE_DLL")
 
+#include "spt\utils\ent_list.hpp"
+
 // for TraceLineWithWorldInfoServer()
 struct WorldHitInfo
 {
@@ -45,12 +47,11 @@ struct WorldHitInfo
 	}
 };
 
-template<bool server>
 struct TraceFilterIgnorePlayer : public CTraceFilter
 {
 	virtual bool ShouldHitEntity(IHandleEntity* pEntity, int contentsMask) override
 	{
-		return pEntity != spt_entprops.GetPlayer(server);
+		return pEntity->GetRefEHandle().GetEntryIndex() != 1;
 	}
 };
 

--- a/spt/features/visualizations/draw_ent_collides.cpp
+++ b/spt/features/visualizations/draw_ent_collides.cpp
@@ -82,10 +82,10 @@ private:
 
 	struct
 	{
-		utils::CachedField<matrix3x4_t, "CBaseEntity", "m_rgflCoordinateFrame", true, true> coordFrame;
-		utils::CachedField<int, "CBaseEntity", "m_CollisionGroup", true, true> collisionGroup;
-		utils::CachedField<ushort, "CBaseEntity", "m_Collision.m_usSolidFlags", true, true> solidFlags;
-		utils::CachedField<string_t, "CBaseEntity", "m_iClassname", true, true> className;
+		utils::CachedField<matrix3x4_t, "CBaseEntity", "m_rgflCoordinateFrame", true> coordFrame;
+		utils::CachedField<int, "CBaseEntity", "m_CollisionGroup", true> collisionGroup;
+		utils::CachedField<ushort, "CBaseEntity", "m_Collision.m_usSolidFlags", true> solidFlags;
+		utils::CachedField<string_t, "CBaseEntity", "m_iClassname", true> className;
 	} entFields;
 
 	int lastUpdateTick = -1;

--- a/spt/features/visualizations/draw_seams.cpp
+++ b/spt/features/visualizations/draw_seams.cpp
@@ -166,7 +166,7 @@ void DrawSeamsFeature::OnMeshRenderSignal(MeshRendererDelegate& mr)
 		return;
 
 	Vector cameraPosition = utils::GetPlayerEyePosition();
-	static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true, true> vangle;
+	static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true> vangle;
 	QAngle angles = *vangle.GetPtrPlayer();
 
 	auto env = utils::GetEnvironmentPortal();

--- a/spt/features/visualizations/draw_seams.cpp
+++ b/spt/features/visualizations/draw_seams.cpp
@@ -161,7 +161,7 @@ void DrawSeamsFeature::OnMeshRenderSignal(MeshRendererDelegate& mr)
 {
 	if (!y_spt_draw_seams.GetBool())
 		return;
-	auto player = utils::GetServerPlayer();
+	auto player = utils::spt_serverEntList.GetPlayer();
 	if (!player)
 		return;
 
@@ -169,9 +169,8 @@ void DrawSeamsFeature::OnMeshRenderSignal(MeshRendererDelegate& mr)
 	static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true, true> vangle;
 	QAngle angles = *vangle.GetPtrPlayer();
 
-	auto env = GetEnvironmentPortal();
-	if (env)
-		transformThroughPortal(env, cameraPosition, angles, cameraPosition, angles);
+	auto env = utils::GetEnvironmentPortal();
+	transformThroughPortal(env, cameraPosition, angles, cameraPosition, angles);
 
 	Vector dir;
 	AngleVectors(angles, &dir);

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -142,17 +142,15 @@ private:
 		static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true, true> vangle;
 		QAngle eyeAng = tas_pause.GetBool() ? utils::GetPlayerEyeAngles() : *vangle.GetPtrPlayer();
 
-		// this transform may be slightly off since it uses client-side ents
-		auto env = GetEnvironmentPortal();
-		if (env)
-			transformThroughPortal(env, eyePos, eyeAng, eyePos, eyeAng);
+		auto env = utils::GetEnvironmentPortal();
+		transformThroughPortal(env, eyePos, eyeAng, eyePos, eyeAng);
 		Vector dir;
 		AngleVectors(eyeAng, &dir);
 
 		Ray_t ray;
 		ray.Init(eyePos, eyePos + dir * MAX_TRACE_LENGTH);
 
-		TraceFilterIgnorePlayer<true> filter{};
+		TraceFilterIgnorePlayer filter{};
 		trace_t tr;
 
 		int fMask = strtol(spt_draw_world_collides_mask.GetString(), nullptr, 0);
@@ -188,8 +186,7 @@ private:
 			    {
 				    Vector clientEyes = *v1.GetPtrPlayer() + *v2.GetPtrPlayer();
 				    QAngle qa;
-				    if (env)
-					    transformThroughPortal(env, clientEyes, qa, clientEyes, qa);
+				    transformThroughPortal(env, clientEyes, qa, clientEyes, qa);
 				    Vector diff = clientEyes - infoIn.cvs.origin;
 				    if (fabsf(diff.x) < 0.01 && fabsf(diff.y) < 0.01 && fabsf(diff.z) < 32)
 					    infoOut.skipRender = true;

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -139,7 +139,7 @@ private:
 	{
 		// this does not work when we're in a vehicle, we'd want to use a modified version of CBasePlayer::CalcView
 		Vector eyePos = utils::GetPlayerEyePosition();
-		static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true, true> vangle;
+		static utils::CachedField<QAngle, "CBasePlayer", "pl.v_angle", true> vangle;
 		QAngle eyeAng = tas_pause.GetBool() ? utils::GetPlayerEyeAngles() : *vangle.GetPtrPlayer();
 
 		auto env = utils::GetEnvironmentPortal();
@@ -179,8 +179,8 @@ private:
 			    // that's good enough. This does not work that well through portals or in vehicles, but it does
 			    // take care of stepping up/down which was the main annoyance I had.
 
-			    utils::CachedField<Vector, "CBasePlayer", "m_vecAbsOrigin", false, false> v1;
-			    utils::CachedField<Vector, "CBasePlayer", "m_vecViewOffset", false, false> v2;
+			    static utils::CachedField<Vector, "CBasePlayer", "m_vecAbsOrigin", false> v1;
+			    static utils::CachedField<Vector, "CBasePlayer", "m_vecViewOffset", false> v2;
 
 			    if (v1.Exists() && v2.Exists())
 			    {

--- a/spt/features/visualizations/draw_world_collides.cpp
+++ b/spt/features/visualizations/draw_world_collides.cpp
@@ -9,6 +9,7 @@
 #include "spt\features\tracing.hpp"
 #include "spt\features\generic.hpp"
 #include "spt\features\create_collide.hpp"
+#include "spt\features\tas.hpp"
 #include "renderer\mesh_renderer.hpp"
 #include "imgui\imgui_interface.hpp"
 
@@ -23,8 +24,6 @@ ConVar spt_draw_world_collides(
     "    - purple: complex (i.e. non-box) brush\n"
     "    - white: displacement\n"
     "    - red: static prop");
-
-extern ConVar tas_pause;
 
 // this hidden cvar can be used to change the mask
 const std::string _g_default_mask_str = std::to_string(MASK_PLAYERSOLID | MASK_VISIBLE);

--- a/spt/features/visualizations/oob_ents.cpp
+++ b/spt/features/visualizations/oob_ents.cpp
@@ -120,9 +120,9 @@ void HudOobEntsFeature::OnTickSignal(bool simulating)
 			continue;
 		CBaseEntity* ent = ed->GetIServerEntity()->GetBaseEntity();
 
-		static CachedField<string_t, "CBaseEntity", "m_iName", true, true> nf;
-		static CachedField<string_t, "CBaseEntity", "m_iClassname", true, true> cnf;
-		static CachedField<string_t, "CBaseEntity", "m_iGlobalname", true, true> gnf;
+		static CachedField<string_t, "CBaseEntity", "m_iName", true> nf;
+		static CachedField<string_t, "CBaseEntity", "m_iClassname", true> cnf;
+		static CachedField<string_t, "CBaseEntity", "m_iGlobalname", true> gnf;
 		const char* name = nf.GetPtr(ent)->ToCStr();
 		const char* className = cnf.GetPtr(ent)->ToCStr();
 		const char* globalName = gnf.GetPtr(ent)->ToCStr();
@@ -152,8 +152,8 @@ void HudOobEntsFeature::OnTickSignal(bool simulating)
 		}
 
 		// m_Collision is not in datamap, use field before it
-		static CachedField<CCollisionProperty, "CBaseEntity", "m_hMovePeer", true, true, sizeof EHANDLE> cf;
-		static CachedField<QAngle, "CBaseEntity", "m_angAbsRotation", true, true> rotField;
+		static CachedField<CCollisionProperty, "CBaseEntity", "m_hMovePeer", true, sizeof EHANDLE> cf;
+		static CachedField<QAngle, "CBaseEntity", "m_angAbsRotation", true> rotField;
 		const CCollisionProperty* colProp = cf.GetPtr(ent);
 		// arbitary decision: we don't care about things being oob that aren't solid according to this function
 		if (!colProp->IsSolid())

--- a/spt/features/visualizations/portal_placement.cpp
+++ b/spt/features/visualizations/portal_placement.cpp
@@ -219,15 +219,14 @@ CON_COMMAND_F(
 	grid.camPos = utils::GetPlayerEyePosition();
 	grid.gridAngDiameter = clamp(y_spt_draw_pp_grid_fov.GetFloat(), 0.1, 179.9);
 	grid.camAng = utils::GetPlayerEyeAngles();
-	IClientEntity* env = GetEnvironmentPortal();
-	if (env)
-		transformThroughPortal(env, grid.camPos, grid.camAng, grid.camPos, grid.camAng);
+	const utils::PortalInfo* env = utils::GetEnvironmentPortal();
+	transformThroughPortal(env, grid.camPos, grid.camAng, grid.camPos, grid.camAng);
 	grid.mapName = interfaces::engine_tool->GetCurrentMap();
 }
 
 void PortalPlacement::UpdatePlacementInfo()
 {
-	auto player = utils::GetServerPlayer();
+	auto player = utils::spt_serverEntList.GetPlayer();
 	if (!player)
 	{
 		p1.placementResult = PORTAL_PLACEMENT_FAIL_NO_SERVER;
@@ -764,7 +763,7 @@ void PortalPlacement::ImGuiGridPlacementCallback()
 	ImGui::SetItemTooltip("%s 0", wrangledName);
 	ImGui::SameLine();
 
-	auto player = utils::GetServerPlayer();
+	auto player = utils::spt_serverEntList.GetPlayer();
 	bool disabled = !player || !spt_tracing.ORIG_GetActiveWeapon(player);
 	ImGui::BeginDisabled(disabled);
 

--- a/spt/features/visualizations/sg-collide-vis.cpp
+++ b/spt/features/visualizations/sg-collide-vis.cpp
@@ -13,6 +13,7 @@
 #include "spt\feature.hpp"
 #include "spt\utils\game_detection.hpp"
 #include "spt\utils\signals.hpp"
+#include "spt\utils\portal_utils.hpp"
 #include "spt\features\ent_props.hpp"
 #include "spt\features\create_collide.hpp"
 
@@ -31,11 +32,8 @@ ConVar y_spt_draw_portal_env_type(
     "y_spt_draw_portal_env_type",
     "auto",
     FCVAR_CHEAT | FCVAR_DONTRECORD,
-    "This determines what portal to use for all spt_draw_portal_* cvars. Accepts the following values:\n"
-    "   - collide: draw what the player has collision with\n"
-    "   - auto: prioritize what the player has collision with, otherwise use last drawn portal index\n"
-    "   - blue/orange: look for specific portal color\n"
-    "   - <index>: specify portal entity index");
+    "This determines what portal to use for all spt_draw_portal_* cvars. Valid values are:\n"
+    "" SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION);
 
 ConVar y_spt_draw_portal_env_ents(
     "y_spt_draw_portal_env_ents",
@@ -104,33 +102,6 @@ class SgCollideVisFeature : public FeatureWrapper<SgCollideVisFeature>
 public:
 	static SgCollideVisFeature featureInstance;
 
-	struct
-	{
-		int pos;
-		int ang;
-		int isOrange;
-		int isActivated;
-		int linked;
-		int simulator;
-		int m_Collision;
-	} portalFieldOffs;
-
-	PlayerField<int> envPortalField;
-
-	struct PortalInfo
-	{
-		Vector pos;
-		QAngle ang;
-		CBaseHandle linked;
-		bool isOrange, isActivated, isOpen;
-	};
-
-	struct
-	{
-		bool collide, auto_, blue, orange, idx;
-		int idxVal;
-	} userWishes;
-
 	struct MeshCache
 	{
 		struct CachedRemoteGeo
@@ -160,9 +131,7 @@ public:
 		std::vector<CachedRemoteGeo> remoteWorld;
 		std::array<CachedEnt, MAX_EDICTS> ents{};
 
-		CBaseHandle lastPortal{INVALID_EHANDLE_INDEX};
-		PortalInfo lastPortalInfo{vec3_invalid};
-		PortalInfo lastLinkedInfo{vec3_invalid};
+		utils::PortalInfo lastPortal;
 
 		void Clear()
 		{
@@ -171,9 +140,7 @@ public:
 			remoteWorld.clear();
 			for (auto& cachedEnt : ents)
 				cachedEnt.Clear();
-			lastPortal.Term();
-			lastPortalInfo.pos = vec3_invalid;
-			lastLinkedInfo.pos = vec3_invalid;
+			lastPortal.Invalidate();
 		}
 	} cache;
 
@@ -187,52 +154,11 @@ public:
 		if (!spt_meshRenderer.signal.Works)
 			return;
 
-		// cache all field stuff & check that spt_entprops works
-		portalFieldOffs.pos = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_vecAbsOrigin", true);
-		portalFieldOffs.ang = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_angAbsRotation", true);
-		portalFieldOffs.isOrange = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_bIsPortal2", true);
-		portalFieldOffs.linked = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_hLinkedPortal", true);
-		portalFieldOffs.isActivated = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_bActivated", true);
-		portalFieldOffs.simulator = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_vPortalCorners", true);
-		portalFieldOffs.m_Collision = spt_entprops.GetFieldOffset(PORTAL_CLASS, "m_hMovePeer", true);
-
-		for (int i = 0; i < sizeof(portalFieldOffs) / sizeof(int); i++)
-			if (reinterpret_cast<int*>(&portalFieldOffs)[i] == utils::INVALID_DATAMAP_OFFSET)
-				return;
-		envPortalField = spt_entprops.GetPlayerField<int>("m_hPortalEnvironment", PropMode::Server);
-		if (!envPortalField.ServerOffsetFound())
-			return;
-
-		portalFieldOffs.simulator += sizeof(Vector) * 4;
-		portalFieldOffs.m_Collision += sizeof(EHANDLE);
-
 		spt_meshRenderer.signal.Connect(this, &SgCollideVisFeature::OnMeshRenderSignal);
 		InitConcommandBase(y_spt_draw_portal_env);
 		InitConcommandBase(y_spt_draw_portal_env_type);
 		InitConcommandBase(y_spt_draw_portal_env_ents);
 		InitConcommandBase(y_spt_draw_portal_env_remote);
-
-		y_spt_draw_portal_env_type.InstallChangeCallback(
-		    [](IConVar* var, const char*, float)
-		    {
-			    auto& wish = featureInstance.userWishes;
-			    const char* typeStr = ((ConVar*)var)->GetString();
-			    wish.collide = !_stricmp(typeStr, "collide");
-			    wish.auto_ = !_stricmp(typeStr, "auto");
-			    wish.blue = !_stricmp(typeStr, "blue") || wish.auto_;
-			    wish.orange = !_stricmp(typeStr, "orange") || wish.auto_;
-			    if (!wish.collide && !wish.auto_ && !wish.blue && !wish.orange)
-			    {
-				    wish.idx = true;
-				    wish.idxVal = ((ConVar*)var)->GetInt() + 1; // client -> server index
-			    }
-			    else
-			    {
-				    wish.idx = false;
-			    }
-		    });
-		// trigger callback to initialize wish values
-		y_spt_draw_portal_env_type.SetValue(y_spt_draw_portal_env_type.GetDefault());
 	}
 
 	virtual void UnloadFeature() override
@@ -240,150 +166,29 @@ public:
 		cache.Clear();
 	}
 
-	bool GetPortalInfo(edict_t* edict, PortalInfo* outInfo) const
-	{
-		if (!edict || strcmp(edict->GetClassName(), "prop_portal"))
-			return false;
-		if (outInfo)
-		{
-			uintptr_t ent = reinterpret_cast<uintptr_t>(edict->GetIServerEntity()->GetBaseEntity());
-			outInfo->pos = *reinterpret_cast<Vector*>(ent + portalFieldOffs.pos);
-			outInfo->ang = *reinterpret_cast<QAngle*>(ent + portalFieldOffs.ang);
-			outInfo->isOrange = *reinterpret_cast<bool*>(ent + portalFieldOffs.isOrange);
-			outInfo->isActivated = *reinterpret_cast<bool*>(ent + portalFieldOffs.isActivated);
-			outInfo->linked = *reinterpret_cast<CBaseHandle*>(ent + portalFieldOffs.linked);
-			outInfo->isOpen = outInfo->linked.IsValid();
-		}
-		return true;
-	}
-
-	bool PortalMatchesUserWish(const PortalInfo& pInfo) const
-	{
-		if (userWishes.collide && pInfo.isOpen) // if collide is set, assume we're checking player portal env
-			return true;
-		if (userWishes.blue && !pInfo.isOrange)
-			return true;
-		if (userWishes.orange && pInfo.isOrange)
-			return true;
-		return false;
-	}
-
-	edict_t* GetSgDrawPortal() const
-	{
-		if (!engine_server->PEntityOfEntIndex(0)
-		    || (!y_spt_draw_portal_env.GetBool() && !y_spt_draw_portal_env_ents.GetBool()
-		        && !y_spt_draw_portal_env_remote.GetBool()))
-		{
-			return nullptr;
-		}
-
-		if (userWishes.idx)
-		{
-			edict_t* ed = engine_server->PEntityOfEntIndex(userWishes.idxVal);
-			if (GetPortalInfo(ed, nullptr))
-				return ed;
-			return nullptr;
-		}
-
-		// user doesn't want index - always prioritize player's env portal
-		int envIdx = envPortalField.GetValue();
-		if (envIdx != INVALID_EHANDLE_INDEX)
-		{
-			PortalInfo envInfo;
-			edict_t* envEd = engine_server->PEntityOfEntIndex(envIdx & INDEX_MASK);
-			if (GetPortalInfo(envEd, &envInfo) && PortalMatchesUserWish(envInfo))
-				return envEd;
-			else if (userWishes.collide)
-				return nullptr;
-		}
-		else if (userWishes.collide)
-		{
-			return nullptr;
-		}
-
-		// player env doesn't match wish, let's check the last used index
-		int lastUsedPortalIndex = cache.lastPortal.GetEntryIndex();
-		if (lastUsedPortalIndex > 0)
-		{
-			edict_t* ed = engine_server->PEntityOfEntIndex(lastUsedPortalIndex);
-			PortalInfo tmpInfo;
-			if (GetPortalInfo(ed, &tmpInfo) && PortalMatchesUserWish(tmpInfo))
-			{
-				// check if the last used index refers to a different colored portal, saveloads can mess with that
-				if (!userWishes.auto_)
-					return ed;
-				if (userWishes.auto_ && tmpInfo.isOrange == cache.lastPortalInfo.isOrange)
-					return ed;
-			}
-		}
-
-		// fine, go through all ents
-		edict_t* bestMatch = nullptr;
-		bool bestIsActivated = false;
-		bool bestIsOpen = false;
-		for (int i = 1; i < MAX_EDICTS; i++)
-		{
-			edict_t* tmpEd = engine_server->PEntityOfEntIndex(i);
-			PortalInfo tmpInfo;
-			if (GetPortalInfo(tmpEd, &tmpInfo) && PortalMatchesUserWish(tmpInfo))
-			{
-				// same color, pos, & ang? this is exactly what we want
-				if (tmpInfo.isOrange == cache.lastPortalInfo.isOrange
-				    && tmpInfo.pos == cache.lastPortalInfo.pos
-				    && tmpInfo.ang == cache.lastPortalInfo.ang)
-				{
-					return tmpEd;
-				}
-				// otherwise, prioritize open & activated portals
-				if (!bestMatch || (!bestIsActivated && tmpInfo.isActivated)
-				    || (!bestIsOpen && tmpInfo.isOpen))
-				{
-					bestMatch = tmpEd;
-					bestIsActivated = tmpInfo.isActivated;
-					bestIsOpen = tmpInfo.isOpen;
-				}
-			}
-		}
-		return bestMatch; // couldn't find the same portal as was previously used, but maybe found something else
-	}
-
 	void OnMeshRenderSignal(MeshRendererDelegate& mr)
 	{
-		edict_t* portalEd = GetSgDrawPortal();
-		if (!portalEd)
-			return;
-		CBaseHandle curPortal = portalEd->GetNetworkable()->GetEntityHandle()->GetRefEHandle();
-		CBaseEntity* portalEnt = portalEd->GetIServerEntity()->GetBaseEntity();
-		PortalInfo curInfo;
-		GetPortalInfo(portalEd, &curInfo);
+		// actually CProp_Portal::simulator
+		static utils::CachedField<char*********, "CProp_Portal", "m_vPortalCorners", true, sizeof(Vector[4])>
+		    fSimulator;
 
-		if (cache.lastPortal != curPortal || cache.lastPortalInfo.pos != curInfo.pos
-		    || cache.lastPortalInfo.ang != curInfo.ang)
+		if (!y_spt_draw_portal_env.GetBool() || !utils::spt_serverEntList.Valid() || !fSimulator.Exists())
 		{
-			// wish portal moved? clear cache
 			cache.Clear();
+			return;
 		}
-		else
+		const utils::PortalInfo* newPortal = getPortal(y_spt_draw_portal_env_type.GetString(), false, true);
+
+		if (!newPortal)
+			return;
+
+		if (cache.lastPortal != *newPortal)
 		{
-			// clear remote cache if the linked portal changed
-			PortalInfo curLinkedInfo;
-			edict_t* linkedEd = engine_server->PEntityOfEntIndex(curInfo.linked.GetEntryIndex());
-			if (!GetPortalInfo(linkedEd, &curLinkedInfo))
-				curLinkedInfo.isOpen = false;
-
-			if (!curInfo.isOpen || cache.lastLinkedInfo.pos != curLinkedInfo.pos
-			    || cache.lastLinkedInfo.ang != curLinkedInfo.ang
-			    || cache.lastLinkedInfo.isOpen != curLinkedInfo.isOpen)
-			{
-				cache.remoteWorld.clear();
-				cache.lastLinkedInfo = curLinkedInfo;
-			}
+			cache.Clear();
+			cache.lastPortal = *newPortal;
 		}
-		cache.lastPortal = curPortal;
-		cache.lastPortalInfo = curInfo;
 
-		// collision simulator
-		uintptr_t sim = (uintptr_t)portalEnt + portalFieldOffs.simulator;
+		uintptr_t sim = (uintptr_t)newPortal->pEnt + fSimulator.Get();
 
 		// draw portal hole when showing anything
 		if (y_spt_draw_portal_env.GetBool() || y_spt_draw_portal_env_remote.GetBool()
@@ -479,7 +284,7 @@ public:
 
 	void DrawPortalEntities(MeshRendererDelegate& mr, uintptr_t sim)
 	{
-		if (!cache.lastPortalInfo.isOpen)
+		if (!cache.lastPortal.isOpen)
 			return; // the sim's vectors are valid but empty and there's no point in drawing the trace test ents
 
 		// we'll go through each ent and give it flags, then draw at the end
@@ -507,12 +312,16 @@ public:
 		* behavior for entities on the portal plane, but we gotta replicate it to show what we collide with.
 		*/
 
-		Vector portalPos = cache.lastPortalInfo.pos;
+		Vector portalPos = cache.lastPortal.pos;
 		Vector portalNorm;
-		AngleVectors(cache.lastPortalInfo.ang, &portalNorm);
+		AngleVectors(cache.lastPortal.ang, &portalNorm);
 		Vector pt1007 = portalPos + portalNorm * 1007;
 
 		VPlane testPlane{portalNorm, portalNorm.Dot(portalPos + portalNorm * 7)};
+
+		// actually CBaseEntity::m_Collision
+		static utils::CachedField<CCollisionProperty, "CProp_Portal", "m_hMovePeer", true, sizeof(EHANDLE)>
+		    fCollision;
 
 		for (int i = 1; i < MAX_EDICTS; i++)
 		{
@@ -520,7 +329,10 @@ public:
 			if (!ed || !ed->GetIServerEntity())
 				continue;
 			IServerEntity* pEnt = ed->GetIServerEntity();
-			auto pCp = (CCollisionProperty*)((uint32_t)pEnt + portalFieldOffs.m_Collision);
+
+			auto pCp = fCollision.GetPtr(pEnt);
+			if (!pCp)
+				continue;
 			bool collisionSolid = pCp->IsSolid();
 
 			// optimization - if the bounding sphere doesn't intersect the plane then don't check the OBB

--- a/spt/scripts/condition.cpp
+++ b/spt/scripts/condition.cpp
@@ -47,13 +47,13 @@ namespace scripts
 
 	bool PosSpeedCondition::IsTrue(int tick, int totalTicks) const
 	{
-		if (!utils::playerEntityAvailable())
+		if (!utils::spt_clientEntList.GetPlayer())
 			return false;
 
 		Vector v;
 
 		if (isPos)
-			v = spt_playerio.GetPlayerEyePos();
+			v = spt_playerio.GetPlayerEyePos(true);
 		else
 			v = spt_playerio.GetPlayerVelocity();
 
@@ -104,19 +104,20 @@ namespace scripts
 
 	bool AliveCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return !utils::playerEntityAvailable() || spt_propertyGetter.GetProperty<int>(0, "m_iHealth") > 0;
+		return !utils::spt_clientEntList.GetPlayer() || spt_propertyGetter.GetProperty<int>(1, "m_iHealth") > 0;
 	}
 
 	bool AliveCondition::ShouldTerminate(int tick, int totalTicks) const
 	{
-		return utils::playerEntityAvailable() && spt_propertyGetter.GetProperty<int>(0, "m_iHealth") <= 0;
+		return utils::spt_clientEntList.GetPlayer()
+		       && spt_propertyGetter.GetProperty<int>(1, "m_iHealth") <= 0;
 	}
 
 	LoadCondition::LoadCondition() {}
 
 	bool LoadCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return !utils::playerEntityAvailable();
+		return !utils::spt_clientEntList.GetPlayer();
 	}
 
 	bool LoadCondition::ShouldTerminate(int tick, int totalTicks) const
@@ -132,7 +133,7 @@ namespace scripts
 
 	bool VelAngleCondition::IsTrue(int tick, int totalTicks) const
 	{
-		if (!utils::playerEntityAvailable())
+		if (!utils::spt_clientEntList.GetPlayer())
 			return false;
 
 		Vector v = spt_playerio.GetPlayerVelocity();
@@ -158,7 +159,7 @@ namespace scripts
 
 	bool PBubbleCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return (GetEnvironmentPortal() == NULL) ^ searchForInBubble;
+		return !utils::GetEnvironmentPortal() ^ searchForInBubble;
 	}
 
 	bool PBubbleCondition::ShouldTerminate(int tick, int totalTicks) const

--- a/spt/scripts/parsed_script.cpp
+++ b/spt/scripts/parsed_script.cpp
@@ -3,10 +3,9 @@
 #include "..\spt-serverplugin.hpp"
 #include "file.hpp"
 #include "..\features\demo.hpp"
+#include "..\features\tas.hpp"
 #include "framebulk_handler.hpp"
 #include "thirdparty\md5.hpp"
-
-extern ConVar tas_script_savestates;
 
 namespace scripts
 {

--- a/spt/scripts/srctas_reader.cpp
+++ b/spt/scripts/srctas_reader.cpp
@@ -14,9 +14,9 @@
 #include "framebulk_handler.hpp"
 #include "..\features\afterframes.hpp"
 #include "..\features\demo.hpp"
+#include "..\features\tas.hpp"
 
 extern ConVar y_spt_gamedir;
-extern ConVar tas_script_onsuccess;
 
 namespace scripts
 {

--- a/spt/scripts/tracker.cpp
+++ b/spt/scripts/tracker.cpp
@@ -67,12 +67,14 @@ namespace scripts
 
 	std::string PosTracker::GenerateTestData() const
 	{
-		return GenerateVectorData(spt_playerio.GetPlayerEyePos(), decimals);
+		extern ConVar tas_strafe_version;
+		return GenerateVectorData(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), decimals);
 	}
 
 	ValidationResult PosTracker::Validate(const std::string& expectedValue) const
 	{
-		return VectorValidation(spt_playerio.GetPlayerEyePos(), expectedValue, decimals);
+		extern ConVar tas_strafe_version;
+		return VectorValidation(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), expectedValue, decimals);
 	}
 
 	std::string PosTracker::TrackerName() const

--- a/spt/scripts/tracker.cpp
+++ b/spt/scripts/tracker.cpp
@@ -3,6 +3,7 @@
 #include "..\sptlib-wrapper.hpp"
 #include "string_utils.hpp"
 #include "..\features\playerio.hpp"
+#include "..\features\tas.hpp"
 
 namespace scripts
 {
@@ -67,13 +68,11 @@ namespace scripts
 
 	std::string PosTracker::GenerateTestData() const
 	{
-		extern ConVar tas_strafe_version;
 		return GenerateVectorData(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), decimals);
 	}
 
 	ValidationResult PosTracker::Validate(const std::string& expectedValue) const
 	{
-		extern ConVar tas_strafe_version;
 		return VectorValidation(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), expectedValue, decimals);
 	}
 

--- a/spt/scripts/variable_container.cpp
+++ b/spt/scripts/variable_container.cpp
@@ -2,8 +2,7 @@
 #include "variable_container.hpp"
 #include "dbg.h"
 #include "srctas_reader.hpp"
-
-extern ConVar tas_script_printvars;
+#include "..\features\tas.hpp"
 
 namespace scripts
 {

--- a/spt/scripts2/condition2.cpp
+++ b/spt/scripts2/condition2.cpp
@@ -47,13 +47,13 @@ namespace scripts2
 
 	bool PosSpeedCondition::IsTrue(int tick, int totalTicks) const
 	{
-		if (!utils::playerEntityAvailable())
+		if (!utils::spt_clientEntList.GetPlayer())
 			return false;
 
 		Vector v;
 
 		if (isPos)
-			v = spt_playerio.GetPlayerEyePos();
+			v = spt_playerio.GetPlayerEyePos(true);
 		else
 			v = spt_playerio.GetPlayerVelocity();
 
@@ -104,19 +104,19 @@ namespace scripts2
 
 	bool AliveCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return !utils::playerEntityAvailable() || spt_propertyGetter.GetProperty<int>(0, "m_iHealth") > 0;
+		return !utils::spt_clientEntList.GetPlayer() || spt_propertyGetter.GetProperty<int>(1, "m_iHealth") > 0;
 	}
 
 	bool AliveCondition::ShouldTerminate(int tick, int totalTicks) const
 	{
-		return utils::playerEntityAvailable() && spt_propertyGetter.GetProperty<int>(0, "m_iHealth") <= 0;
+		return utils::spt_clientEntList.GetPlayer() && spt_propertyGetter.GetProperty<int>(1, "m_iHealth") <= 0;
 	}
 
 	LoadCondition::LoadCondition() {}
 
 	bool LoadCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return !utils::playerEntityAvailable();
+		return !utils::spt_clientEntList.GetPlayer();
 	}
 
 	bool LoadCondition::ShouldTerminate(int tick, int totalTicks) const
@@ -132,7 +132,7 @@ namespace scripts2
 
 	bool VelAngleCondition::IsTrue(int tick, int totalTicks) const
 	{
-		if (!utils::playerEntityAvailable())
+		if (!utils::spt_clientEntList.GetPlayer())
 			return false;
 
 		Vector v = spt_playerio.GetPlayerVelocity();
@@ -158,7 +158,7 @@ namespace scripts2
 
 	bool PBubbleCondition::IsTrue(int tick, int totalTicks) const
 	{
-		return (GetEnvironmentPortal() == NULL) ^ searchForInBubble;
+		return !utils::GetEnvironmentPortal() ^ searchForInBubble;
 	}
 
 	bool PBubbleCondition::ShouldTerminate(int tick, int totalTicks) const

--- a/spt/scripts2/parsed_script2.cpp
+++ b/spt/scripts2/parsed_script2.cpp
@@ -3,10 +3,9 @@
 #include "file.hpp"
 #include "parsed_script2.hpp"
 #include "..\features\demo.hpp"
+#include "..\features\tas.hpp"
 #include "..\spt-serverplugin.hpp"
 #include "thirdparty\md5.hpp"
-
-extern ConVar tas_script_savestates;
 
 namespace scripts2
 {

--- a/spt/scripts2/srctas_reader2.cpp
+++ b/spt/scripts2/srctas_reader2.cpp
@@ -11,10 +11,10 @@
 #include "..\features\afterframes.hpp"
 #include "..\features\demo.hpp"
 #include "..\features\tickrate.hpp"
+#include "..\features\tas.hpp"
 #include "..\spt-serverplugin.hpp"
 #include "..\sptlib-wrapper.hpp"
 
-extern ConVar tas_script_onsuccess;
 extern ConVar y_spt_gamedir;
 
 namespace scripts2

--- a/spt/scripts2/tracker2.cpp
+++ b/spt/scripts2/tracker2.cpp
@@ -67,12 +67,14 @@ namespace scripts2
 
 	std::string PosTracker::GenerateTestData() const
 	{
-		return GenerateVectorData(spt_playerio.GetPlayerEyePos(), decimals);
+		extern ConVar tas_strafe_version;
+		return GenerateVectorData(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), decimals);
 	}
 
 	ValidationResult PosTracker::Validate(const std::string& expectedValue) const
 	{
-		return VectorValidation(spt_playerio.GetPlayerEyePos(), expectedValue, decimals);
+		extern ConVar tas_strafe_version;
+		return VectorValidation(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), expectedValue, decimals);
 	}
 
 	std::string PosTracker::TrackerName() const

--- a/spt/scripts2/tracker2.cpp
+++ b/spt/scripts2/tracker2.cpp
@@ -2,6 +2,7 @@
 #include "tracker2.hpp"
 #include "string_utils.hpp"
 #include "..\features\playerio.hpp"
+#include "..\features\tas.hpp"
 #include "..\sptlib-wrapper.hpp"
 
 namespace scripts2
@@ -67,13 +68,11 @@ namespace scripts2
 
 	std::string PosTracker::GenerateTestData() const
 	{
-		extern ConVar tas_strafe_version;
 		return GenerateVectorData(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), decimals);
 	}
 
 	ValidationResult PosTracker::Validate(const std::string& expectedValue) const
 	{
-		extern ConVar tas_strafe_version;
 		return VectorValidation(spt_playerio.GetPlayerEyePos(tas_strafe_version.GetInt() >= 8), expectedValue, decimals);
 	}
 

--- a/spt/scripts2/variable_container2.cpp
+++ b/spt/scripts2/variable_container2.cpp
@@ -2,8 +2,7 @@
 #include "srctas_reader2.hpp"
 #include "variable_container2.hpp"
 #include "dbg.h"
-
-extern ConVar tas_script_printvars;
+#include "..\features\tas.hpp"
 
 namespace scripts2
 {

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -123,15 +123,6 @@ void SetViewAngles(const float viewangles[3])
 	}
 }
 
-void DefaultFOVChangeCallback(ConVar* var, char const* pOldString)
-{
-	if (FStrEq(var->GetString(), "75") && FStrEq(pOldString, "90"))
-	{
-		//Msg("Attempted to change default_fov from 90 to 75. Preventing.\n");
-		var->SetValue("90");
-	}
-}
-
 CSourcePauseTool g_SourcePauseTool;
 
 extern "C" __declspec(dllexport) const void* CreateInterface(const char* pName, int* pReturnCode)

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -60,7 +60,7 @@ namespace interfaces
 	IMaterialSystem* materialSystem = nullptr;
 	IInputSystem* inputSystem = nullptr;
 	IGameMovement* gm = nullptr;
-	IClientEntityList* entList;
+	IClientEntityList* entListClient = nullptr;
 	IVModelInfo* modelInfo;
 	IBaseClientDLL* clientInterface;
 	IEngineTrace* engineTraceClient = nullptr;
@@ -88,12 +88,6 @@ ConVar* _sv_cheats = nullptr;
 extern ConVar tas_force_airaccelerate;
 extern ConVar tas_force_wishspeed_cap;
 extern ConVar tas_reset_surface_friction;
-
-// useful helper func
-inline bool FStrEq(const char* sz1, const char* sz2)
-{
-	return (stricmp(sz1, sz2) == 0);
-}
 
 void CallServerCommand(const char* cmd)
 {
@@ -317,7 +311,7 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 	interfaces::inputSystem = (IInputSystem*)interfaceFactory(INPUTSYSTEM_INTERFACE_VERSION, NULL);
 
 	auto clientFactory = Sys_GetFactory("client");
-	interfaces::entList = (IClientEntityList*)clientFactory(VCLIENTENTITYLIST_INTERFACE_VERSION, NULL);
+	interfaces::entListClient = (IClientEntityList*)clientFactory(VCLIENTENTITYLIST_INTERFACE_VERSION, NULL);
 	interfaces::modelInfo = (IVModelInfo*)interfaceFactory(VMODELINFO_SERVER_INTERFACE_VERSION, NULL);
 	interfaces::clientInterface = (IBaseClientDLL*)clientFactory(CLIENT_DLL_INTERFACE_VERSION, NULL);
 	interfaces::engineTraceClient = (IEngineTrace*)interfaceFactory(INTERFACEVERSION_ENGINETRACE_CLIENT, NULL);
@@ -436,8 +430,8 @@ bool CSourcePauseTool::Load(CreateInterfaceFn interfaceFactory, CreateInterfaceF
 	if (!interfaces::inputSystem)
 		DevWarning("SPT: Failed to get the input system interface.\n");
 
-	if (!interfaces::entList)
-		DevWarning("Unable to retrieve entitylist interface.\n");
+	if (!interfaces::entListClient)
+		DevWarning("Unable to retrieve client entity list interface.\n");
 
 	if (!interfaces::modelInfo)
 		DevWarning("Unable to retrieve the model info interface.\n");

--- a/spt/spt-serverplugin.cpp
+++ b/spt/spt-serverplugin.cpp
@@ -15,6 +15,7 @@
 #include "game_detection.hpp"
 #include "..\features\generic.hpp"
 #include "..\features\playerio.hpp"
+#include "..\features\tas.hpp"
 #include "custom_interfaces.hpp"
 #include "cvars.hpp"
 #include "scripts\srctas_reader.hpp"
@@ -84,10 +85,6 @@ ConVar* _sv_gravity = nullptr;
 ConVar* _sv_maxvelocity = nullptr;
 ConVar* _sv_bounce = nullptr;
 ConVar* _sv_cheats = nullptr;
-
-extern ConVar tas_force_airaccelerate;
-extern ConVar tas_force_wishspeed_cap;
-extern ConVar tas_reset_surface_friction;
 
 void CallServerCommand(const char* cmd)
 {

--- a/spt/strafe/strafestuff.cpp
+++ b/spt/strafe/strafestuff.cpp
@@ -76,13 +76,13 @@ namespace Strafe
 
 	void SetMoveData()
 	{
-		data.m_nPlayerHandle = utils::GetServerPlayer()->GetRefEHandle();
+		data.m_nPlayerHandle = utils::spt_serverEntList.GetPlayer()->GetRefEHandle();
 		void** player = reinterpret_cast<void**>((uintptr_t*)interfaces::gm + spt_autojump.off_player_ptr);
 		CMoveData** mv = reinterpret_cast<CMoveData**>((uintptr_t*)interfaces::gm + spt_autojump.off_mv_ptr);
 		oldmv = *mv;
 		oldPlayer = *player;
 		*mv = &data;
-		*player = utils::GetServerPlayer();
+		*player = utils::spt_serverEntList.GetPlayer();
 	}
 
 	void UnsetMoveData()
@@ -130,7 +130,7 @@ namespace Strafe
 
 			spt_tracing.ORIG_UTIL_TraceRay(ray,
 			                               MASK_PLAYERSOLID_BRUSHONLY,
-			                               utils::GetClientEntity(0),
+			                               utils::spt_clientEntList.GetPlayer(),
 			                               COLLISION_GROUP_PLAYER_MOVEMENT,
 			                               &trace);
 		}
@@ -168,7 +168,7 @@ namespace Strafe
 		ray.Init(start, end);
 		spt_tracing.ORIG_UTIL_TraceRay(ray,
 		                               MASK_PLAYERSOLID_BRUSHONLY,
-		                               utils::GetClientEntity(0),
+		                               utils::spt_clientEntList.GetPlayer(),
 		                               COLLISION_GROUP_PLAYER_MOVEMENT,
 		                               &trace);
 #endif
@@ -181,7 +181,7 @@ namespace Strafe
 	bool CanUnduck(const PlayerData& player)
 	{
 		if ((player.DuckPressed && !tas_strafe_autojb.GetBool()) || !tas_strafe_use_tracing.GetBool()
-		    || !utils::GetServerPlayer())
+		    || !utils::spt_serverEntList.GetPlayer())
 			return false;
 		else
 		{
@@ -201,7 +201,7 @@ namespace Strafe
 		int strafe_version = tas_strafe_version.GetInt();
 
 		if (!tas_strafe_use_tracing.GetBool() || strafe_version == 0 || !CanTrace()
-		    || !utils::GetServerPlayer())
+		    || !utils::spt_serverEntList.GetPlayer())
 		{
 			if (spt_playerio.IsGroundEntitySet())
 				return PositionType::GROUND;

--- a/spt/strafe/strafestuff.cpp
+++ b/spt/strafe/strafestuff.cpp
@@ -18,6 +18,7 @@
 #include "..\features\playerio.hpp"
 #include "..\features\tracing.hpp"
 #include "..\features\autojump.hpp"
+#include "..\features\tas.hpp"
 #include "SDK\hl_movedata.h"
 #include "interfaces.hpp"
 
@@ -30,19 +31,6 @@
 #ifdef min
 #undef min
 #endif
-
-extern ConVar tas_strafe_afh_length;
-extern ConVar tas_strafe_allow_jump_override;
-extern ConVar tas_strafe_autojb;
-extern ConVar tas_strafe_capped_limit;
-extern ConVar tas_strafe_hull_is_line;
-extern ConVar tas_strafe_jumptype;
-extern ConVar tas_strafe_lgagst_max;
-extern ConVar tas_strafe_lgagst_min;
-extern ConVar tas_strafe_use_tracing;
-extern ConVar tas_strafe_version;
-extern ConVar tas_strafe_vectorial_increment;
-extern ConVar tas_strafe_vectorial_snap;
 
 // This code is a messed up version of hlstrafe,
 // go take a look at that instead:

--- a/spt/utils/datamap_wrapper.cpp
+++ b/spt/utils/datamap_wrapper.cpp
@@ -118,7 +118,6 @@ namespace utils
 			{
 			// Some weird stuff so ignore it
 			case FIELD_VOID:
-			case FIELD_CUSTOM:
 			case FIELD_FUNCTION:
 			case FIELD_TYPECOUNT:
 				continue;

--- a/spt/utils/ent_list.hpp
+++ b/spt/utils/ent_list.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <vector>
+#include <algorithm>
+
+#include "iserverentity.h"
+#include "icliententity.h"
+#include "basehandle.h"
+
+namespace utils
+{
+	struct PortalInfo
+	{
+		void* pEnt; // client/server entity (depends on which ent list you used)
+		CBaseHandle handle, linkedHandle;
+		Vector pos, linkedPos;
+		QAngle ang, linkedAng;
+		bool isOrange, isActivated, isOpen;
+		unsigned char linkageId = 0; // only exists on server
+
+		inline const PortalInfo* GetLinkedPortal() const;
+
+		void Invalidate()
+		{
+			handle = linkedHandle = CBaseHandle{};
+			pos = linkedPos = Vector{NAN, NAN, NAN};
+			ang = linkedAng = QAngle{NAN, NAN, NAN};
+		}
+
+		bool operator==(const PortalInfo& other) const
+		{
+			return !memcmp(this, &other, sizeof other);
+		}
+
+		bool operator!=(const PortalInfo& other) const
+		{
+			return !!memcmp(this, &other, sizeof other);
+		}
+	};
+
+	/*
+	* A server/client entity list abstraction. Stores an internal list for all entities which is
+	* rebuilt every tick/frame for server/client. Also does the same for portals. All portal info
+	* is returned by POINTERS which should NOT be stored inside a feature. All pointers are invalid
+	* on the next tick/frame. If required, portal info can be copied and stored by value, but this
+	* should not be necessary for most features.
+	*/
+	template<bool SERVER>
+	class SptEntList
+	{
+		using ent_type = std::conditional_t<SERVER, IServerEntity*, IClientEntity*>;
+
+	private:
+		std::vector<ent_type> _entList;
+		std::vector<PortalInfo> _portalList;
+		int lastUpdatedAt = -666;
+
+		void FillPortalInfo(ent_type ent, PortalInfo& info);
+
+		SptEntList() = default;
+		SptEntList(SptEntList&) = delete;
+		SptEntList(SptEntList&&) = delete;
+
+	public:
+		static SptEntList& GetSingleton()
+		{
+			static SptEntList entList;
+			return entList;
+		}
+
+		void CheckRebuildLists(bool force = false);
+
+		const auto& GetEntList()
+		{
+			CheckRebuildLists(false);
+			return _entList;
+		}
+
+		const auto& GetPortalList()
+		{
+			CheckRebuildLists(false);
+			return _portalList;
+		}
+
+		static ent_type GetPlayer()
+		{
+			return GetEnt(1);
+		};
+
+		static bool EntIsPortal(ent_type ent)
+		{
+			const char* name = NetworkClassName(ent);
+			return name && !strcmp(name, "CProp_Portal");
+		}
+
+		const PortalInfo* GetPortalAtIndex(int index)
+		{
+			auto& portalList = GetPortalList();
+			auto it = std::lower_bound(portalList.cbegin(),
+			                           portalList.cend(),
+			                           index,
+			                           [](const PortalInfo& portal, int x)
+			                           { return portal.handle.GetEntryIndex() < x; });
+			return it != portalList.cend() && it->handle.GetEntryIndex() == index ? &*it : nullptr;
+		}
+
+		static bool Valid()
+		{
+			return !!GetEnt(0);
+		}
+
+		const PortalInfo* GetEnvironmentPortal();
+		static ent_type GetEnt(int index);
+		static const char* NetworkClassName(ent_type ent);
+	};
+
+	using SptEntListServer = SptEntList<true>;
+	using SptEntListClient = SptEntList<false>;
+
+	// (references to) the singleton objects
+	inline SptEntListServer& spt_serverEntList = SptEntListServer::GetSingleton();
+	inline SptEntListClient& spt_clientEntList = SptEntListClient::GetSingleton();
+
+	/*
+	* Portal wrappers that can be used directly from the 'utils' namespace. The portal info struct
+	* is server/client agnostic by design with some slight differences:
+	* - the server position is more accurate
+	* - entity handle serial numbers are different (TODO check)
+	* 
+	* This logic prefers getting portal info from the server when available, otherwise gets it from
+	* the client.
+	*/
+
+	// avoid copying by value :p
+	static auto& GetPortalList()
+	{
+		return spt_serverEntList.Valid() ? spt_serverEntList.GetPortalList()
+		                                 : spt_clientEntList.GetPortalList();
+	}
+
+	static auto GetEnvironmentPortal()
+	{
+		return spt_serverEntList.Valid() ? spt_serverEntList.GetEnvironmentPortal()
+		                                 : spt_clientEntList.GetEnvironmentPortal();
+	}
+
+	static const PortalInfo* GetPortalAtIndex(int index)
+	{
+		return spt_serverEntList.Valid() ? spt_serverEntList.GetPortalAtIndex(index)
+		                                 : spt_clientEntList.GetPortalAtIndex(index);
+	}
+
+	inline const PortalInfo* PortalInfo::GetLinkedPortal() const
+	{
+		return handle.IsValid() && linkedHandle.IsValid() ? GetPortalAtIndex(linkedHandle.GetEntryIndex())
+		                                                  : nullptr;
+	}
+
+} // namespace utils

--- a/spt/utils/ent_list_client.cpp
+++ b/spt/utils/ent_list_client.cpp
@@ -1,0 +1,87 @@
+#include <stdafx.hpp>
+
+#include "ent_list.hpp"
+#include "spt/features/ent_props.hpp"
+#include "spt/features/property_getter.hpp"
+#include "interfaces.hpp"
+
+template<>
+void utils::SptEntListClient::CheckRebuildLists(bool force)
+{
+	if (!interfaces::engine_tool || !interfaces::entListClient)
+		return;
+	int newFrame = interfaces::engine_tool->HostFrameCount();
+	if (newFrame == lastUpdatedAt && !force)
+		return;
+	lastUpdatedAt = newFrame;
+	_entList.clear();
+	_portalList.clear();
+	/*
+	* On newer versions you can do a a couple static casts:
+	* IClientEntityList -> CClienEntityList -> CBaseEntityList
+	* 
+	* This would give a nice linked list that can be used for client entity iteration, but this
+	* doesn't work on OE, so we just use the IClientEntityList directly.
+	*/
+	for (int i = 0; i < interfaces::entListClient->GetHighestEntityIndex(); i++)
+	{
+		IClientEntity* ent = GetEnt(i);
+		if (!ent)
+			continue;
+		_entList.push_back(ent);
+		if (EntIsPortal(ent))
+		{
+			_portalList.emplace_back();
+			FillPortalInfo(ent, _portalList.back());
+		}
+	}
+}
+
+template<>
+auto utils::SptEntListClient::GetEnt(int i) -> ent_type
+{
+	// the engine does not check the upper bound for us :/
+	if (!interfaces::entListClient || i >= NUM_ENT_ENTRIES)
+		return nullptr;
+	return interfaces::entListClient->GetClientEntity(i);
+}
+
+template<>
+const char* utils::SptEntListClient::NetworkClassName(ent_type ent)
+{
+	return ent ? ent->GetClientClass()->GetName() : nullptr;
+}
+
+template<>
+void utils::SptEntListClient::FillPortalInfo(ent_type ent, utils::PortalInfo& info)
+{
+	Assert(EntIsPortal(ent));
+	if (!interfaces::modelInfo)
+	{
+		Assert(0);
+		return;
+	}
+
+	CBaseHandle handle = ent->GetRefEHandle();
+	CBaseHandle linked = spt_propertyGetter.GetProperty<CBaseHandle>(handle.GetEntryIndex(), "m_hLinkedPortal");
+	bool activated = spt_propertyGetter.GetProperty<bool>(handle.GetEntryIndex(), "m_bActivated");
+	auto linkedEnt = linked.IsValid() ? GetEnt(linked.GetEntryIndex()) : nullptr;
+
+	info.pEnt = ent;
+	info.handle = handle;
+	info.linkedHandle = linked;
+	info.pos = ent->GetAbsOrigin();
+	info.linkedPos = linkedEnt ? linkedEnt->GetAbsOrigin() : Vector{NAN, NAN, NAN};
+	info.ang = ent->GetAbsAngles();
+	info.linkedAng = linkedEnt ? linkedEnt->GetAbsAngles() : QAngle{NAN, NAN, NAN};
+	info.isOrange = !!strstr(interfaces::modelInfo->GetModelName(ent->GetModel()), "portal2");
+	info.isActivated = activated;
+	info.isOpen = linked.IsValid();
+}
+
+template<>
+const utils::PortalInfo* utils::SptEntListClient::GetEnvironmentPortal()
+{
+	CBaseHandle handle = spt_propertyGetter.GetProperty<CBaseHandle>(1, "m_hPortalEnvironment");
+	return handle.IsValid() ? GetPortalAtIndex(handle.GetEntryIndex()) : nullptr;
+}

--- a/spt/utils/ent_list_server.cpp
+++ b/spt/utils/ent_list_server.cpp
@@ -1,0 +1,95 @@
+#include <stdafx.hpp>
+
+#include "ent_list.hpp"
+#include "spt\features\ent_props.hpp"
+#include "interfaces.hpp"
+
+#include "server_class.h"
+
+template<>
+void utils::SptEntListServer::CheckRebuildLists(bool force)
+{
+	if (!interfaces::engine_tool || !interfaces::engine_server)
+		return;
+	int newTick = interfaces::engine_tool->HostTick();
+	if (newTick == lastUpdatedAt && !force)
+		return;
+	lastUpdatedAt = newTick;
+	_entList.clear();
+	_portalList.clear();
+	if (!Valid())
+		return;
+	int maxNEnts = interfaces::engine_server->GetEntityCount();
+	for (int i = 0; (int)_entList.size() < maxNEnts && i < MAX_EDICTS; i++)
+	{
+		IServerEntity* ent = GetEnt(i);
+		if (!ent)
+			continue;
+		_entList.push_back(ent);
+		if (EntIsPortal(ent))
+		{
+			_portalList.emplace_back();
+			FillPortalInfo(ent, _portalList.back());
+		}
+	}
+}
+
+template<>
+auto utils::SptEntListServer::GetEnt(int i) -> ent_type
+{
+	if (!interfaces::engine_server)
+		return nullptr;
+	edict_t* ed = interfaces::engine_server->PEntityOfEntIndex(i);
+	if (!ed || (int)ed == -1) // -1 check is from ent_props, not sure if it's necessary
+		return nullptr;
+	return ed->GetIServerEntity();
+}
+
+template<>
+const char* utils::SptEntListServer::NetworkClassName(ent_type ent)
+{
+	constexpr int fOff = -(int)sizeof(CBaseHandle);
+	static CachedField<ServerClass*, "CBaseEntity", "m_Network.m_hParent", true, fOff> fClass;
+	return fClass.Exists() && *fClass.GetPtr(ent) ? (**fClass.GetPtr(ent)).GetName() : nullptr;
+}
+
+template<>
+void utils::SptEntListServer::FillPortalInfo(ent_type ent, utils::PortalInfo& info)
+{
+	Assert(EntIsPortal(ent));
+	static utils::CachedField<Vector, "CProp_Portal", "m_vecAbsOrigin", true> fPos;
+	static utils::CachedField<QAngle, "CProp_Portal", "m_angAbsRotation", true> fAng;
+	static utils::CachedField<CBaseHandle, "CProp_Portal", "m_hLinkedPortal", true> fLinked;
+	static utils::CachedField<bool, "CProp_Portal", "m_bIsPortal2", true> fIsPortal2;
+	static utils::CachedField<bool, "CProp_Portal", "m_bActivated", true> fActivated;
+	static utils::CachedField<unsigned char, "CProp_Portal", "m_iLinkageGroupID", true> fLinkage;
+	static utils::CachedFields portalFields{fPos, fAng, fLinked, fIsPortal2, fActivated, fLinkage};
+
+	if (!portalFields.HasAll())
+	{
+		Assert(0);
+		return;
+	}
+	auto [pos, ang, linked, p2, activated, linkageId] = portalFields.GetAllPtrs(ent);
+	auto linkedEnt = linked->IsValid() ? GetEnt(linked->GetEntryIndex()) : nullptr;
+
+	info.pEnt = ent;
+	info.handle = ent->GetRefEHandle();
+	info.linkedHandle = *linked;
+	info.pos = *pos;
+	info.linkedPos = linkedEnt ? *fPos.GetPtr(linkedEnt) : Vector{NAN, NAN, NAN};
+	info.ang = *ang;
+	info.linkedAng = linkedEnt ? *fAng.GetPtr(linkedEnt) : QAngle{NAN, NAN, NAN};
+	info.isOrange = *p2;
+	info.isActivated = *activated;
+	info.isOpen = linked->IsValid();
+	info.linkageId = *linkageId;
+}
+
+template<>
+const utils::PortalInfo* utils::SptEntListServer::GetEnvironmentPortal()
+{
+	static utils::CachedField<CBaseHandle, "CPortal_Player", "m_hPortalEnvironment", true> fEnv;
+	CBaseHandle* handle = fEnv.GetPtrPlayer();
+	return handle && handle->IsValid() ? GetPortalAtIndex(handle->GetEntryIndex()) : nullptr;
+}

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -16,7 +16,6 @@
 #include "..\features\property_getter.hpp"
 #include "string_utils.hpp"
 #include "math.hpp"
-#include "game_detection.hpp"
 #include "..\features\playerio.hpp"
 #include "..\features\tickrate.hpp"
 #include "..\features\tracing.hpp"
@@ -363,41 +362,5 @@ namespace utils
 			return false;
 		}
 	}
-
-#if !defined(OE)
-
-	void CheckPiwSave(bool simulating)
-	{
-		if (!simulating || y_spt_piwsave.GetString()[0] == '\0')
-			return;
-		auto ply = spt_serverEntList.GetPlayer();
-		if (!ply)
-			return;
-		static CachedField<IPhysicsObject*, "CBaseEntity", "m_pPhysicsObject", true> fPhys;
-		if (!fPhys.Exists())
-			return;
-		auto pphys = *fPhys.GetPtr(ply);
-		if (!pphys || (pphys->GetGameFlags() & FVPHYSICS_PENETRATING))
-			return;
-
-		for (auto ent : spt_serverEntList.GetEntList())
-		{
-			auto phys = *fPhys.GetPtr(ent);
-			if (!phys)
-				continue;
-
-			const auto mask = FVPHYSICS_PLAYER_HELD | FVPHYSICS_PENETRATING;
-
-			if ((phys->GetGameFlags() & mask) == mask)
-			{
-				std::ostringstream oss;
-				oss << "save " << y_spt_piwsave.GetString();
-				EngineConCmd(oss.str().c_str());
-				y_spt_piwsave.SetValue("");
-			}
-		}
-	}
-
-#endif
 
 } // namespace utils

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -19,6 +19,7 @@
 #include "..\features\playerio.hpp"
 #include "..\features\tickrate.hpp"
 #include "..\features\tracing.hpp"
+#include "..\features\tas.hpp"
 #include "..\spt-serverplugin.hpp"
 #include "interfaces.hpp"
 #include "spt\utils\ent_list.hpp"
@@ -31,7 +32,6 @@
 #endif
 
 extern ConVar y_spt_piwsave;
-extern ConVar tas_strafe_version;
 
 namespace utils
 {

--- a/spt/utils/ent_utils.hpp
+++ b/spt/utils/ent_utils.hpp
@@ -38,7 +38,4 @@ namespace utils
 
 	JBData CanJB(float height);
 	bool GetPunchAngleInformation(QAngle& punchAngle, QAngle& punchAngleVel);
-#if !defined(OE)
-	void CheckPiwSave(bool simulating);
-#endif
 } // namespace utils

--- a/spt/utils/ent_utils.hpp
+++ b/spt/utils/ent_utils.hpp
@@ -24,20 +24,11 @@ namespace utils
 	};
 
 	void GetAllProps(RecvTable* table, void* ptr, std::vector<propValue>& props);
-	IClientEntity* GetClientEntity(int index);
-	void PrintAllClientEntities();
-	IClientEntity* GetPlayer();
-	const char* GetModelName(IClientEntity* ent);
 	void PrintAllProps(int index);
-	Vector GetPortalPosition(IClientEntity* ent);
-	QAngle GetPortalAngles(IClientEntity* ent);
 	Vector GetPlayerEyePosition();
 	QAngle GetPlayerEyeAngles();
-	IClientEntity* FindLinkedPortal(IClientEntity* ent);
 	int FillInfoArray(std::string argString, wchar* arr, int maxEntries, int bufferSize, char sep, char entSep);
 	void SimulateFrames(int frames);
-	int GetIndex(void* ent);
-	IServerUnknown* GetServerPlayer();
 	struct JBData
 	{
 		bool canJB;
@@ -46,7 +37,6 @@ namespace utils
 	};
 
 	JBData CanJB(float height);
-	bool playerEntityAvailable();
 	bool GetPunchAngleInformation(QAngle& punchAngle, QAngle& punchAngleVel);
 #if !defined(OE)
 	void CheckPiwSave(bool simulating);

--- a/spt/utils/interfaces.hpp
+++ b/spt/utils/interfaces.hpp
@@ -34,7 +34,7 @@ namespace interfaces
 	extern IMaterialSystem* materialSystem;
 	extern IInputSystem* inputSystem;
 	extern IGameMovement* gm;
-	extern IClientEntityList* entList;
+	extern IClientEntityList* entListClient;
 	extern IVModelInfo* modelInfo;
 	extern IBaseClientDLL* clientInterface;
 	extern IEngineTrace* engineTraceClient;

--- a/spt/utils/map_utils.cpp
+++ b/spt/utils/map_utils.cpp
@@ -1,0 +1,47 @@
+#include "stdafx.hpp"
+
+#include <unordered_map>
+
+#include "map_utils.hpp"
+#include "spt/features/ent_props.hpp"
+
+auto utils::GetLandmarksInLoadedMap() -> const SptLandmarkList&
+{
+	static std::unordered_map<std::string, SptLandmarkList> cache;
+	static SptLandmarkList emptyList;
+
+	auto [it, is_new] = cache.try_emplace(GetLoadedMap());
+	if (!is_new)
+		return it->second;
+
+	static utils::CachedField<string_t, "CBaseEntity", "m_iClassname", true, false> f1;
+	static utils::CachedField<string_t, "CBaseEntity", "m_iName", true, false> f2;
+	static utils::CachedField<Vector, "CBaseEntity", "m_vecAbsOrigin", true, false> f3;
+	static utils::CachedFields fields{f1, f2, f3};
+
+	if (fields.HasAll())
+	{
+		if (!utils::spt_serverEntList.Valid())
+		{
+			cache.erase(it);
+			return emptyList;
+		}
+		for (auto ent : utils::spt_serverEntList.GetEntList())
+		{
+			auto [cn, n, pos] = fields.GetAllPtrs(ent);
+			if (strcmp(cn->ToCStr(), "info_landmark"))
+				continue;
+			it->second.emplace_back(n->ToCStr(), *pos);
+		}
+	}
+	return it->second;
+}
+
+Vector utils::LandmarkDelta(const SptLandmarkList& from, const SptLandmarkList& to)
+{
+	for (auto& [fromName, fromPos] : from)
+		for (auto& [toName, toPos] : to)
+			if (fromName == toName)
+				return fromPos - toPos;
+	return vec3_origin;
+}

--- a/spt/utils/map_utils.hpp
+++ b/spt/utils/map_utils.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "interfaces.hpp"
+
+namespace utils
+{
+	inline const char* GetLoadedMap()
+	{
+		return interfaces::engine_tool ? interfaces::engine_tool->GetCurrentMap() : "";
+	}
+
+	using SptLandmarkList = std::vector<std::pair<std::string, Vector>>;
+
+	const SptLandmarkList& GetLandmarksInLoadedMap();
+	// returns the landmark delta between two adjacent maps; if no shared landmarks are found returns <0,0,0>
+	// ASSUMES THE MAPS ARE DIFFERENT
+	Vector LandmarkDelta(const SptLandmarkList& from, const SptLandmarkList& to);
+} // namespace utils

--- a/spt/utils/portal_utils.cpp
+++ b/spt/utils/portal_utils.cpp
@@ -41,265 +41,235 @@ void UpdatePortalTransformationMatrix(const matrix3x4_t& localToWorld,
 	matrix = matPortal2ToWorld * matRotation * matPortal1ToWorldInv;
 }
 
-void UpdatePortalTransformationMatrix(IClientEntity* localPortal, IClientEntity* remotePortal, VMatrix& matrix)
+void UpdatePortalTransformationMatrix(const utils::PortalInfo* info, VMatrix& matrix)
 {
 	Vector localForward, localRight, localUp;
 	Vector remoteForward, remoteRight, remoteUp;
-	AngleVectors(utils::GetPortalAngles(localPortal), &localForward, &localRight, &localUp);
-	AngleVectors(utils::GetPortalAngles(remotePortal), &remoteForward, &remoteRight, &remoteUp);
+	AngleVectors(info->ang, &localForward, &localRight, &localUp);
+	AngleVectors(info->linkedAng, &remoteForward, &remoteRight, &remoteUp);
 
-	matrix3x4_t localToWorld(localForward, -localRight, localUp, utils::GetPortalPosition(localPortal));
-	matrix3x4_t remoteToWorld(remoteForward, -remoteRight, remoteUp, utils::GetPortalPosition(remotePortal));
+	matrix3x4_t localToWorld(localForward, -localRight, localUp, info->pos);
+	matrix3x4_t remoteToWorld(remoteForward, -remoteRight, remoteUp, info->linkedPos);
 	UpdatePortalTransformationMatrix(localToWorld, remoteToWorld, matrix);
 }
 
-bool invalidPortal(IClientEntity* portal)
+void calculateAGPosition(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles)
 {
-	return !portal || strcmp(portal->GetClientClass()->GetName(), "CProp_Portal") != 0;
+	if (portal && portal->linkedHandle.IsValid())
+		calculateAGOffsetPortal(portal, new_player_origin, new_player_angles);
 }
 
-IClientEntity* GetEnvironmentPortal()
+void calculateSGPosition(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles)
 {
-	if (!utils::DoesGameLookLikePortal())
-		return nullptr;
-	int handle = spt_propertyGetter.GetProperty<int>(0, "m_hPortalEnvironment");
-	if (handle == 0)
-		return nullptr;
-	int index = (handle & INDEX_MASK) - 1;
-	return utils::GetClientEntity(index);
-}
-
-IClientEntity* GetLinkedPortal(IClientEntity* portal)
-{
-	return utils::FindLinkedPortal(portal);
-}
-
-bool getPortal(IClientEntity** portal_edict, Vector& new_player_origin, QAngle& new_player_angles)
-{
-	IClientEntity* portal = getPortal(_y_spt_overlay_portal.GetString(), false);
-
-	if (!portal)
-	{
-		new_player_origin = utils::GetPlayerEyePosition();
-		new_player_angles = utils::GetPlayerEyeAngles();
-
-		return false;
-	}
-
-	*portal_edict = portal;
-	return true;
-}
-
-void calculateAGPosition(Vector& new_player_origin, QAngle& new_player_angles)
-{
-	IClientEntity* enter_portal = NULL;
-	IClientEntity* exit_portal = NULL;
-
-	if (getPortal(&enter_portal, new_player_origin, new_player_angles))
-	{
-		exit_portal = GetLinkedPortal(enter_portal);
-		if (exit_portal)
-		{
-			calculateAGOffsetPortal(enter_portal, exit_portal, new_player_origin, new_player_angles);
-		}
-	}
-}
-
-void calculateSGPosition(Vector& new_player_origin, QAngle& new_player_angles)
-{
-	IClientEntity* portal;
-	if (getPortal(&portal, new_player_origin, new_player_angles))
+	if (portal && portal->linkedHandle.IsValid())
 		calculateOffsetPlayer(portal, new_player_origin, new_player_angles);
 }
 
-bool isInfrontOfPortal(IClientEntity* saveglitch_portal, const Vector& player_origin)
+std::wstring calculateWillAGSG(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles)
 {
-	const auto& portal_origin = utils::GetPortalPosition(saveglitch_portal);
-	const auto& portal_angles = utils::GetPortalAngles(saveglitch_portal);
-
-	Vector delta = player_origin - portal_origin;
-	Vector normal;
-	AngleVectors(portal_angles, &normal);
-	float dot = DotProduct(normal, delta);
-
-	return dot >= 0;
-}
-
-std::wstring calculateWillAGSG(Vector& new_player_origin, QAngle& new_player_angles)
-{
-	IClientEntity* enter_portal;
-	if (!getPortal(&enter_portal, new_player_origin, new_player_angles))
+	if (!portal)
 		return L"no portal selected";
 
-	Vector enter_origin = utils::GetPortalPosition(enter_portal);
-	const auto& enter_angles = utils::GetPortalAngles(enter_portal);
 	Vector enterForward;
-	AngleVectors(enter_angles, &enterForward);
-
-	if (enterForward.z >= -0.7071f)
-		return L"no, bad entry portal";
+	AngleVectors(portal->ang, &enterForward);
 
 	Vector pos;
 	QAngle qa;
-	calculateAGPosition(pos, qa);
+	calculateAGPosition(portal, pos, qa);
 
-	if (enterForward.Dot(pos - enter_origin) >= 0)
+	if (enterForward.Dot(pos - portal->pos) >= 0)
 		return L"no, tp position in front";
 	else
 		return L"yes";
 }
 
-void calculateAGOffsetPortal(IClientEntity* enter_portal,
-                             IClientEntity* exit_portal,
-                             Vector& new_player_origin,
-                             QAngle& new_player_angles)
+void calculateAGOffsetPortal(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles)
 {
-	const auto& enter_origin = utils::GetPortalPosition(enter_portal);
-	const auto& enter_angles = utils::GetPortalAngles(enter_portal);
-	const auto& exit_origin = utils::GetPortalPosition(exit_portal);
-	const auto& exit_angles = utils::GetPortalAngles(exit_portal);
-
 	Vector exitForward, exitRight, exitUp;
 	Vector enterForward, enterRight, enterUp;
-	AngleVectors(enter_angles, &enterForward, &enterRight, &enterUp);
-	AngleVectors(exit_angles, &exitForward, &exitRight, &exitUp);
+	AngleVectors(portal->ang, &enterForward, &enterRight, &enterUp);
+	AngleVectors(portal->linkedAng, &exitForward, &exitRight, &exitUp);
 
-	auto delta = enter_origin - exit_origin;
+	auto delta = portal->pos - portal->linkedPos;
 
 	Vector exit_portal_coords;
 	exit_portal_coords.x = delta.Dot(exitForward);
 	exit_portal_coords.y = delta.Dot(exitRight);
 	exit_portal_coords.z = delta.Dot(exitUp);
 
-	Vector transition(0, 0, 0);
+	Vector transition(0.f);
 	transition -= exit_portal_coords.x * enterForward;
 	transition -= exit_portal_coords.y * enterRight;
 	transition += exit_portal_coords.z * enterUp;
 
-	auto new_eye_origin = enter_origin + transition;
-	new_player_origin = new_eye_origin;
+	new_player_origin = portal->pos + transition;
 	new_player_angles = utils::GetPlayerEyeAngles();
 }
 
-void transformThroughPortal(IClientEntity* saveglitch_portal,
+void transformThroughPortal(const utils::PortalInfo* portal,
                             const Vector& start_pos,
                             const QAngle start_angles,
                             Vector& transformed_origin,
                             QAngle& transformed_angles)
 {
-	VMatrix matrix;
-	matrix.Identity();
+	Vector normal;
+	if (portal)
+		AngleVectors(portal->ang, &normal);
 
-	if (isInfrontOfPortal(saveglitch_portal, start_pos))
+	if (!portal || normal.Dot(start_pos - portal->pos) >= 0)
 	{
 		transformed_origin = start_pos;
 		transformed_angles = start_angles;
-	}
-	else
-	{
-		edict_t* e = interfaces::engine_server->PEntityOfEntIndex(saveglitch_portal->entindex());
-		static int offset = spt_entprops.GetFieldOffset("CProp_Portal", "m_matrixThisToLinked", true);
-		if (e && offset != -1)
-		{
-			uintptr_t serverEnt = reinterpret_cast<uintptr_t>(e->GetUnknown());
-			matrix = *reinterpret_cast<VMatrix*>(serverEnt + offset);
-		}
-		else
-		{
-			IClientEntity* linkedPortal = GetLinkedPortal(saveglitch_portal);
-
-			if (linkedPortal)
-			{
-				UpdatePortalTransformationMatrix(saveglitch_portal, linkedPortal, matrix);
-			}
-		}
+		return;
 	}
 
-	auto eye_origin = start_pos;
-	auto new_eye_origin = matrix * eye_origin;
-	transformed_origin = new_eye_origin;
+	VMatrix matrix;
+	UpdatePortalTransformationMatrix(portal, matrix);
 
+	transformed_origin = matrix * start_pos;
 	transformed_angles = TransformAnglesToWorldSpace(start_angles, matrix.As3x4());
 	transformed_angles.x = AngleNormalizePositive(transformed_angles.x);
 	transformed_angles.y = AngleNormalizePositive(transformed_angles.y);
 	transformed_angles.z = AngleNormalizePositive(transformed_angles.z);
 }
 
-void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_origin, QAngle& new_player_angles)
+void calculateOffsetPlayer(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles)
 {
 	const auto& player_origin = utils::GetPlayerEyePosition();
 	const auto& player_angles = utils::GetPlayerEyeAngles();
-	transformThroughPortal(saveglitch_portal, player_origin, player_angles, new_player_origin, new_player_angles);
+	transformThroughPortal(portal, player_origin, player_angles, new_player_origin, new_player_angles);
 }
 
-IClientEntity* getPortal(const char* arg, bool verbose)
+const utils::PortalInfo* getPortal(const char* arg, bool onlyOpen, bool allowAuto)
 {
-	int portal_index = atoi(arg);
-	IClientEntity* portal = nullptr;
-	bool want_blue = !strcmp(arg, "blue");
-	bool want_orange = !strcmp(arg, "orange");
-	bool want_auto = !strcmp(arg, "auto");
+	if (!arg || !utils::DoesGameLookLikePortal())
+		return nullptr;
 
-	if (want_auto)
+	if (!stricmp(arg, "overlay"))
 	{
-		return GetEnvironmentPortal();
+		arg = _y_spt_overlay_portal.GetString();
+		allowAuto = true; // copy same portal as used for overlay, meaning that 'auto' is allowed
 	}
 
-	if (want_blue || want_orange || want_auto)
+	enum PortalSelector
 	{
-		std::vector<int> indices;
+		PS_ORANGE,
+		PS_BLUE,
+		PS_AUTO,
+		_PS_FIRST_ONLY_OPEN,
+		PS_ORANGE_ONLY_OPEN = _PS_FIRST_ONLY_OPEN,
+		PS_BLUE_ONLY_OPEN,
+		PS_AUTO_ONLY_OPEN,
 
-		for (int i = 0; i < MAX_EDICTS; ++i)
-		{
-			IClientEntity* ent = utils::GetClientEntity(i);
+		_PS_N_STATEFUL_SELECTORS,
 
-			if (!invalidPortal(ent))
-			{
-				const char* modelName = utils::GetModelName(ent);
-				bool is_orange_portal = strstr(modelName, "portal2");
+		PS_ENV,
+		PS_INDEX,
+	};
 
-				if (is_orange_portal && want_orange)
-				{
-					indices.push_back(i);
-				}
-				else if (!is_orange_portal && want_blue)
-				{
-					indices.push_back(i);
-				}
-			}
-		}
+	static std::array<utils::PortalInfo, _PS_N_STATEFUL_SELECTORS> lastUsedLookup{};
 
-		if (indices.size() > 1)
-		{
-			if (verbose)
-				Msg("There are multiple %s portals, please use the index:\n", arg);
-
-			for (auto i : indices)
-			{
-				auto ent = utils::GetClientEntity(i);
-				const auto& origin = utils::GetPortalPosition(ent);
-
-				if (verbose)
-					Msg("%d located at %.8f %.8f %.8f\n", i, origin.x, origin.y, origin.z);
-			}
-		}
-		else if (indices.size() == 0)
-		{
-			if (verbose)
-				Msg("There are no %s portals.\n", arg);
-		}
+	PortalSelector selector;
+	{
+		if (!stricmp(arg, "blue"))
+			selector = onlyOpen ? PS_BLUE_ONLY_OPEN : PS_BLUE;
+		else if (!stricmp(arg, "orange"))
+			selector = onlyOpen ? PS_ORANGE_ONLY_OPEN : PS_ORANGE;
+		else if (allowAuto && !stricmp(arg, "auto"))
+			selector = onlyOpen ? PS_AUTO_ONLY_OPEN : PS_AUTO;
+		else if (!stricmp(arg, "env"))
+			selector = PS_ENV;
 		else
+			selector = PS_INDEX;
+	}
+
+	bool wantBlue = true;
+	bool wantOrange = true;
+
+	// check if a portal matches the selector string
+	const auto portalIsMatch = [&wantBlue, &wantOrange, onlyOpen](const utils::PortalInfo* p)
+	{ return p && (!onlyOpen || p->isOpen) && ((wantOrange && p->isOrange) || (wantBlue && !p->isOrange)); };
+
+	// index selector is easy
+	if (selector == PS_INDEX)
+	{
+		char* end;
+		int idx = (int)strtol(arg, &end, 10);
+		if (end == arg)
+			return nullptr;
+		const utils::PortalInfo* p = utils::GetPortalAtIndex(idx);
+		return portalIsMatch(p) ? p : nullptr;
+	}
+
+	// 'env' selector is easy
+	if (selector == PS_ENV)
+	{
+		const utils::PortalInfo* p = utils::GetEnvironmentPortal();
+		return portalIsMatch(p) ? p : nullptr;
+	}
+
+	// looking for blue/orange/auto
+
+	wantBlue = selector != PS_ORANGE && selector != PS_ORANGE_ONLY_OPEN;
+	wantOrange = selector != PS_BLUE && selector != PS_BLUE_ONLY_OPEN;
+
+	utils::PortalInfo& lastUsed = lastUsedLookup[selector];
+
+	// overwrite with player's environment, a bit weird but nice for most features
+	{
+		const utils::PortalInfo* p = utils::GetEnvironmentPortal();
+		if (portalIsMatch(p))
 		{
-			portal_index = indices[0];
-			portal = utils::GetClientEntity(portal_index);
+			lastUsed = *p;
+			return p;
 		}
+	}
+
+	// use same index if possible
+	if (lastUsed.handle.IsValid())
+	{
+		const utils::PortalInfo* p = utils::GetPortalAtIndex(lastUsed.handle.GetEntryIndex());
+		if (portalIsMatch(p))
+		{
+			lastUsed = *p;
+			return p;
+		}
+	}
+
+	/*
+	* The player's environment and the previously used index do not match this selector. Look
+	* through all portals and find one which matches. Prioritize:
+	* - portals which have the same pos/ang/color as the previously used portal since the index
+	*   of portals may change across saveloads
+	* - activated portals
+	* - open portals
+	*/
+	const utils::PortalInfo* bestMatch = nullptr;
+	for (auto& p : utils::GetPortalList())
+	{
+		if (!portalIsMatch(&p))
+			continue;
+		if (!bestMatch || (!bestMatch->isActivated && p.isActivated) || (!bestMatch->isOpen && p.isOpen))
+			bestMatch = &p;
+
+		if (lastUsed.handle.IsValid() && lastUsed.isOrange == p.isOrange
+		    && VectorsAreEqual(lastUsed.pos, p.pos, 1) && QAnglesAreEqual(lastUsed.ang, p.ang, 1))
+		{
+			bestMatch = &p;
+			break;
+		}
+	}
+
+	if (bestMatch)
+	{
+		lastUsed = *bestMatch;
+		return bestMatch;
 	}
 	else
 	{
-		portal = utils::GetClientEntity(portal_index);
+		lastUsed.Invalidate();
+		return nullptr;
 	}
-
-	return portal;
 }
 
 #endif

--- a/spt/utils/portal_utils.hpp
+++ b/spt/utils/portal_utils.hpp
@@ -8,22 +8,40 @@
 #include "engine\iserverplugin.h"
 #include "icliententity.h"
 #include "tier2\tier2.h"
+#include "spt\utils\ent_list.hpp"
 
-IClientEntity* getPortal(const char* arg, bool verbose);
-bool invalidPortal(IClientEntity* portal);
-IClientEntity* GetEnvironmentPortal();
-void calculateAGPosition(Vector& new_player_origin, QAngle& new_player_angles);
-void calculateAGOffsetPortal(IClientEntity* enter_portal,
-                             IClientEntity* exit_portal,
-                             Vector& new_player_origin,
-                             QAngle& new_player_angles);
-void transformThroughPortal(IClientEntity* saveglitch_portal,
+void calculateAGPosition(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles);
+void calculateAGOffsetPortal(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles);
+void transformThroughPortal(const utils::PortalInfo* portal,
                             const Vector& start_pos,
                             const QAngle start_angles,
                             Vector& transformed_origin,
                             QAngle& transformed_angles);
-void calculateSGPosition(Vector& new_player_origin, QAngle& new_player_angles);
-void calculateOffsetPlayer(IClientEntity* saveglitch_portal, Vector& new_player_origin, QAngle& new_player_angles);
-std::wstring calculateWillAGSG(Vector& new_player_origin, QAngle& new_player_angles);
+void calculateSGPosition(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles);
+void calculateOffsetPlayer(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles);
+std::wstring calculateWillAGSG(const utils::PortalInfo* portal, Vector& new_player_origin, QAngle& new_player_angles);
+
+/*
+* getPortal should be used for all portal selection cvars (e.g. spt_overlay_type). Before, all such
+* features used their own logic and behaved differently. This is especially annoying from a ImGui
+* perspective - ideally all the logic shoud be the same so that there can be a single function for
+* a portal selection widget. The macros here should be used for the description of these cvars.
+* 
+* Allowed options are: blue/orange/auto/env/overlay/<index>.
+*/
+
+// prepend to the rest of the description if getPortal(allowAuto=true) is used
+#define SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX \
+	"  - auto: prioritize the player's portal environment, otherwise uses last drawn portal\n"
+
+// prepend to the rest of the description if getPortal("overlay") is allowed
+#define SPT_PORTAL_SELECT_DESCRIPTION_OVERLAY_PREFIX "  - overlay: uses the same portal as spt_overlay_portal\n"
+
+#define SPT_PORTAL_SELECT_DESCRIPTION \
+	"  - env: draw using the player's portal environment\n" \
+	"  - blue/orange: use a specific portal color\n" \
+	"  - <index>: specify portal entity index"
+
+const utils::PortalInfo* getPortal(const char* arg, bool onlyOpen, bool allowAuto = true);
 
 #endif


### PR DESCRIPTION
Yet another big giant mega commit by me. So much for getting the player trace done in smaller commits...

The main purpose of these commits is to simplify entity and portal iteration. Server & client entity logic has been merged into `utils/ent_list.hpp` which all features have been changed to use. Also, pretty much all portal entity related logic now uses a convenient `utils::PortalInfo` type. Also also, `getPortal` has been made juicier and more powerful and all the portal selection cvars have been changed to use it.

The main reason the portal selection logic was changed is because I would like to continue on the path of ImGui glory, which means adding portal selection widgets. The problem is that all 4 portal selection cvars behave differently! The goal was to synchronize the behavior of all of the cvars (to a reasonable extent), so that way I wouldn't have to make 4 different ImGui widgets. The behavior of the portal selection for e.g. `spt_draw_portal_env_type` was relatively sophisticated, but I liked it more than the default logic for `spt_overlay_portal`; this is why the new `getPortal()` behavior much more closely mimics the former. 

After much discussion with bill, the result is basically 5 selectors:
- 'env': like the original 'auto' in `spt_overlay_portal`
- 'blue': like the original 'blue' in `spt_overlay_portal`, but prioritizes open & activated portals
- same thing for 'orange'
- 'auto': a heuristic based selector
- index

The 'blue', 'orange', and 'auto' selectors are stateful - they will remember the previously used blue portal and continue to use that. If the player enters a portal environment or the previously used portal selector used a matching portal, that portal will be used. This is in contrast to the old selectors in `spt_overlay_portal` which only choose the first matching portal. Features also get to say if they care about closed portals or not, so e.g. `spt_draw_vag_entry_portal` will never look for closed portals.

## User facing changes

- all entity index cvars (e.g. `spt_print_ents`, `spt_overlay_portal`, `spt_tas_aim_ent`, `spt_hud_ent_info`, etc) now use indices starting at 0 for world, 1 for player, etc. for both server *and* client
- `spt_print_ents` now also prints server entities
- `spt_print_portals` is now more accurate when the server is active
- `spt_tas_strafe_version` bumped to 8 (for backwards compatibility with the entity index logic for `spt_tas_aim_ent` & `spt_playerio.GetPlayerEyePos`)
- `spt_draw_map_overlay` now auto aligns adjacent maps to the currently loaded map

### Portal selection cvar changes:
- (`spt_overlay_portal`, `spt_draw_portal_env_type`, `spt_draw_vag_entry_portal`, `spt_vag_search_portal`) now all behave *mostly* the same
- new 'env' portal selection type added
- when using 'blue' or 'orange' as a portal selection type, the same 'blue' or 'orange' portal is used for all portal selection cvars
- when using 'blue' or 'orange' as a portal selection type, the priority is the player's environment portal, then open portals, then activated portals
- features that can't do anything with closed portals (all but `spt_draw_portal_env_type`) won't attempt to use closed portals anymore