### PR TITLE
ImGui portal selection & spt_set_sg

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1225,6 +1225,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\features\qccmd.cpp" />
     <ClCompile Include="spt\features\restart.cpp" />
     <ClCompile Include="spt\features\saveloads.cpp" />
+    <ClCompile Include="spt\features\set_sg.cpp" />
     <ClCompile Include="spt\features\shadow.cpp" />
     <ClCompile Include="spt\features\strafehud.cpp" />
     <ClCompile Include="spt\features\stucksave.cpp" />

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1461,7 +1461,6 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\features\visualizations\imgui\imgui_interface.hpp" />
     <ClInclude Include="spt\features\visualizations\imgui\imgui_styles.hpp" />
     <ClInclude Include="spt\features\visualizations\imgui\jetbrains_mono_bold.hpp" />
-    <ClInclude Include="spt\features\visualizations\renderer\create_collide.hpp" />
     <ClInclude Include="spt\features\visualizations\renderer\internal\internal_defs.hpp" />
     <ClInclude Include="spt\features\visualizations\renderer\internal\materials_manager.hpp" />
     <ClInclude Include="spt\features\visualizations\renderer\internal\mesh_builder_internal.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -409,6 +409,9 @@
     <ClCompile Include="spt\utils\map_utils.cpp">
       <Filter>spt\utils</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\set_sg.cpp">
+      <Filter>spt\features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/features/autojump.cpp
+++ b/spt/features/autojump.cpp
@@ -188,7 +188,7 @@ void AutojumpFeature::LoadFeature()
 			// dmomm
 			off_player_ptr = 4;
 
-		SptImGuiGroup::Cheats_Jumping.RegisterUserCallback(
+		SptImGuiGroup::Cheats_Misc_Jumping.RegisterUserCallback(
 		    []()
 		    {
 			    SptImGui::CvarCheckbox(y_spt_autojump, "##checkbox_autojump");
@@ -211,7 +211,7 @@ void AutojumpFeature::LoadFeature()
 	if (utils::DoesGameLookLikePortal() && ORIG_CGameMovement__AirMove && ORIG_CPortalGameMovement__AirMove)
 	{
 		InitConcommandBase(y_spt_aircontrol);
-		SptImGuiGroup::Cheats_HL2AirControl.RegisterUserCallback(
+		SptImGuiGroup::Cheats_Misc_HL2AirControl.RegisterUserCallback(
 		    []() { SptImGui::CvarCheckbox(y_spt_aircontrol, "##checkbox"); });
 	}
 }

--- a/spt/features/collision_group.cpp
+++ b/spt/features/collision_group.cpp
@@ -75,7 +75,7 @@ void CollisionGroup::LoadFeature()
 	if (ORIG_SetCollisionGroup)
 	{
 		InitCommand(y_spt_set_collision_group);
-		SptImGuiGroup::Cheats_PlayerCollisionGroup.RegisterUserCallback(ImGuiCallback);
+		SptImGuiGroup::Cheats_Misc_PlayerCollisionGroup.RegisterUserCallback(ImGuiCallback);
 	}
 }
 

--- a/spt/features/game_fixes/free_oob.cpp
+++ b/spt/features/game_fixes/free_oob.cpp
@@ -112,7 +112,7 @@ void FreeOobFeature::LoadFeature()
 				INIT_BYTE_REPLACE(SecondJump, cur);
 
 				InitConcommandBase(y_spt_free_oob);
-				SptImGuiGroup::Cheats_FreeOob.RegisterUserCallback(
+				SptImGuiGroup::Cheats_Misc_FreeOob.RegisterUserCallback(
 				    []() { SptImGui::CvarCheckbox(y_spt_free_oob, "##checkbox"); });
 				return;
 			}

--- a/spt/features/game_fixes/snapshot_overflow.cpp
+++ b/spt/features/game_fixes/snapshot_overflow.cpp
@@ -85,7 +85,7 @@ protected:
 			    spt_snapShotOverflow.SetOverwrite(((ConVar*)var)->GetBool());
 		    });
 
-		SptImGuiGroup::Cheats_SnapshotOverflow.RegisterUserCallback(
+		SptImGuiGroup::Cheats_Misc_SnapshotOverflow.RegisterUserCallback(
 		    []() { SptImGui::CvarCheckbox(spt_prevent_snapshot_overflow, "##checkbox"); });
 	};
 

--- a/spt/features/game_fixes/vag_crash.cpp
+++ b/spt/features/game_fixes/vag_crash.cpp
@@ -66,7 +66,7 @@ void VAG::LoadFeature()
 		InitConcommandBase(y_spt_prevent_vag_crash);
 		VagCrashSignal.Works = true;
 
-		SptImGuiGroup::Cheats_VagCrash.RegisterUserCallback(
+		SptImGuiGroup::Cheats_PortalSpecific_VagCrash.RegisterUserCallback(
 			[]() { SptImGui::CvarCheckbox(y_spt_prevent_vag_crash, "##checkbox"); });
 	}
 	recursiveTeleportCount = 0;

--- a/spt/features/isg.cpp
+++ b/spt/features/isg.cpp
@@ -91,7 +91,7 @@ void ISGFeature::LoadFeature()
 	    "isg", [](std::string) { spt_hud_feat.DrawTopHudElement(L"isg: %d", IsISGActive()); }, y_spt_hud_isg);
 #endif
 
-	SptImGuiGroup::Cheats_ISG.RegisterUserCallback(ImGuiCallback);
+	SptImGuiGroup::Cheats_Misc_ISG.RegisterUserCallback(ImGuiCallback);
 	if (hudCallbackEnabled)
 		SptImGui::RegisterHudCvarCheckbox(y_spt_hud_isg);
 }

--- a/spt/features/movement_vars.cpp
+++ b/spt/features/movement_vars.cpp
@@ -74,7 +74,7 @@ void VarChanger::LoadFeature()
 	{
 		ProcessMovementPre_Signal.Connect(ProcessMovementPre);
 		InitConcommandBase(spt_player_maxspeed);
-		SptImGuiGroup::Cheats_MaxSpeed.RegisterUserCallback(
+		SptImGuiGroup::Cheats_Misc_MaxSpeed.RegisterUserCallback(
 		    []()
 		    { SptImGui::CvarDouble(spt_player_maxspeed, "override max speed value", "enter float value"); });
 	}

--- a/spt/features/overlay.cpp
+++ b/spt/features/overlay.cpp
@@ -37,12 +37,16 @@ ConVar _y_spt_overlay_type("_y_spt_overlay_type",
                            4);
 
 #ifdef SPT_PORTAL_UTILS
+
+constexpr int SPT_PORTAL_SELECT_FLAGS = GPF_ALLOW_AUTO | GPF_ALLOW_PLAYER_ENV | GPF_ONLY_OPEN_PORTALS;
+
 ConVar _y_spt_overlay_portal(
     "_y_spt_overlay_portal",
     "env",
     FCVAR_CHEAT,
     "Chooses the portal for the overlay camera. For the SG camera this is the portal you save glitch on, for angle glitch simulation this is the portal you enter. Valid values are:\n"
-    "" SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION);
+    "" SPT_PORTAL_SELECT_DESCRIPTION_ENV_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX
+    "" SPT_PORTAL_SELECT_DESCRIPTION);
 #endif
 
 ConVar _y_spt_overlay_width("_y_spt_overlay_width",
@@ -94,7 +98,7 @@ namespace patterns
 #ifdef SPT_PORTAL_UTILS
 const utils::PortalInfo* Overlay::GetOverlayPortal()
 {
-	return getPortal(_y_spt_overlay_portal.GetString(), false, false);
+	return getPortal(_y_spt_overlay_portal.GetString(), SPT_PORTAL_SELECT_FLAGS);
 }
 #endif
 

--- a/spt/features/overlay.hpp
+++ b/spt/features/overlay.hpp
@@ -59,6 +59,7 @@ private:
 	void DrawCrosshair();
 	void ModifyView(CViewSetup* renderView);
 	void ModifyScreenFlags(int& clearFlags, int& drawFlags);
+	static void ImGuiCallback();
 };
 
 extern Overlay spt_overlay;

--- a/spt/features/pause.cpp
+++ b/spt/features/pause.cpp
@@ -136,7 +136,7 @@ void PauseFeature::LoadFeature()
 
 		InitConcommandBase(y_spt_pause);
 
-		SptImGuiGroup::Cheats_Pause.RegisterUserCallback(
+		SptImGuiGroup::Cheats_Misc_Pause.RegisterUserCallback(
 		    [pause1_works, pause2_works]()
 		    {
 			    const char* opts[] = {

--- a/spt/features/set_sg.cpp
+++ b/spt/features/set_sg.cpp
@@ -99,7 +99,7 @@ void SetSgFeature::ClearSg()
 void SetSgFeature::LoadFeature()
 {
 	InitCommand(spt_set_sg);
-	SptImGuiGroup::Cheats_SetSg.RegisterUserCallback(ImGuiCallback);
+	SptImGuiGroup::Cheats_PortalSpecific_SetSg.RegisterUserCallback(ImGuiCallback);
 }
 
 void SetSgFeature::ImGuiCallback()

--- a/spt/features/set_sg.cpp
+++ b/spt/features/set_sg.cpp
@@ -1,0 +1,128 @@
+#include "stdafx.hpp"
+#include "..\feature.hpp"
+
+#include "spt\utils\game_detection.hpp"
+#include "spt\utils\portal_utils.hpp"
+#include "visualizations\imgui\imgui_interface.hpp"
+#include "ent_props.hpp"
+
+#ifdef SPT_PORTAL_UTILS
+
+class SetSgFeature : public FeatureWrapper<SetSgFeature>
+{
+public:
+	static const utils::PortalInfo* SetSg(const char* portal, const char** errMsg);
+	static const utils::PortalInfo* SetSg(int portalIdx, const char** errMsg);
+	static void ClearSg();
+
+protected:
+	virtual bool ShouldLoadFeature() override
+	{
+		return utils::DoesGameLookLikePortal();
+	};
+
+	virtual void LoadFeature() override;
+
+private:
+	static void ImGuiCallback();
+};
+
+static SetSgFeature spt_set_sg_feat;
+
+constexpr int SPT_PORTAL_SELECT_FLAGS = GPF_NONE;
+
+CON_COMMAND_F(spt_set_sg,
+              "Set the SG to the given portal. Valid options are:\n" SPT_PORTAL_SELECT_DESCRIPTION
+              "\n  - clear: clears SG",
+              FCVAR_DONTRECORD)
+{
+	if (args.ArgC() != 2)
+	{
+		Msg("Usage: %s [blue/orange/<index>/clear]\n", spt_set_sg_command.GetName());
+		return;
+	}
+	const char* errMsg = nullptr;
+	auto sgPortal = spt_set_sg_feat.SetSg(args[1], &errMsg);
+	if (sgPortal)
+		Msg("Set SG on portal index %d\n", sgPortal->handle.GetEntryIndex());
+	else if (errMsg)
+		Warning("Failed to set SG: %s\n", errMsg);
+}
+
+const utils::PortalInfo* SetSgFeature::SetSg(const char* portal, const char** errMsg)
+{
+	auto serverPlayer = utils::spt_serverEntList.GetPlayer();
+	if (!serverPlayer)
+	{
+		*errMsg = "player not found.";
+		return nullptr;
+	}
+
+	static utils::CachedField<CBaseHandle, "CPortal_Player", "m_hPortalEnvironment", true> fPortalEnv;
+	if (!fPortalEnv.Exists())
+	{
+		*errMsg = "CPortal_Player::m_hPortalEnvironment not found.";
+		return nullptr;
+	}
+
+	if (!stricmp(portal, "clear"))
+	{
+		fPortalEnv.GetPtr(serverPlayer)->Term();
+		return nullptr;
+	}
+
+	auto newSgPortal = getPortal(portal, SPT_PORTAL_SELECT_FLAGS);
+
+	if (!newSgPortal)
+	{
+		*errMsg = "portal not found.";
+		return nullptr;
+	}
+
+	*fPortalEnv.GetPtr(serverPlayer) = newSgPortal->handle;
+	return newSgPortal;
+}
+
+const utils::PortalInfo* SetSgFeature::SetSg(int portalIdx, const char** errMsg)
+{
+	char buf[32];
+	snprintf(buf, sizeof buf, "%d", portalIdx);
+	return SetSg(buf, errMsg);
+}
+
+void SetSgFeature::ClearSg()
+{
+	const char* dummy;
+	SetSg("clear", &dummy);
+}
+
+void SetSgFeature::LoadFeature()
+{
+	InitCommand(spt_set_sg);
+	SptImGuiGroup::Cheats_SetSg.RegisterUserCallback(ImGuiCallback);
+}
+
+void SetSgFeature::ImGuiCallback()
+{
+	static SptImGui::TimedToolTip errTip;
+	static SptImGui::PortalSelectionPersist persist;
+	auto envPortal = utils::spt_serverEntList.GetEnvironmentPortal();
+	persist.selectedPortalIdx = envPortal ? envPortal->handle.GetEntryIndex() : -1;
+	SptImGui::PortalSelectionWidget(persist, SPT_PORTAL_SELECT_FLAGS);
+	if (persist.userSelectedPortalByIndexLastCall)
+	{
+		if (spt_set_sg_feat.SetSg(persist.selectedPortalIdx, &errTip.text))
+			errTip.StopShowing();
+		else
+			errTip.StartShowing();
+	}
+	errTip.Show(SPT_IMGUI_WARN_COLOR_YELLOW, 3);
+
+	if (ImGui::Button("Clear SG"))
+	{
+		ClearSg();
+		errTip.StopShowing();
+	}
+}
+
+#endif

--- a/spt/features/shadow.cpp
+++ b/spt/features/shadow.cpp
@@ -96,7 +96,7 @@ void ShadowPosition::LoadFeature()
 	{
 		InitCommand(y_spt_set_shadow_roll);
 
-		SptImGuiGroup::Cheats_PlayerShadow.RegisterUserCallback(
+		SptImGuiGroup::Cheats_Misc_PlayerShadow.RegisterUserCallback(
 		    []()
 		    {
 			    static double df = 0.f;

--- a/spt/features/strafehud.cpp
+++ b/spt/features/strafehud.cpp
@@ -77,9 +77,9 @@ ConVar spt_strafehud_detail_scale("spt_strafehud_detail_scale",
                                   FCVAR_CHEAT,
                                   "The detail scale for the lines of the strafe HUD.",
                                   true,
-                                  0,
+                                  1,
                                   true,
-                                  645);
+                                  15);
 ConVar spt_strafehud_lock_mode("spt_strafehud_lock_mode",
                                "1",
                                FCVAR_CHEAT,

--- a/spt/features/tickrate.cpp
+++ b/spt/features/tickrate.cpp
@@ -85,7 +85,7 @@ void TickrateMod::LoadFeature()
 		{
 			InitCommand(_y_spt_tickrate);
 
-			SptImGuiGroup::Cheats_Tickrate.RegisterUserCallback(
+			SptImGuiGroup::Cheats_Misc_Tickrate.RegisterUserCallback(
 			    []()
 			    {
 				    ImGui::Text("Current tickrate: %g", spt_tickrate.GetTickrate());

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -138,7 +138,7 @@ void VagSearcher::LoadFeature()
 	{
 		VagCrashSignal.Connect(this, &VagSearcher::VagCrashTriggered);
 	}
-	SptImGuiGroup::Cheats_VagSearch.RegisterUserCallback(ImGuiCallback);
+	SptImGuiGroup::Cheats_PortalSpecific_VagSearch.RegisterUserCallback(ImGuiCallback);
 }
 
 void VagSearcher::UnloadFeature() {}

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -293,22 +293,15 @@ void VagSearcher::OnTick(bool simulating)
 
 void VagSearcher::ImGuiCallback()
 {
-	static const char* lastErrMsg = nullptr;
-	static double lastErrMsgStartTime = -666;
-
+	static SptImGui::TimedToolTip errTip;
 	if (SptImGui::CmdButton("Start search", y_spt_vag_search_command))
 	{
-		if (spt_vag_searcher.StartSearch(&lastErrMsg))
-			lastErrMsgStartTime = -666;
+		if (spt_vag_searcher.StartSearch(&errTip.text))
+			errTip.StopShowing();
 		else
-			lastErrMsgStartTime = ImGui::GetTime();
+			errTip.StartShowing();
 	}
-	if (lastErrMsg && ImGui::GetTime() - lastErrMsgStartTime < 3)
-	{
-		ImGui::PushStyleColor(ImGuiCol_Text, SPT_IMGUI_WARN_COLOR_YELLOW);
-		ImGui::SetTooltip("%s", lastErrMsg);
-		ImGui::PopStyleColor();
-	}
+	errTip.Show(SPT_IMGUI_WARN_COLOR_YELLOW, 3);
 
 	static SptImGui::PortalSelectionPersist persist;
 	SptImGui::PortalSelectionWidgetCvar(y_spt_vag_search_portal, persist, SPT_PORTAL_SELECT_FLAGS);

--- a/spt/features/vag_searcher.cpp
+++ b/spt/features/vag_searcher.cpp
@@ -76,6 +76,8 @@ private:
 
 VagSearcher spt_vag_searcher;
 
+constexpr int SPT_PORTAL_SELECT_FLAGS = GPF_ALLOW_OVERLAY | GPF_ONLY_OPEN_PORTALS;
+
 ConVar y_spt_vag_search_portal("y_spt_vag_search_portal",
                                "overlay",
                                FCVAR_CHEAT,
@@ -92,7 +94,7 @@ void VagSearcher::StartSearch()
 	if (IsIterating())
 		return;
 
-	enter_portal = getPortal(y_spt_vag_search_portal.GetString(), true, false);
+	enter_portal = getPortal(y_spt_vag_search_portal.GetString(), SPT_PORTAL_SELECT_FLAGS);
 
 	if (!enter_portal || !enter_portal->linkedHandle.IsValid())
 	{

--- a/spt/features/visualizations/draw_line.cpp
+++ b/spt/features/visualizations/draw_line.cpp
@@ -162,12 +162,13 @@ void DrawLine::ImGuiCallback()
 		focusIdx = -1;
 		recompute = true;
 	}
-	ImGui::SameLine();
 	int importType = 0;
-	if (ImGui::Button("Import from clipboard (replace)"))
+	ImGui::Text("Import from clipboard:");
+	ImGui::SameLine();
+	if (ImGui::Button("Replace"))
 		importType = 1;
 	ImGui::SameLine();
-	if (ImGui::Button("Import from clipboard (append)"))
+	if (ImGui::Button("Append"))
 		importType = 2;
 	if (importType)
 	{
@@ -229,7 +230,6 @@ void DrawLine::ImGuiCallback()
 		}
 	}
 	errTip.Show(SPT_IMGUI_WARN_COLOR_YELLOW, 2.0);
-	ImGui::SameLine();
 	if (ImGui::Button("Export to clipboard"))
 	{
 		ImGui::LogToClipboard();

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -202,6 +202,7 @@ namespace SptImGuiGroup
 	// cheats - stuff that changes gameplay or cannot be done via normal means
 	inline Tab Cheats{"Cheats", &Root};
 	inline Section Cheats_Jumping{"Jumping", &Cheats};
+	inline Section Cheats_SetSg{"Set SG", &Cheats};
 	inline Section Cheats_HL2AirControl{"HL2 air control", &Cheats};
 	inline Section Cheats_ISG{"ISG", &Cheats};
 	inline Section Cheats_SnapshotOverflow{"Snapshot overflow fix", &Cheats};

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -423,6 +423,47 @@ public:
 	                                                          int getPortalFlags);
 
 #endif
+
+	/*
+	* Useful for short timed error messages, e.g. user pressed a button but something failed
+	* internally. To use, create a static instance of this and always call Show(). Call
+	* StartShowing(text) to display a tooltip, or set the text first then call StartShowing().
+	*/
+	struct TimedToolTip
+	{
+		const char* text = nullptr;
+		double lastStartDisplayTime = -666;
+
+		bool Show(const ImVec4& color, double duration) const
+		{
+			if (text && ImGui::GetTime() - lastStartDisplayTime < duration)
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, color);
+				ImGui::SetTooltip("%s", text);
+				ImGui::PopStyleColor();
+				return true;
+			}
+			return false;
+		}
+
+		// newText must remain a valid pointer while showing
+		void StartShowing(const char* newText)
+		{
+			text = newText;
+			StartShowing();
+		}
+
+		void StartShowing()
+		{
+			lastStartDisplayTime = ImGui::GetTime();
+		}
+
+		void StopShowing()
+		{
+			text = nullptr;
+			lastStartDisplayTime = -666;
+		}
+	};
 };
 
 inline ConCommand spt_gui{

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -174,9 +174,9 @@ namespace SptImGuiGroup
 	// drawing visualizations
 	inline Tab Draw{"Drawing", &Root};
 	inline Tab Draw_Collides{"Collision", &Draw};
-	inline Section Draw_Collides_World{"World collides", &Draw_Collides};
-	inline Section Draw_Collides_Ents{"Entity collides", &Draw_Collides};
-	inline Section Draw_Collides_PortalEnv{"Portal environment collision", &Draw_Collides};
+	inline Tab Draw_Collides_World{"World collides", &Draw_Collides};
+	inline Tab Draw_Collides_Ents{"Entity collides", &Draw_Collides};
+	inline Tab Draw_Collides_PortalEnv{"Portal environment collision", &Draw_Collides};
 	inline Tab Draw_MapOverlay{"Map overlay", &Draw};
 	inline Tab Draw_PpPlacement{"Portal placement", &Draw};
 	inline Section Draw_PpPlacement_Gun{"Gun portal placement", &Draw_PpPlacement};
@@ -201,19 +201,21 @@ namespace SptImGuiGroup
 
 	// cheats - stuff that changes gameplay or cannot be done via normal means
 	inline Tab Cheats{"Cheats", &Root};
-	inline Section Cheats_Jumping{"Jumping", &Cheats};
-	inline Section Cheats_SetSg{"Set SG", &Cheats};
-	inline Section Cheats_HL2AirControl{"HL2 air control", &Cheats};
-	inline Section Cheats_ISG{"ISG", &Cheats};
-	inline Section Cheats_SnapshotOverflow{"Snapshot overflow fix", &Cheats};
-	inline Section Cheats_VagCrash{"Prevent VAG crash", &Cheats};
-	inline Section Cheats_VagSearch{"VAG search", &Cheats};
-	inline Section Cheats_PlayerShadow{"Player shadow", &Cheats};
-	inline Section Cheats_Pause{"Pause on load", &Cheats};
-	inline Section Cheats_FreeOob{"Free OOB", &Cheats};
-	inline Section Cheats_PlayerCollisionGroup{"Player collision group", &Cheats};
-	inline Section Cheats_MaxSpeed{"Max speed", &Cheats};
-	inline Section Cheats_Tickrate{"Tickrate", &Cheats};
+	inline Tab Cheats_PortalSpecific{"Portal specific", &Cheats};
+	inline Section Cheats_PortalSpecific_SetSg{"Set SG", &Cheats_PortalSpecific};
+	inline Section Cheats_PortalSpecific_VagCrash{"Prevent VAG crash", &Cheats_PortalSpecific};
+	inline Section Cheats_PortalSpecific_VagSearch{"VAG search", &Cheats_PortalSpecific};
+	inline Tab Cheats_Misc{"Misc", &Cheats};
+	inline Section Cheats_Misc_Jumping{"Jumping", &Cheats_Misc};
+	inline Section Cheats_Misc_HL2AirControl{"HL2 air control", &Cheats_Misc};
+	inline Section Cheats_Misc_ISG{"ISG", &Cheats_Misc};
+	inline Section Cheats_Misc_SnapshotOverflow{"Snapshot overflow fix", &Cheats_Misc};
+	inline Section Cheats_Misc_PlayerShadow{"Player shadow", &Cheats_Misc};
+	inline Section Cheats_Misc_Pause{"Pause on load", &Cheats_Misc};
+	inline Section Cheats_Misc_FreeOob{"Free OOB", &Cheats_Misc};
+	inline Section Cheats_Misc_PlayerCollisionGroup{"Player collision group", &Cheats_Misc};
+	inline Section Cheats_Misc_MaxSpeed{"Max speed", &Cheats_Misc};
+	inline Section Cheats_Misc_Tickrate{"Tickrate", &Cheats_Misc};
 
 	// spt_hud and friends
 	inline Tab Hud{"HUD", &Root};

--- a/spt/features/visualizations/map_overlay.cpp
+++ b/spt/features/visualizations/map_overlay.cpp
@@ -380,14 +380,16 @@ void MapOverlay::ImGuiCallback()
 	static SptImGui::AutocompletePersistData acPersist;
 	static bool ztest = true;
 
-	static double errMsgStartTime = -666;
-	static const char* errMsg;
+	static SptImGui::TimedToolTip errTip;
 
 	ConCommand& cmd = spt_draw_map_overlay_command;
 	const char* cmdName = WrangleLegacyCommandName(cmd.GetName(), true, nullptr);
 
 	if (ImGui::Button("Clear"))
+	{
 		ClearMeshes();
+		errTip.StopShowing();
+	}
 	if (ImGui::BeginItemTooltip())
 	{
 		ImGui::Text("%s 0", cmdName);
@@ -397,8 +399,10 @@ void MapOverlay::ImGuiCallback()
 	ImGui::SameLine();
 	if (ImGui::Button("Draw map"))
 	{
-		if (!LoadMapFile(acPersist.textInput, ztest, &errMsg))
-			errMsgStartTime = ImGui::GetTime();
+		if (LoadMapFile(acPersist.textInput, ztest, &errTip.text))
+			errTip.StopShowing();
+		else
+			errTip.StartShowing();
 	}
 	if (ImGui::BeginItemTooltip())
 	{
@@ -414,12 +418,7 @@ void MapOverlay::ImGuiCallback()
 		ImGui::EndTooltip();
 	}
 
-	if (errMsg && ImGui::GetTime() - errMsgStartTime < 2)
-	{
-		ImGui::PushStyleColor(ImGuiCol_Text, SPT_IMGUI_WARN_COLOR_YELLOW);
-		ImGui::SetTooltip("%s", errMsg);
-		ImGui::PopStyleColor();
-	}
+	errTip.Show(SPT_IMGUI_WARN_COLOR_YELLOW, 2.0);
 
 	ImGui::SameLine();
 	SptImGui::HelpMarker("%s", cmd.GetHelpText());

--- a/spt/features/visualizations/sg-collide-vis.cpp
+++ b/spt/features/visualizations/sg-collide-vis.cpp
@@ -28,12 +28,15 @@ ConVar y_spt_draw_portal_env("y_spt_draw_portal_env",
                              "   - blue: world geometry behind the portal\n"
                              "   - yellow: static props");
 
+constexpr int SPT_PORTAL_SELECT_FLAGS = GPF_ALLOW_AUTO | GPF_ALLOW_PLAYER_ENV;
+
 ConVar y_spt_draw_portal_env_type(
     "y_spt_draw_portal_env_type",
     "auto",
     FCVAR_CHEAT | FCVAR_DONTRECORD,
     "This determines what portal to use for all spt_draw_portal_* cvars. Valid values are:\n"
-    "" SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION);
+    "" SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION_ENV_PREFIX
+    "" SPT_PORTAL_SELECT_DESCRIPTION);
 
 ConVar y_spt_draw_portal_env_ents(
     "y_spt_draw_portal_env_ents",
@@ -177,7 +180,8 @@ public:
 			cache.Clear();
 			return;
 		}
-		const utils::PortalInfo* newPortal = getPortal(y_spt_draw_portal_env_type.GetString(), false, true);
+		const utils::PortalInfo* newPortal =
+		    getPortal(y_spt_draw_portal_env_type.GetString(), SPT_PORTAL_SELECT_FLAGS);
 
 		if (!newPortal)
 			return;

--- a/spt/features/visualizations/sg-collide-vis.cpp
+++ b/spt/features/visualizations/sg-collide-vis.cpp
@@ -7,7 +7,6 @@
 #include "predictable_entity.h"
 #include "dt_common.h"
 #include "collisionproperty.h"
-#include "vphysics_interface.h"
 
 #include "interfaces.hpp"
 #include "spt\feature.hpp"
@@ -16,6 +15,7 @@
 #include "spt\utils\portal_utils.hpp"
 #include "spt\features\ent_props.hpp"
 #include "spt\features\create_collide.hpp"
+#include "imgui\imgui_interface.hpp"
 
 using interfaces::engine_server;
 
@@ -162,6 +162,8 @@ public:
 		InitConcommandBase(y_spt_draw_portal_env_type);
 		InitConcommandBase(y_spt_draw_portal_env_ents);
 		InitConcommandBase(y_spt_draw_portal_env_remote);
+
+		SptImGuiGroup::Draw_Collides_PortalEnv.RegisterUserCallback(ImGuiCallback);
 	}
 
 	virtual void UnloadFeature() override
@@ -413,6 +415,16 @@ public:
 			            infoOut.mat = entMat;
 			            RenderCallbackZFightFix(infoIn, infoOut);
 		            });
+	}
+
+	static void ImGuiCallback()
+	{
+		ImGui::BeginDisabled(!SptImGui::CvarCheckbox(y_spt_draw_portal_env, "Draw portal geometry"));
+		SptImGui::CvarCheckbox(y_spt_draw_portal_env_ents, "Draw portal entities");
+		SptImGui::CvarCheckbox(y_spt_draw_portal_env_remote, "Draw remote portal geometry");
+		static SptImGui::PortalSelectionPersist persist;
+		SptImGui::PortalSelectionWidgetCvar(y_spt_draw_portal_env_type, persist, SPT_PORTAL_SELECT_FLAGS);
+		ImGui::EndDisabled();
 	}
 };
 

--- a/spt/features/visualizations/vag_trace.cpp
+++ b/spt/features/visualizations/vag_trace.cpp
@@ -20,12 +20,15 @@ ConVar y_spt_draw_vag_target_trace("y_spt_draw_vag_target_trace",
                                    FCVAR_CHEAT,
                                    "Draw where to place wall/floor/ceiling portal to get to VAG target");
 
+constexpr int SPT_PORTAL_SELECT_FLAGS = GPF_ALLOW_AUTO | GPF_ALLOW_OVERLAY | GPF_ONLY_OPEN_PORTALS;
+
 ConVar y_spt_draw_vag_entry_portal(
     "y_spt_draw_vag_entry_portal",
     "overlay",
     FCVAR_CHEAT,
     "Chooses the portal for the VAG trace, this is the portal you enter. Valid options are:\n"
-    "" SPT_PORTAL_SELECT_DESCRIPTION_OVERLAY_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION);
+    "" SPT_PORTAL_SELECT_DESCRIPTION_OVERLAY_PREFIX "" SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX
+    "" SPT_PORTAL_SELECT_DESCRIPTION);
 
 ConVar y_spt_draw_vag_lock_entry("y_spt_draw_vag_lock_entry",
                                  "1",
@@ -157,7 +160,9 @@ void VagTrace::OnMeshRenderSignal(MeshRendererDelegate& mr)
 		            { MatrixSetColumn(target, 3, infoOut.mat); });
 	}
 
-	const utils::PortalInfo* newPortal = getPortal(y_spt_draw_vag_entry_portal.GetString(), true, false);
+	const utils::PortalInfo* newPortal =
+	    getPortal(y_spt_draw_vag_entry_portal.GetString(), SPT_PORTAL_SELECT_FLAGS);
+
 	if (!newPortal)
 	{
 		cache.entryPortal.Invalidate();

--- a/spt/utils/portal_utils.hpp
+++ b/spt/utils/portal_utils.hpp
@@ -30,18 +30,29 @@ std::wstring calculateWillAGSG(const utils::PortalInfo* portal, Vector& new_play
 * Allowed options are: blue/orange/auto/env/overlay/<index>.
 */
 
-// prepend to the rest of the description if getPortal(allowAuto=true) is used
+// prepend to the rest of the description if GPF_ALLOW_AUTO is used
 #define SPT_PORTAL_SELECT_DESCRIPTION_AUTO_PREFIX \
 	"  - auto: prioritize the player's portal environment, otherwise uses last drawn portal\n"
 
-// prepend to the rest of the description if getPortal("overlay") is allowed
+// prepend to the rest of the description if GPF_ALLOW_OVERLAY is allowed
 #define SPT_PORTAL_SELECT_DESCRIPTION_OVERLAY_PREFIX "  - overlay: uses the same portal as spt_overlay_portal\n"
 
+// prepend to the rest of the description if GPF_ALLOW_PLAYER_ENV is allowed
+#define SPT_PORTAL_SELECT_DESCRIPTION_ENV_PREFIX "  - env: use the player's portal environment\n"
+
 #define SPT_PORTAL_SELECT_DESCRIPTION \
-	"  - env: draw using the player's portal environment\n" \
 	"  - blue/orange: use a specific portal color\n" \
 	"  - <index>: specify portal entity index"
 
-const utils::PortalInfo* getPortal(const char* arg, bool onlyOpen, bool allowAuto = true);
+enum GetPortalFlags
+{
+	GPF_NONE = 0,
+	GPF_ONLY_OPEN_PORTALS = 1 << 0,
+	GPF_ALLOW_AUTO = 1 << 1,
+	GPF_ALLOW_OVERLAY = 1 << 2,
+	GPF_ALLOW_PLAYER_ENV = 1 << 3,
+};
+
+const utils::PortalInfo* getPortal(const char* arg, int getPortalFlags);
 
 #endif


### PR DESCRIPTION
## Internal changes
- `getPortal(const char* arg, bool, bool)` -> `getPortal(const char* arg, flags)`: I have three cases of slightly different types of portal selection behavior and it's much easier to deal with flags than a bunch of bools
- `SptImgui::TimedTooltip`: a pattern I've been using a bunch in ImGui is 'press button' -> 'display tooltip for x seconds if button fails'
![timed_tooltip_ex](https://github.com/user-attachments/assets/8659f1bd-ab97-4fe4-bebb-a1a8e802fecd)

## User changes
- All portal selection cvars now have a corresponding widget in ImGui
- Added `spt_set_sg` (and a corresponding section @ `Cheats/Portal specific/Set SG`)
- Organized ImGui tabs a little bit

https://github.com/user-attachments/assets/b2c1121c-7698-462a-a39d-633865a853e1