### PR TITLE
Some uninitialized crap in strafe type 2

### DIFF
--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -364,6 +364,8 @@ Strafe::PlayerData PlayerIOFeature::GetPlayerData()
 		return Strafe::PlayerData();
 
 	Strafe::PlayerData data;
+	if (tas_strafe_version.GetInt() >= 9)
+		data.Init();
 	const int IN_DUCK = 1 << 2;
 
 	data.Ducking = GetFlagsDucking();

--- a/spt/features/tas.cpp
+++ b/spt/features/tas.cpp
@@ -100,7 +100,7 @@ ConVar tas_force_onground(
     FCVAR_TAS_RESET,
     "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 ConVar tas_strafe_version("tas_strafe_version",
-                          "8",
+                          "9",
                           FCVAR_TAS_RESET,
                           "Strafe version. For backwards compatibility with old scripts.");
 

--- a/spt/strafe/strafestuff.cpp
+++ b/spt/strafe/strafestuff.cpp
@@ -595,6 +595,8 @@ namespace Strafe
 
 		Vector2D avec(std::cos(theta), std::sin(theta));
 		PlayerData vel;
+		if (tas_strafe_version.GetInt() >= 9)
+			vel.Init();
 		vel.Velocity.x = player.Velocity.Length2D();
 		VectorFME(vel, vars, onground, wishspeed, avec);
 

--- a/spt/strafe/strafestuff.hpp
+++ b/spt/strafe/strafestuff.hpp
@@ -60,6 +60,15 @@ namespace Strafe
 		Vector Basevelocity;
 		bool Ducking;
 		bool DuckPressed;
+
+		void Init()
+		{
+			UnduckedOrigin = vec3_origin;
+			Velocity = vec3_origin;
+			Basevelocity = vec3_origin;
+			Ducking = false;
+			DuckPressed = false;
+		}
 	};
 
 	enum class Button : unsigned char


### PR DESCRIPTION
strafe_type 2 was throwing an assert from the SDK when initializing Vector2 with some NAN values. I'm not familiar with how this strafing code works - it's entirely possible that it all worked fine and the assert can be ignored in this specific code path. Regardless, it makes strafe type 2 annoying to use in a Debug build.