### PR TITLE
Remove json lib from PCH

### DIFF
--- a/SDK/bms_new/include/public/video/ivideoservices.h
+++ b/SDK/bms_new/include/public/video/ivideoservices.h
@@ -27,9 +27,7 @@
 #endif
 
 
-#ifndef nullptr
-	#define nullptr		( 0 )
-#endif
+
 #ifndef INT32_MAX
 #define INT32_MAX    (0x7FFFFFFF)
 #endif

--- a/SDK/sdk2013_new/include/public/video/ivideoservices.h
+++ b/SDK/sdk2013_new/include/public/video/ivideoservices.h
@@ -27,9 +27,6 @@
 #endif
 
 
-#ifndef nullptr
-	#define nullptr		( 0 )
-#endif
 #ifndef INT32_MAX
 #define INT32_MAX    (0x7FFFFFFF)
 #endif

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1609,7 +1609,6 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\utils\spt_vprof.hpp" />
     <ClInclude Include="spt\utils\stdafx.hpp" />
     <ClInclude Include="spt\utils\string_utils.hpp" />
-    <ClInclude Include="spt\utils\typeinfo.h" />
     <ClInclude Include="spt\utils\vcall.hpp" />
     <ClInclude Include="spt\vgui\vgui_utils.hpp" />
     <ClInclude Include="thirdparty\curl\include\curl\curl.h" />

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1631,6 +1631,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="thirdparty\imgui\imstb_textedit.h" />
     <ClInclude Include="thirdparty\imgui\imstb_truetype.h" />
     <ClInclude Include="thirdparty\json.hpp" />
+    <ClInclude Include="thirdparty\json_spt_include.hpp" />
     <ClInclude Include="thirdparty\kmp-cpp.hpp" />
     <ClInclude Include="thirdparty\md5.hpp" />
     <ClInclude Include="thirdparty\Signal.h" />

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1392,15 +1392,96 @@ del "$(OutDir)spt-version.obj"</Command>
     </ClCompile>
     <ClCompile Include="spt\utils\string_utils.cpp" />
     <ClCompile Include="spt\vgui\vgui_utils.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui_demo.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui_draw.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui_impl_dx9.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui_impl_win32.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui_tables.cpp" />
-    <ClCompile Include="thirdparty\imgui\imgui_widgets.cpp" />
-    <ClCompile Include="thirdparty\md5.cpp" />
-    <ClCompile Include="thirdparty\x86.c" />
+    <ClCompile Include="thirdparty\imgui\imgui.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\imgui\imgui_demo.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\imgui\imgui_draw.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\imgui\imgui_impl_dx9.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\imgui\imgui_impl_win32.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\imgui\imgui_tables.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\imgui\imgui_widgets.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\md5.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="thirdparty\x86.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug 2013|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug OE|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug BMS|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release 2013|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h" />
@@ -1582,6 +1663,7 @@ del "$(OutDir)spt-version.obj"</Command>
   <ItemGroup>
     <Text Include="spt\features\template.cpp.txt" />
     <Text Include="thirdparty\example.txt" />
+    <Text Include="thirdparty\xz\readme.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="thirdparty\imgui\README" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -1042,6 +1042,9 @@
     <Text Include="spt\features\template.cpp.txt">
       <Filter>spt\features</Filter>
     </Text>
+    <Text Include="thirdparty\xz\readme.txt">
+      <Filter>thirdparty\xz</Filter>
+    </Text>
   </ItemGroup>
   <ItemGroup>
     <None Include="thirdparty\imgui\README">

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -939,6 +939,9 @@
     <ClInclude Include="spt\utils\vcall.hpp">
       <Filter>spt\utils</Filter>
     </ClInclude>
+    <ClInclude Include="thirdparty\json_spt_include.hpp">
+      <Filter>thirdparty</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="SDK includes &amp; libs">

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -708,9 +708,6 @@
     <ClInclude Include="spt\scripts2\variable_container2.hpp">
       <Filter>spt\scripts2</Filter>
     </ClInclude>
-    <ClInclude Include="spt\utils\typeinfo.h">
-      <Filter>spt\utils</Filter>
-    </ClInclude>
     <ClInclude Include="spt\utils\portal_utils.hpp">
       <Filter>spt\utils</Filter>
     </ClInclude>

--- a/spt/features/ipc-spt.cpp
+++ b/spt/features/ipc-spt.cpp
@@ -2,7 +2,7 @@
 #include "..\feature.hpp"
 #include "convar.hpp"
 #include "file.hpp"
-#include "thirdparty\json.hpp"
+#include "thirdparty\json_spt_include.hpp"
 #include "ent_utils.hpp"
 #include "property_getter.hpp"
 #include "signals.hpp"

--- a/spt/features/ipc-spt.cpp
+++ b/spt/features/ipc-spt.cpp
@@ -85,7 +85,7 @@ namespace ipc
 
 	void Init()
 	{
-		ipc::AddPrintFunc(MsgWrapper);
+		ipc::AddIpcPrintFunc(MsgWrapper);
 		if (y_spt_ipc.GetBool())
 		{
 			StartIPC();

--- a/spt/features/updater.cpp
+++ b/spt/features/updater.cpp
@@ -2,7 +2,7 @@
 
 #ifdef _WIN32
 
-#include "thirdparty\json.hpp"
+#include "thirdparty\json_spt_include.hpp"
 #include "game_detection.hpp"
 #include "interfaces.hpp"
 #include "file.hpp"

--- a/spt/features/visualizations/imgui/imgui_interface.cpp
+++ b/spt/features/visualizations/imgui/imgui_interface.cpp
@@ -15,7 +15,7 @@
 #include "thirdparty/imgui/imgui_impl_win32.h"
 
 #include "thirdparty/x86.h"
-#include "thirdparty/json.hpp"
+#include "thirdparty/json_spt_include.hpp"
 #include "thirdparty/curl/include/curl/curlver.h"
 #include "thirdparty/xz/include/lzma.h"
 

--- a/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
+++ b/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
@@ -1,5 +1,6 @@
 #include <stdafx.hpp>
 #include <inttypes.h>
+#include <array>
 
 #include "imgui_interface.hpp"
 #include "thirdparty/imgui/imgui_internal.h"

--- a/spt/ipc/ipc.cpp
+++ b/spt/ipc/ipc.cpp
@@ -10,7 +10,7 @@
 
 using namespace ipc;
 
-static PrintFunc PRINT_FUNC = nullptr;
+static IpcPrintFunc PRINT_FUNC = nullptr;
 static bool WINSOCK_INITIALIZED = false;
 static u_long BLOCKING = 1;
 const int BUFLEN = 32767;
@@ -59,7 +59,7 @@ void ipc::InitWinsock()
 	WINSOCK_INITIALIZED = true;
 }
 
-void ipc::AddPrintFunc(PrintFunc func)
+void ipc::AddIpcPrintFunc(IpcPrintFunc func)
 {
 	PRINT_FUNC = func;
 }

--- a/spt/ipc/ipc.hpp
+++ b/spt/ipc/ipc.hpp
@@ -1,7 +1,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "thirdparty\json.hpp"
+#include "thirdparty\json_spt_include.hpp"
 
 namespace ipc
 {

--- a/spt/ipc/ipc.hpp
+++ b/spt/ipc/ipc.hpp
@@ -5,14 +5,14 @@
 
 namespace ipc
 {
-	typedef void (*PrintFunc)(const char* msg);
+	typedef void (*IpcPrintFunc)(const char* msg);
 	typedef void (*MsgCallback)(const nlohmann::json& msg);
 
 	void Print(const char* msg, ...);
 	void Shutdown_IPC();
 	bool Winsock_Initialized();
 	void InitWinsock();
-	void AddPrintFunc(PrintFunc func);
+	void AddIpcPrintFunc(IpcPrintFunc func);
 
 	class IPCServer
 	{

--- a/spt/utils/stdafx.hpp
+++ b/spt/utils/stdafx.hpp
@@ -1,10 +1,7 @@
-#include <codecvt>
-#include <cstddef>
-#include <cstdint>
+#pragma once
+
 #include <fstream>
 #include <future>
-#include <iomanip>
-#include <locale>
 #include <map>
 #include <sstream>
 #include <string>
@@ -12,17 +9,3 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
-
-// Some hacks to make this json library behave well with its disgusting macros
-
-#ifdef null
-#undef null
-#endif
-
-#include "thirdparty\json.hpp"
-#undef and
-#undef or
-
-// Remove min/max definitions from some SDK versions
-#undef min
-#undef max

--- a/spt/utils/typeinfo.h
+++ b/spt/utils/typeinfo.h
@@ -1,4 +1,0 @@
-#pragma once
-// MSVC 14.23+ workaround
-// Required in Debug builds only
-#include <typeinfo>

--- a/thirdparty/imgui/README
+++ b/thirdparty/imgui/README
@@ -1,6 +1,5 @@
 To update Dear ImGui files go to https://github.com/ocornut/imgui/tree/docking.
 1) Switch to a commit with the tag X.XX.X-docking.
 2) Copy all .h & .cpp files in the main imgui directory as well as the dx9 & win32 backends EXCEPT for the imconfig.h file.
-3) Add '#include <stdafx.hpp>' to all .cpp files.
 
 - uncrafted

--- a/thirdparty/imgui/imgui.cpp
+++ b/thirdparty/imgui/imgui.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui, v1.91.0
 // (main code and documentation)
 

--- a/thirdparty/imgui/imgui_demo.cpp
+++ b/thirdparty/imgui/imgui_demo.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui, v1.91.0
 // (demo code)
 

--- a/thirdparty/imgui/imgui_draw.cpp
+++ b/thirdparty/imgui/imgui_draw.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui, v1.91.0
 // (drawing and font code)
 

--- a/thirdparty/imgui/imgui_impl_dx9.cpp
+++ b/thirdparty/imgui/imgui_impl_dx9.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui: Renderer Backend for DirectX9
 // This needs to be used along with a Platform Backend (e.g. Win32)
 

--- a/thirdparty/imgui/imgui_impl_win32.cpp
+++ b/thirdparty/imgui/imgui_impl_win32.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui: Platform Backend for Windows (standard windows API for 32-bits AND 64-bits applications)
 // This needs to be used along with a Renderer (e.g. DirectX11, OpenGL3, Vulkan..)
 

--- a/thirdparty/imgui/imgui_tables.cpp
+++ b/thirdparty/imgui/imgui_tables.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui, v1.91.0
 // (tables and columns code)
 

--- a/thirdparty/imgui/imgui_widgets.cpp
+++ b/thirdparty/imgui/imgui_widgets.cpp
@@ -1,5 +1,3 @@
-#include <stdafx.hpp>
-
 // dear imgui, v1.91.0
 // (widgets code)
 

--- a/thirdparty/json_spt_include.hpp
+++ b/thirdparty/json_spt_include.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+// SDK is funny
+#ifdef null
+#undef null
+#endif
+
+#include "json.hpp"

--- a/thirdparty/md5.cpp
+++ b/thirdparty/md5.cpp
@@ -30,8 +30,6 @@ documentation and/or software.
 
 */
 
-#include "stdafx.hpp"
-
 /* interface header */
 #include "md5.hpp"
 

--- a/thirdparty/x86.c
+++ b/thirdparty/x86.c
@@ -14,7 +14,6 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "stdafx.hpp"
 #include "x86.h"
 
 static int mrm(unsigned char b, int addrlen) {


### PR DESCRIPTION
Decreased compile time of Debug ful rebuild on my laptop from 61s to 44s. Plus I found the source of a couple weird macro conflicts with the json lib and pulled it out of the PCH (always thought it was weird that it was in there).

For future pull requests I think it's a good idea to ask people to keep STL/system headers in stdafx.hpp.