### PR TITLE
Player trace entity info in ImGui

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1255,6 +1255,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\features\visualizations\player_trace\import_export\tr_binary_read_upgrade.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\import_export\tr_binary_write.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_collect.cpp" />
+    <ClCompile Include="spt\features\visualizations\player_trace\tr_entity_cache.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_feature.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_record_cache.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_render_cache.cpp" />

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1257,6 +1257,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\features\visualizations\player_trace\tr_collect.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_entity_cache.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_feature.cpp" />
+    <ClCompile Include="spt\features\visualizations\player_trace\tr_imgui.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_record_cache.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_render_cache.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_state_access.cpp" />
@@ -1558,6 +1559,8 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\features\visualizations\player_trace\import_export\tr_binary_compress.hpp" />
     <ClInclude Include="spt\features\visualizations\player_trace\import_export\tr_binary_internal.hpp" />
     <ClInclude Include="spt\features\visualizations\player_trace\tr_config.hpp" />
+    <ClInclude Include="spt\features\visualizations\player_trace\tr_entity_cache.hpp" />
+    <ClInclude Include="spt\features\visualizations\player_trace\tr_imgui.hpp" />
     <ClInclude Include="spt\features\visualizations\player_trace\tr_record_cache.hpp" />
     <ClInclude Include="spt\features\visualizations\player_trace\tr_render_cache.hpp" />
     <ClInclude Include="spt\features\visualizations\player_trace\tr_structs.hpp" />

--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1258,6 +1258,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClCompile Include="spt\features\visualizations\player_trace\tr_feature.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_record_cache.cpp" />
     <ClCompile Include="spt\features\visualizations\player_trace\tr_render_cache.cpp" />
+    <ClCompile Include="spt\features\visualizations\player_trace\tr_state_access.cpp" />
     <ClCompile Include="spt\features\visualizations\portal_placement.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\internal\materials_manager.cpp" />
     <ClCompile Include="spt\features\visualizations\renderer\internal\mesh_builder.cpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -436,6 +436,9 @@
     <ClCompile Include="spt\features\visualizations\player_trace\import_export\tr_binary_compress.cpp">
       <Filter>spt\features\visualizations\player_trace\import_export</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\visualizations\player_trace\tr_state_access.cpp">
+      <Filter>spt\features\visualizations\player_trace</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -442,6 +442,9 @@
     <ClCompile Include="spt\features\visualizations\player_trace\tr_entity_cache.cpp">
       <Filter>spt\features\visualizations\player_trace</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\visualizations\player_trace\tr_imgui.cpp">
+      <Filter>spt\features\visualizations\player_trace</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">
@@ -948,8 +951,14 @@
     <ClInclude Include="thirdparty\json_spt_include.hpp">
       <Filter>thirdparty</Filter>
     </ClInclude>
-	<ClInclude Include="spt\features\portalled_pause.hpp">
+    <ClInclude Include="spt\features\portalled_pause.hpp">
       <Filter>spt\features</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\features\visualizations\player_trace\tr_entity_cache.hpp">
+      <Filter>spt\features\visualizations\player_trace</Filter>
+    </ClInclude>
+    <ClInclude Include="spt\features\visualizations\player_trace\tr_imgui.hpp">
+      <Filter>spt\features\visualizations\player_trace</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -439,6 +439,9 @@
     <ClCompile Include="spt\features\visualizations\player_trace\tr_state_access.cpp">
       <Filter>spt\features\visualizations\player_trace</Filter>
     </ClCompile>
+    <ClCompile Include="spt\features\visualizations\player_trace\tr_entity_cache.cpp">
+      <Filter>spt\features\visualizations\player_trace</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\public\tier0\basetypes.h">

--- a/spt/features/visualizations/imgui/imgui_interface.hpp
+++ b/spt/features/visualizations/imgui/imgui_interface.hpp
@@ -188,6 +188,12 @@ namespace SptImGuiGroup
 	inline Section Draw_Misc_Seams{"Seamshots", &Draw_Misc};
 	inline Section Draw_Misc_LeafVis{"Leaf vis", &Draw_Misc};
 
+	// player trace
+	inline Tab PlayerTrace{"Player trace", &Root};
+	inline Tab PlayerTrace_Player{"Player data", &PlayerTrace};
+	inline Tab PlayerTrace_Entities{"Active entities", &PlayerTrace};
+	inline Tab PlayerTrace_Portals{"Active portals", &PlayerTrace};
+
 	// quality of life and/or purely visual stuff
 	inline Tab QoL{"QoL", &Root};
 	inline Section QoL_Demo{"Demo utils", &QoL};

--- a/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
+++ b/spt/features/visualizations/imgui/spt_imgui_widgets.cpp
@@ -333,7 +333,11 @@ void SptImGui::CmdHelpMarkerWithName(const ConCommandBase& c)
 
 bool SptImGui::BeginBordered(const ImVec2& outer_size, float inner_width)
 {
-	if (ImGui::BeginTable("##table_border", 1, ImGuiTableFlags_BordersOuter, outer_size, inner_width))
+	if (ImGui::BeginTable("##table_border",
+	                      1,
+	                      ImGuiTableFlags_BordersOuter | ImGuiTableFlags_NoHostExtendX,
+	                      outer_size,
+	                      inner_width))
 	{
 		ImGui::TableNextRow();
 		ImGui::TableNextColumn();

--- a/spt/features/visualizations/player_trace/tr_collect.cpp
+++ b/spt/features/visualizations/player_trace/tr_collect.cpp
@@ -60,7 +60,8 @@ void TrPlayerTrace::StartRecording()
 	    { ((h.firstExportVersion = TR_LUMP_VERSION(typename std::remove_reference_t<decltype(h)>::type)), ...); },
 	    versions);
 
-	auto& rc = *(recordingCache = std::make_unique<TrRecordingCache>(*this));
+	TrReadContextScope scope{*this};
+	auto& rc = *(recordingCache = std::make_unique<TrRecordingCache>());
 	rc.StartRecording();
 
 	// hardcoding player hulls for now...
@@ -76,6 +77,7 @@ void TrPlayerTrace::StartRecording()
 
 void TrPlayerTrace::StopRecording()
 {
+	TrReadContextScope scope{*this};
 	recordingCache->StopRecording();
 	recordingCache.reset();
 	std::apply([](auto&... vecs) { (vecs.shrink_to_fit(), ...); }, _storage);

--- a/spt/features/visualizations/player_trace/tr_config.hpp
+++ b/spt/features/visualizations/player_trace/tr_config.hpp
@@ -108,6 +108,7 @@ namespace player_trace
 			ShapeColor physMeshPortalCollisionEnt{C_OUTLINE(200, 60, 100, 20)};
 			ShapeColor obb{C_WIRE(220, 150, 20, 255)};
 			ShapeColor obbTrigger{C_OUTLINE(200, 200, 20, 10)};
+			ShapeColor obbHovered{C_OUTLINE(255, 0, 0, 100), false, false, WD_BOTH};
 			ShapeColor collectAABB{C_WIRE(150, 100, 100, 255)};
 		} entities;
 	} inline trColors;

--- a/spt/features/visualizations/player_trace/tr_entity_cache.cpp
+++ b/spt/features/visualizations/player_trace/tr_entity_cache.cpp
@@ -1,0 +1,239 @@
+#include <stdafx.hpp>
+
+#include "tr_entity_cache.hpp"
+
+#ifdef SPT_PLAYER_TRACE_ENABLED
+
+using namespace player_trace;
+
+void TrEntityCache::VerifySnapshotState() const
+{
+	if (!initialized)
+		return;
+	Assert(snapshotIdx.IsValid());
+	if (snapshotIdx.IsValid() && snapshotDeltaIdx.IsValid())
+	{
+		Assert(snapshotIdx->snapDeltaIdx <= snapshotDeltaIdx);
+		Assert(snapshotIdx->tick <= snapshotDeltaIdx->tick);
+	}
+}
+
+void TrEntityCache::UpdateEntSnapshot(tr_tick toTick)
+{
+	if (initialized && toTick == tick)
+		return;
+
+	VerifySnapshotState();
+
+	auto& tr = TrReadContextScope::Current();
+
+	TrIdx<TrEntSnapshot> snapIdxLow = tr.GetAtTick<TrEntSnapshot>(toTick);
+	auto snapIdxHigh = snapIdxLow + 1;
+
+	if (!snapIdxLow.IsValid())
+		return; // no baselines :/
+
+	TrIdx<TrEntSnapshotDelta> snapDeltaIdx = tr.GetAtTick<TrEntSnapshotDelta>(toTick);
+	if (!snapDeltaIdx.IsValid())
+	{
+		// no deltas, rely on snapshots only
+		if (snapshotIdx == snapIdxLow && initialized)
+			tick = toTick;
+		else
+			JumpToEntSnapshot(snapIdxLow);
+		return;
+	}
+
+#define TR_DEBUG_UPDATE_SNAPSHOT 0
+
+	// small optimization
+	if (initialized && snapDeltaIdx == snapshotDeltaIdx)
+	{
+		tick = toTick;
+#if TR_DEBUG_UPDATE_SNAPSHOT
+		DevMsg("SPT: [%s] no deltas applied\n", __FUNCTION__);
+#endif
+		return;
+	}
+
+	// calculate most efficient approach to the desired delta
+
+	enum SnapshotDeltaApproach
+	{
+		SDA_JUMP_TO_SNAPSHOT_THEN_INCREMENT,
+		SDA_JUMP_TO_SNAPSHOT_THEN_DECREMENT,
+		SDA_INCREMENT,
+		SDA_DECREMENT,
+
+		SDA_COUNT,
+	};
+
+	constexpr uint32_t JUMP_TO_SNAPSHOT_COST = 3;
+	constexpr uint32_t SNAPSHOT_DELTA_COST = 1;
+
+	SnapshotDeltaApproach approach = SDA_JUMP_TO_SNAPSHOT_THEN_INCREMENT;
+	size_t cost = JUMP_TO_SNAPSHOT_COST + SNAPSHOT_DELTA_COST * (snapDeltaIdx - snapIdxLow->snapDeltaIdx);
+	size_t nDeltas = snapDeltaIdx - snapIdxLow->snapDeltaIdx;
+
+	if (snapIdxHigh.IsValid())
+	{
+		size_t newCost =
+		    JUMP_TO_SNAPSHOT_COST + SNAPSHOT_DELTA_COST * (snapIdxHigh->snapDeltaIdx - snapDeltaIdx);
+		if (newCost < cost)
+		{
+			approach = SDA_JUMP_TO_SNAPSHOT_THEN_DECREMENT;
+			cost = newCost;
+			nDeltas = snapIdxHigh->snapDeltaIdx - snapDeltaIdx;
+		}
+	}
+
+	if (initialized)
+	{
+		if (tick <= toTick)
+		{
+			size_t newCost = SNAPSHOT_DELTA_COST * (snapDeltaIdx - snapshotDeltaIdx);
+			if (newCost < cost)
+			{
+				approach = SDA_INCREMENT;
+				cost = newCost;
+				nDeltas = snapDeltaIdx - snapshotDeltaIdx;
+			}
+		}
+		else
+		{
+			size_t newCost = SNAPSHOT_DELTA_COST * (snapshotDeltaIdx - snapDeltaIdx);
+			if (newCost < cost)
+			{
+				approach = SDA_DECREMENT;
+				cost = newCost;
+				nDeltas = snapshotDeltaIdx - snapDeltaIdx;
+			}
+		}
+	}
+
+#if TR_DEBUG_UPDATE_SNAPSHOT
+	static std::array<const char*, SDA_COUNT> approachStrs = {
+	    "JUMP THEN INCREMENT",
+	    "JUMP THEN DECREMENT",
+	    "INCREMENT",
+	    "DECREMENT",
+	};
+	DevMsg("SPT: [%s] using approach %s with %u deltas\n", __FUNCTION__, approachStrs[approach], nDeltas);
+#endif
+
+	switch (approach)
+	{
+	case SDA_JUMP_TO_SNAPSHOT_THEN_INCREMENT:
+		JumpToEntSnapshot(snapIdxLow);
+		[[fallthrough]];
+	case SDA_INCREMENT:
+		ForwardIterateSnapshotDeltas(toTick);
+		break;
+	case SDA_JUMP_TO_SNAPSHOT_THEN_DECREMENT:
+		JumpToEntSnapshot(snapIdxHigh);
+		[[fallthrough]];
+	case SDA_DECREMENT:
+		BackwardIterateSnapshotDeltas(toTick);
+		break;
+	default:
+		Assert(0);
+	}
+}
+
+void TrEntityCache::JumpToEntSnapshot(TrIdx<TrEntSnapshot> snapIdx)
+{
+	entMap.clear();
+	for (auto& create : *snapIdx->createSp)
+		entMap[create.entIdx] = {create.transIdx};
+
+	snapshotIdx = snapIdx;
+	snapshotDeltaIdx = snapIdx->snapDeltaIdx;
+	tick = snapIdx->tick;
+	initialized = true;
+}
+
+void TrEntityCache::ForwardIterateSnapshotDeltas(tr_tick toTick)
+{
+	VerifySnapshotState();
+	TrIdx<TrEntSnapshot> snapIdxLow = snapshotIdx;
+
+	while ((snapshotDeltaIdx + 1).IsValid() && snapshotDeltaIdx->tick < toTick)
+	{
+		auto& delta = **++snapshotDeltaIdx;
+
+		for (auto& create : *delta.createSp)
+			entMap.emplace(create.entIdx, create.transIdx);
+
+		for (auto& transDelta : *delta.deltaSp)
+		{
+			auto it = entMap.find(transDelta.entIdx);
+			if (it == entMap.cend())
+			{
+				AssertMsg(0, "SPT: attempting to delta non-existing ent");
+				continue;
+			}
+			it->second = transDelta.toTransIdx;
+		}
+
+		for (auto& del : *delta.deleteSp)
+		{
+			auto it = entMap.find(del.entIdx);
+			if (it == entMap.cend())
+			{
+				AssertMsg(0, "SPT: attempting to delete non-existing ent");
+				continue;
+			}
+			entMap.erase(it);
+		}
+
+		tick = delta.tick;
+
+		if ((snapIdxLow + 1).IsValid() && (snapIdxLow + 1)->tick <= delta.tick)
+			snapshotIdx = ++snapIdxLow;
+	}
+	tick = toTick;
+}
+
+void TrEntityCache::BackwardIterateSnapshotDeltas(tr_tick toTick)
+{
+	VerifySnapshotState();
+	TrIdx<TrEntSnapshot> snapIdxLow = snapshotIdx;
+
+	while ((snapshotDeltaIdx - 1).IsValid() && snapshotDeltaIdx->tick > toTick)
+	{
+		auto& delta = **snapshotDeltaIdx--;
+
+		for (auto& create : *delta.createSp)
+		{
+			auto it = entMap.find(create.entIdx);
+			if (it == entMap.cend())
+			{
+				AssertMsg(0, "SPT: attempting to delete non-existing ent");
+				continue;
+			}
+			entMap.erase(it);
+		}
+
+		for (auto& transDelta : *delta.deltaSp)
+		{
+			auto it = entMap.find(transDelta.entIdx);
+			if (it == entMap.cend())
+			{
+				AssertMsg(0, "SPT: attempting to delta non-existing ent");
+				continue;
+			}
+			it->second = transDelta.fromTransIdx;
+		}
+
+		for (auto& del : *delta.deleteSp)
+			entMap.emplace(del.entIdx, del.oldTransIdx);
+
+		tick = delta.tick;
+
+		if ((snapIdxLow - 1).IsValid() && snapIdxLow->tick >= delta.tick)
+			snapshotIdx = --snapIdxLow;
+	}
+	tick = toTick;
+}
+
+#endif

--- a/spt/features/visualizations/player_trace/tr_entity_cache.hpp
+++ b/spt/features/visualizations/player_trace/tr_entity_cache.hpp
@@ -13,8 +13,8 @@ namespace player_trace
 
 	private:
 		EntMap entMap;
-		TrIdx<TrEntSnapshot> snapshotIdx = 0;
-		TrIdx<TrEntSnapshotDelta> snapshotDeltaIdx = 0;
+		TrIdx<TrEntSnapshot> snapshotIdx;
+		TrIdx<TrEntSnapshotDelta> snapshotDeltaIdx;
 		tr_tick tick = 0;
 		bool initialized = false;
 
@@ -27,6 +27,8 @@ namespace player_trace
 	public:
 		TrEntityCache() = default;
 		TrEntityCache(const TrEntityCache&) = delete;
+
+		TrIdx<TrEnt> hoveredEnt; // set by imgui, reset by renderer
 
 		const EntMap& GetEnts(tr_tick atTick)
 		{

--- a/spt/features/visualizations/player_trace/tr_entity_cache.hpp
+++ b/spt/features/visualizations/player_trace/tr_entity_cache.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "tr_structs.hpp"
+
+#ifdef SPT_PLAYER_TRACE_ENABLED
+
+namespace player_trace
+{
+	class TrEntityCache
+	{
+	public:
+		using EntMap = std::unordered_map<TrIdx<TrEnt>, TrIdx<TrEntTransform>>;
+
+	private:
+		EntMap entMap;
+		TrIdx<TrEntSnapshot> snapshotIdx = 0;
+		TrIdx<TrEntSnapshotDelta> snapshotDeltaIdx = 0;
+		tr_tick tick = 0;
+		bool initialized = false;
+
+		void UpdateEntSnapshot(tr_tick toTick);
+		void VerifySnapshotState() const;
+		void JumpToEntSnapshot(TrIdx<TrEntSnapshot> snapIdx);
+		void ForwardIterateSnapshotDeltas(tr_tick toTick);
+		void BackwardIterateSnapshotDeltas(tr_tick toTick);
+
+	public:
+		TrEntityCache() = default;
+		TrEntityCache(const TrEntityCache&) = delete;
+
+		const EntMap& GetEnts(tr_tick atTick)
+		{
+			UpdateEntSnapshot(atTick);
+			return entMap;
+		}
+	};
+
+} // namespace player_trace
+
+#endif

--- a/spt/features/visualizations/player_trace/tr_feature.cpp
+++ b/spt/features/visualizations/player_trace/tr_feature.cpp
@@ -276,7 +276,7 @@ void PlayerTraceFeature::LoadFeature()
 	    [](IConVar* var, const char*, float)
 	    {
 		    if (!((ConVar*)var)->GetBool())
-			    spt_player_trace_feat.tr.StopRendering();
+			    spt_player_trace_feat.tr.KillRenderingCache();
 	    });
 }
 

--- a/spt/features/visualizations/player_trace/tr_feature.cpp
+++ b/spt/features/visualizations/player_trace/tr_feature.cpp
@@ -339,6 +339,7 @@ void PlayerTraceFeature::OnMeshRenderSignal(MeshRendererDelegate& mr)
 	if (!spt_draw_trace.GetBool())
 		return;
 	activeDrawTick = clamp(activeDrawTick, 0, tr.numRecordedTicks - 1);
+	TrReadContextScope scope{tr};
 	tr.GetRenderingCache().RenderAll(mr, activeDrawTick);
 }
 

--- a/spt/features/visualizations/player_trace/tr_imgui.cpp
+++ b/spt/features/visualizations/player_trace/tr_imgui.cpp
@@ -1,0 +1,359 @@
+#include "stdafx.hpp"
+
+#include <inttypes.h>
+#include <bitset>
+
+#include "tr_imgui.hpp"
+#include "tr_entity_cache.hpp"
+
+#ifdef SPT_PLAYER_TRACE_ENABLED
+
+#include "spt/utils/game_detection.hpp"
+#include "spt/features/visualizations/imgui/imgui_interface.hpp"
+
+#define _VEC_FMT "<%f, %f, %f>"
+#define _VEC_UNP(v) (v).x, (v).y, (v).z
+
+using namespace player_trace;
+
+static void TrShowActiveTick(tr_tick activeTick)
+{
+	auto& tr = TrReadContextScope::Current();
+	if (tr.hasStartRecordingBeenCalled)
+	{
+		ImGui::Text("Active tick: %" PRIu32 "/%" PRIu32,
+		            activeTick,
+		            tr.numRecordedTicks == 0 ? 0 : tr.numRecordedTicks - 1);
+	}
+	else
+	{
+		ImGui::TextUnformatted("No active trace");
+	}
+}
+
+void tr_imgui::PlayerTabCallback(tr_tick activeTick)
+{
+	TrShowActiveTick(activeTick);
+	auto& tr = TrReadContextScope::Current();
+
+	tr_struct_version playerExportVersion = tr.GetFirstExportVersion<TrPlayerData>();
+	auto plIdx = tr.GetAtTick<TrPlayerData>(activeTick);
+	TrPlayerData defaultPl{};
+	auto& pl = plIdx.IsValid() ? **plIdx : defaultPl;
+	Vector vecInvalid{NAN, NAN, NAN};
+	QAngle angInvalid{NAN, NAN, NAN};
+	TrTransform transInvalid{};
+
+	Vector eyePos, sgEyePos, vPhysPos;
+	QAngle eyeAng, sgEyeAng, vPhysAng;
+	pl.transVPhysIdx.GetOrDefault(transInvalid).GetPosAng(vPhysPos, vPhysAng);
+	pl.transEyesIdx.GetOrDefault(transInvalid).GetPosAng(eyePos, eyeAng);
+	pl.transSgEyesIdx.GetOrDefault(transInvalid).GetPosAng(sgEyePos, sgEyeAng);
+
+	ImGui::Text("QPhys pos: " _VEC_FMT, _VEC_UNP(pl.qPosIdx.GetOrDefault(vecInvalid)));
+	ImGui::Text("VPhys pos: " _VEC_FMT, _VEC_UNP(vPhysPos));
+	ImGui::Text("VPhys ang: " _VEC_FMT, _VEC_UNP(vPhysAng));
+	ImGui::Text("QPhys vel: " _VEC_FMT, _VEC_UNP(pl.qVelIdx.GetOrDefault(vecInvalid)));
+	if (playerExportVersion >= 2)
+		ImGui::Text("VPhys vel: " _VEC_FMT, _VEC_UNP(pl.vVelIdx.GetOrDefault(vecInvalid)));
+	else
+		ImGui::TextDisabled("VPhys vel: data was not recorded on this trace version");
+	ImGui::Text("Eye pos: " _VEC_FMT, _VEC_UNP(eyePos));
+	ImGui::Text("Eye ang: " _VEC_FMT, _VEC_UNP(eyeAng));
+	if (utils::DoesGameLookLikePortal())
+	{
+		if (playerExportVersion >= 2)
+		{
+			if (pl.envPortalHandle.IsValid())
+			{
+				ImGui::Text("Portal environment: %d, (serial: %d)",
+				            pl.envPortalHandle.GetEntryIndex(),
+				            pl.envPortalHandle.GetSerialNumber());
+			}
+			else
+			{
+				ImGui::TextDisabled("Portal environment: NULL");
+			}
+		}
+		else
+		{
+			ImGui::TextDisabled("Portal environment: data was not recorded on this trace version");
+		}
+		if (eyePos == sgEyePos)
+		{
+			ImGui::TextDisabled("SG eye pos: same as eye pos");
+			ImGui::TextDisabled("SG eye ang: same as eye ang");
+		}
+		else
+		{
+			ImGui::Text("SG eye pos: " _VEC_FMT, _VEC_UNP(sgEyePos));
+			ImGui::Text("SG eye ang: " _VEC_FMT, _VEC_UNP(sgEyeAng));
+		}
+	}
+	ImGui::Text("m_fFlags: %d", pl.m_fFlags);
+	ImGui::Text("fov: %" PRIu32, pl.fov);
+	ImGui::Text("health: %" PRIu32, pl.m_iHealth);
+	ImGui::Text("life state: %" PRIu32, pl.m_lifeState);
+	ImGui::Text("collision group: %" PRIu32, pl.m_CollisionGroup);
+	ImGui::Text("move type: %" PRIu32, pl.m_MoveType);
+
+	auto contactSp = *pl.contactPtsSp;
+
+	ImGui::Text("%" PRIu32 " contact point%s%s",
+	            contactSp.size(),
+	            contactSp.size() == 1 ? "" : "s",
+	            contactSp.empty() ? "" : ":");
+
+	ImGui::Indent();
+
+	for (auto contactIdx : contactSp)
+	{
+		const TrPlayerContactPoint& pcp = contactIdx.GetOrDefault();
+		if (SptImGui::BeginBordered())
+		{
+			ImGui::PushID((int)contactIdx);
+			ImGui::Text("object: '%s' (player is object %d)", *pcp.objNameIdx, !pcp.playerIsObj0);
+			ImGui::Text("pos: " _VEC_FMT, _VEC_UNP(pcp.posIdx.GetOrDefault(vecInvalid)));
+			ImGui::Text("normal: " _VEC_FMT, _VEC_UNP(pcp.normIdx.GetOrDefault(vecInvalid)));
+			ImGui::Text("force: %f", pcp.force);
+			ImGui::PopID();
+			SptImGui::EndBordered();
+		}
+	}
+
+	ImGui::Unindent();
+}
+
+void tr_imgui::EntityTabCallback(tr_tick activeTick)
+{
+	TrShowActiveTick(activeTick);
+	auto& tr = TrReadContextScope::Current();
+
+	auto& entCache = tr.GetEntityCache();
+	auto& entMap = entCache.GetEnts(activeTick);
+
+	static std::vector<std::pair<TrIdx<TrEnt>, TrIdx<TrEntTransform>>> sortedEnts;
+	sortedEnts.resize(entMap.size());
+	std::ranges::transform(entMap, sortedEnts.begin(), std::identity{});
+	std::ranges::sort(sortedEnts, std::less{}, [](auto& p) { return p.first->handle.GetEntryIndex(); });
+
+	ImGui::TextUnformatted("Filter:");
+	ImGui::SameLine();
+
+	static ImGuiTextFilter filter;
+	filter.Draw("##filter");
+	ImGui::SetItemTooltip(
+	    "Filter usage:\n"
+	    "  \"\"         display all lines\n"
+	    "  \"xxx\"      display lines containing \"xxx\"\n"
+	    "  \"xxx,yyy\"  display lines containing \"xxx\" or \"yyy\"\n"
+	    "  \"-xxx\"     hide lines containing \"xxx\"");
+
+	std::bitset<MAX_EDICTS> filterPassedSet{};
+	int nPassed = 0;
+
+	for (auto [entIdx, _] : sortedEnts)
+	{
+		const TrEnt& ent = **entIdx;
+		auto objSp = *ent.physSp;
+
+		bool passFilter = !filter.IsActive();
+		if (!passFilter)
+			passFilter = filter.PassFilter(*ent.classNameIdx);
+		if (!passFilter)
+			passFilter = filter.PassFilter(*ent.networkClassNameIdx);
+		if (!passFilter)
+			passFilter = filter.PassFilter(*ent.nameIdx);
+		for (size_t i = 0; !passFilter && i < objSp.size(); i++)
+			passFilter = filter.PassFilter(*objSp[i]->infoIdx->nameIdx);
+
+		// special case for portals, I accidentally collected them in old versions
+		if (!strcmp(*ent.classNameIdx, "prop_portal")) [[unlikely]]
+			passFilter = false;
+
+		filterPassedSet[ent.handle.GetEntryIndex()] = passFilter;
+		if (passFilter)
+			nPassed++;
+	}
+
+	ImGui::Text("showing %d/%u entities", nPassed, sortedEnts.size());
+
+	for (auto [entIdx, entTransIdx] : sortedEnts)
+	{
+		const TrEnt& ent = **entIdx;
+
+		if (!filterPassedSet[ent.handle.GetEntryIndex()])
+			continue;
+
+		ImGui::PushID(ent.handle.GetEntryIndex());
+		const char* entName = *ent.nameIdx;
+		ImGui::BeginGroup();
+		if (ImGui::TreeNodeEx("ent_entry",
+		                      ImGuiTreeNodeFlags_SpanFullWidth,
+		                      "index %d [%s]%s%s%s",
+		                      ent.handle.GetEntryIndex(),
+		                      *ent.networkClassNameIdx,
+		                      *entName ? " \"" : "",
+		                      entName,
+		                      *entName ? "\"" : ""))
+		{
+			if (SptImGui::BeginBordered())
+			{
+				const TrEntTransform& entTrans = **entTransIdx;
+				{
+					Vector mins{NAN}, maxs{NAN}, pos{NAN};
+					QAngle ang{NAN, NAN, NAN};
+					if (entTrans.obbIdx.IsValid())
+						entTrans.obbIdx->GetMinsMaxs(mins, maxs);
+					if (entTrans.obbTransIdx.IsValid())
+						entTrans.obbTransIdx->GetPosAng(pos, ang);
+					ImGui::Text("OBB mins: " _VEC_FMT, _VEC_UNP(mins));
+					ImGui::Text("OBB maxs: " _VEC_FMT, _VEC_UNP(maxs));
+					ImGui::Text("server pos: " _VEC_FMT, _VEC_UNP(pos));
+					ImGui::Text("server ang: " _VEC_FMT, _VEC_UNP(ang));
+				}
+				ImGui::Text("serial: %d", ent.handle.GetSerialNumber());
+				ImGui::Text("class name: \"%s\"", *ent.classNameIdx);
+				ImGui::Text("solid type: %d", ent.m_nSolidType);
+				ImGui::Text("solid flags: %d", ent.m_usSolidFlags);
+				ImGui::Text("collision group: %d", ent.m_CollisionGroup);
+
+				auto objSp = *ent.physSp;
+				if (objSp.empty())
+				{
+					ImGui::Text("0 physics objects");
+				}
+				else if (ImGui::TreeNodeEx("phys_objs",
+				                           ImGuiTreeNodeFlags_None,
+				                           "%" PRIu32 " physics object%s",
+				                           objSp.size(),
+				                           objSp.size() == 1 ? "" : "s"))
+				{
+					auto objTransSp = *entTrans.physTransSp;
+					Assert(objSp.size() == objTransSp.size());
+					for (uint32_t i = 0; i < objSp.size(); i++)
+					{
+						const TrPhysicsObject& obj = **objSp[i];
+						const TrPhysicsObjectInfo& objInfo = **obj.infoIdx;
+						const TrPhysMesh_v1& objMesh = **obj.meshIdx;
+						const TrTransform& objTrans = **objTransSp[i];
+
+						ImGui::PushID((int)objSp[i]);
+						if (SptImGui::BeginBordered())
+						{
+							ImGui::Text("name: \"%s\"", *objInfo.nameIdx);
+							ImGui::Text(
+							    "asleep: %d, moveable: %d, trigger: %d, gravity enabled: %d",
+							    !!(objInfo.flags & TR_POF_ASLEEP),
+							    !!(objInfo.flags & TR_POF_MEOVEABLE),
+							    !!(objInfo.flags & TR_POF_IS_TRIGGER),
+							    !!(objInfo.flags & TR_POF_GRAVITY_ENABLED));
+
+							Vector pos{NAN};
+							QAngle ang{NAN, NAN, NAN};
+							objTrans.GetPosAng(pos, ang);
+							ImGui::Text("pos: " _VEC_FMT, _VEC_UNP(pos));
+							ImGui::Text("ang: " _VEC_FMT, _VEC_UNP(ang));
+
+							if (objMesh.ballRadius > 0)
+							{
+								ImGui::Text("ball mesh of radius %f",
+								            objMesh.ballRadius);
+							}
+							else
+							{
+								ImGui::Text("mesh with %" PRIu32 " verts",
+								            objMesh.vertIdxSp.n);
+							}
+							SptImGui::EndBordered();
+						}
+						ImGui::PopID();
+					}
+					ImGui::TreePop();
+				}
+				SptImGui::EndBordered();
+				// pad the remaining space with a dummy for hover detection
+				auto [_, height] = ImGui::GetItemRectSize();
+				ImGui::SameLine();
+				ImGui::Dummy(ImVec2{ImGui::GetContentRegionAvail().x, height});
+			}
+			ImGui::TreePop();
+		}
+		ImGui::EndGroup();
+
+		if (ImGui::IsItemHovered())
+			entCache.hoveredEnt = entIdx;
+
+		ImGui::PopID();
+	}
+}
+
+void tr_imgui::PortalTabCallback(tr_tick activeTick)
+{
+	TrShowActiveTick(activeTick);
+	auto& tr = TrReadContextScope::Current();
+
+	auto portalSnap = tr.GetAtTick<TrPortalSnapshot>(activeTick);
+	auto portalSp = *portalSnap.GetOrDefault().portalsSp;
+
+	if (portalSp.empty())
+	{
+		ImGui::TextUnformatted("No portals");
+		return;
+	}
+
+	// a simplified copy of the portal selection widget
+	ImGuiTabBarFlags tableFlags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_NoHostExtendX
+	                              | ImGuiTableFlags_NoKeepColumnsVisible;
+	if (ImGui::BeginTable("##portal_select", 11, tableFlags))
+	{
+		ImGui::TableSetupColumn("index", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("linked", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("color", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("state", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("x", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("y", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("z", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("pitch", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("yaw", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("roll", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("linkage", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableHeadersRow();
+
+		for (auto portalIdx : portalSp)
+		{
+			auto& portal = portalIdx.GetOrDefault();
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Text("%d", portal.handle.GetEntryIndex());
+			ImGui::TableSetColumnIndex(1);
+			if (portal.linkedHandle.IsValid())
+				ImGui::Text("%d", portal.linkedHandle.GetEntryIndex());
+			else
+				ImGui::TextDisabled("NONE");
+			ImGui::TableSetColumnIndex(2);
+			ImGui::TextColored(portal.isOrange ? ImVec4{1.f, .63f, .13f, 1.f}
+			                                   : ImVec4{.25f, .63f, 1.f, 1.f},
+			                   portal.isOrange ? "orange" : "blue");
+			ImGui::TableSetColumnIndex(3);
+			ImGui::TextUnformatted(portal.isOpen ? "open" : (portal.isActivated ? "closed" : "inactive"));
+			TrTransform trans = portal.transIdx.GetOrDefault();
+			Vector pos;
+			QAngle ang;
+			trans.GetPosAng(pos, ang);
+			for (int i = 0; i < 3; i++)
+			{
+				ImGui::TableSetColumnIndex(4 + i);
+				ImGui::Text("%f", pos[i]);
+				ImGui::TableSetColumnIndex(7 + i);
+				ImGui::Text("%f", ang[i]);
+			}
+			ImGui::TableSetColumnIndex(10);
+			ImGui::Text("%d", portal.linkageId);
+		}
+
+		ImGui::EndTable();
+	}
+}
+
+#endif

--- a/spt/features/visualizations/player_trace/tr_imgui.hpp
+++ b/spt/features/visualizations/player_trace/tr_imgui.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "tr_structs.hpp"
+
+#ifdef SPT_PLAYER_TRACE_ENABLED
+
+namespace player_trace::tr_imgui
+{
+	void PlayerTabCallback(tr_tick activeTick);
+	void EntityTabCallback(tr_tick activeTick);
+	void PortalTabCallback(tr_tick activeTick);
+
+} // namespace player_trace::tr_imgui
+
+#endif

--- a/spt/features/visualizations/player_trace/tr_record_cache.hpp
+++ b/spt/features/visualizations/player_trace/tr_record_cache.hpp
@@ -17,10 +17,6 @@ namespace player_trace
 
 	class TrRecordingCache
 	{
-		friend struct TrPlayerTrace;
-		TrPlayerTrace* tr;
-
-	private:
 		/*
 		* One of the main goals of the recording cache is to reuse indices that we've seen before.
 		* Say we recording a new player data object, and the player is looking in the same
@@ -157,7 +153,7 @@ namespace player_trace
 		}
 
 	public:
-		TrRecordingCache(TrPlayerTrace& tr) : tr{&tr} {};
+		TrRecordingCache() = default;
 		TrRecordingCache(const TrRecordingCache&) = delete;
 
 		struct EntSnapshotEntry
@@ -215,12 +211,12 @@ namespace player_trace
 		template<typename T>
 		TrIdx<T> GetCachedIdx(const T& t)
 		{
-			TrReadContextScope ctx{*tr};
+			auto& tr = TrReadContextScope::CurrentModifiable();
 			auto& set = GetKeySet<T>();
 			auto [it, new_elem] = set.emplace(t);
 			if (new_elem)
 			{
-				auto& vec = tr->Get<T>();
+				auto& vec = tr.Get<T>();
 				it->idx = vec.size();
 				vec.push_back(t);
 			}
@@ -230,12 +226,12 @@ namespace player_trace
 		template<typename T>
 		TrSpan<T> GetCachedSpan(std::span<const T> sp)
 		{
-			TrReadContextScope ctx{*tr};
+			auto& tr = TrReadContextScope::CurrentModifiable();
 			auto& set = GetSpanSet<T>();
 			auto [it, new_elem] = set.emplace(sp);
 			if (new_elem)
 			{
-				auto& vec = tr->Get<T>();
+				auto& vec = tr.Get<T>();
 				it->trSpan = TrSpan<T>{vec.size(), sp.size()};
 				vec.insert(vec.cend(), sp.begin(), sp.end());
 			}

--- a/spt/features/visualizations/player_trace/tr_render_cache.cpp
+++ b/spt/features/visualizations/player_trace/tr_render_cache.cpp
@@ -413,9 +413,8 @@ void TrRenderingCache::RebuildPhysMeshes()
 {
 	auto& physMeshes = meshes.ents.physObjs;
 
-	if (meshes.ents.anyStale)
-		for (auto& [_, tracked] : physMeshes)
-			tracked.isActive = false;
+	for (auto& [_, tracked] : physMeshes)
+		tracked.isActive = false;
 
 	for (auto& [entIdx, entTransIdx] : entSnapshot.entMap)
 	{
@@ -461,11 +460,7 @@ void TrRenderingCache::RebuildPhysMeshes()
 		}
 	}
 
-	if (meshes.ents.anyStale)
-	{
-		std::erase_if(physMeshes, [](const auto& entry) { return !entry.second.isActive; });
-		meshes.ents.anyStale = false;
-	}
+	std::erase_if(physMeshes, [](const auto& entry) { return !entry.second.isActive; });
 }
 
 void TrRenderingCache::VerifySnapshotState() const

--- a/spt/features/visualizations/player_trace/tr_render_cache.hpp
+++ b/spt/features/visualizations/player_trace/tr_render_cache.hpp
@@ -11,12 +11,7 @@ namespace player_trace
 {
 	class TrRenderingCache
 	{
-	public:
-		TrRenderingCache(const TrPlayerTrace& tr);
-
 	private:
-		friend struct TrPlayerTrace;
-		const TrPlayerTrace* tr;
 		std::unordered_map<std::string, Vector> mapToFirstMapLandmarkOffset;
 
 		void RebuildPlayerHullMeshes();
@@ -105,6 +100,8 @@ namespace player_trace
 		std::string renderedLastTimeOnMap;
 
 	public:
+		TrRenderingCache() = default;
+		TrRenderingCache(const TrRenderingCache&) = delete;
 		void RenderAll(MeshRendererDelegate& mr, tr_tick atTick);
 	};
 

--- a/spt/features/visualizations/player_trace/tr_render_cache.hpp
+++ b/spt/features/visualizations/player_trace/tr_render_cache.hpp
@@ -88,7 +88,7 @@ namespace player_trace
 				};
 
 				std::unordered_map<TrIdx<TrPhysMesh>, TrackedMesh> physObjs;
-				bool anyStale = false;
+				bool anyStale = true;
 			} ents;
 
 		} meshes;

--- a/spt/features/visualizations/player_trace/tr_render_cache.hpp
+++ b/spt/features/visualizations/player_trace/tr_render_cache.hpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "tr_structs.hpp"
+#include "tr_entity_cache.hpp"
 
 #ifdef SPT_PLAYER_TRACE_ENABLED
 
@@ -18,18 +19,12 @@ namespace player_trace
 		void RebuildEyeMeshes(float fov);
 		void RebuildPlayerPathMeshes();
 		void RebuildPortalMeshes();
-		void RebuildPhysMeshes();
+		void RebuildPhysMeshes(const TrEntityCache::EntMap& entMap);
 
 		void RenderPlayerPath(MeshRendererDelegate& mr, const Vector& landmarkDeltaToFirstMap);
 		void RenderPlayerHull(MeshRendererDelegate& mr, const Vector& landmarkDeltaToMapAtTick, tr_tick atTick);
 		void RenderPortals(MeshRendererDelegate& mr, const Vector& landmarkDeltaToMapAtTick, tr_tick atTick);
 		void RenderEntities(MeshRendererDelegate& mr, const Vector& landmarkDeltaToMapAtTick, tr_tick atTick);
-
-		void VerifySnapshotState() const;
-		void UpdateEntSnapshot(tr_tick toTick);
-		void JumpToEntSnapshot(TrIdx<TrEntSnapshot> snapIdx);
-		void ForwardIterateSnapshotDeltas(tr_tick toTick);
-		void BackwardIterateSnapshotDeltas(tr_tick toTick);
 
 		/*
 		* The player path coordinates are computed relative to the first map of the trace, but in order
@@ -87,15 +82,6 @@ namespace player_trace
 			} ents;
 
 		} meshes;
-
-		struct EntSnapshot
-		{
-			std::unordered_map<TrIdx<TrEnt>, TrIdx<TrEntTransform>> entMap;
-			TrIdx<TrEntSnapshot> snapshotIdx = 0;
-			TrIdx<TrEntSnapshotDelta> snapshotDeltaIdx = 0;
-			tr_tick tick = 0;
-			bool initialized = false;
-		} entSnapshot;
 
 		std::string renderedLastTimeOnMap;
 

--- a/spt/features/visualizations/player_trace/tr_state_access.cpp
+++ b/spt/features/visualizations/player_trace/tr_state_access.cpp
@@ -1,0 +1,70 @@
+#include <stdafx.hpp>
+
+#include "tr_record_cache.hpp"
+#include "tr_render_cache.hpp"
+
+#ifdef SPT_PLAYER_TRACE_ENABLED
+
+using namespace player_trace;
+
+void TrPlayerTrace::Clear()
+{
+	recordingCache.reset();
+	renderingCache.reset();
+
+	playerStandBboxIdx.Invalidate();
+	playerDuckBboxIdx.Invalidate();
+
+	std::apply([](auto&... vecs) { ((vecs.clear(), vecs.shrink_to_fit()), ...); }, _storage);
+	std::apply([](auto&... holder) { ((holder.firstExportVersion = TR_INVALID_STRUCT_VERSION), ...); }, versions);
+	numRecordedTicks = 0;
+	hasStartRecordingBeenCalled = false;
+}
+
+TrRecordingCache& TrPlayerTrace::GetRecordingCache()
+{
+	Assert(recordingCache.get());
+	recordingCache->tr = this; // std::move hack
+	return *recordingCache;
+}
+
+TrRenderingCache& TrPlayerTrace::GetRenderingCache() const
+{
+	if (!renderingCache)
+		renderingCache = std::make_unique<TrRenderingCache>(*this);
+	renderingCache->tr = this; // std::move hack
+	return *renderingCache;
+}
+
+void TrPlayerTrace::KillRenderingCache()
+{
+	renderingCache.reset();
+}
+
+int TrPlayerTrace::GetServerTickAtTick(tr_tick atTick) const
+{
+	TrReadContextScope scope{*this};
+	auto svStateIdx = GetAtTick<TrServerState>(atTick);
+	return svStateIdx.IsValid() ? svStateIdx->GetServerTickFromThisAsLastState(atTick) : -1;
+}
+
+TrIdx<TrMap> TrPlayerTrace::GetMapAtTick(tr_tick atTick) const
+{
+	TrReadContextScope scope{*this};
+	auto& transitions = Get<TrMapTransition>();
+	return transitions.empty() || transitions[0].tick > atTick ? TrIdx<TrMap>{0}
+	                                                           : GetAtTick<TrMapTransition>(atTick)->toMapIdx;
+}
+
+Vector TrPlayerTrace::GetAdjacentLandmarkDelta(std::span<const TrLandmark> fromLandmarkSp,
+                                               std::span<const TrLandmark> toLandmarkSp) const
+{
+	TrReadContextScope scope{*this};
+	for (auto& fromLandmark : fromLandmarkSp)
+		for (auto& toLandmark : toLandmarkSp)
+			if (fromLandmark.nameIdx == toLandmark.nameIdx)
+				return **fromLandmark.posIdx - **toLandmark.posIdx;
+	return vec3_origin;
+}
+
+#endif

--- a/spt/features/visualizations/player_trace/tr_state_access.cpp
+++ b/spt/features/visualizations/player_trace/tr_state_access.cpp
@@ -11,6 +11,7 @@ void TrPlayerTrace::Clear()
 {
 	recordingCache.reset();
 	renderingCache.reset();
+	entityCache.reset();
 
 	playerStandBboxIdx.Invalidate();
 	playerDuckBboxIdx.Invalidate();
@@ -25,6 +26,18 @@ TrRecordingCache& TrPlayerTrace::GetRecordingCache()
 {
 	Assert(recordingCache.get());
 	return *recordingCache;
+}
+
+TrEntityCache& TrPlayerTrace::GetEntityCache() const
+{
+	if (!entityCache)
+		entityCache = std::make_unique<TrEntityCache>();
+	return *entityCache;
+}
+
+void TrPlayerTrace::KillEntityCache()
+{
+	entityCache.reset();
 }
 
 TrRenderingCache& TrPlayerTrace::GetRenderingCache() const

--- a/spt/features/visualizations/player_trace/tr_state_access.cpp
+++ b/spt/features/visualizations/player_trace/tr_state_access.cpp
@@ -24,15 +24,13 @@ void TrPlayerTrace::Clear()
 TrRecordingCache& TrPlayerTrace::GetRecordingCache()
 {
 	Assert(recordingCache.get());
-	recordingCache->tr = this; // std::move hack
 	return *recordingCache;
 }
 
 TrRenderingCache& TrPlayerTrace::GetRenderingCache() const
 {
 	if (!renderingCache)
-		renderingCache = std::make_unique<TrRenderingCache>(*this);
-	renderingCache->tr = this; // std::move hack
+		renderingCache = std::make_unique<TrRenderingCache>();
 	return *renderingCache;
 }
 

--- a/spt/features/visualizations/player_trace/tr_structs.hpp
+++ b/spt/features/visualizations/player_trace/tr_structs.hpp
@@ -252,6 +252,12 @@ namespace player_trace
 	struct TrAbsBox_v1
 	{
 		TrIdx<Vector> minsIdx, maxsIdx;
+
+		void GetMinsMaxs(Vector& mins, Vector& maxs) const
+		{
+			mins = minsIdx.IsValid() ? **minsIdx : Vector{NAN};
+			maxs = maxsIdx.IsValid() ? **maxsIdx : Vector{NAN};
+		}
 	};
 	TR_DEFINE_LUMP(TrAbsBox_v1, "aabb", 1);
 
@@ -261,6 +267,12 @@ namespace player_trace
 	{
 		TrIdx<Vector> posIdx;
 		TrIdx<QAngle> angIdx;
+
+		void GetPosAng(Vector& pos, QAngle& ang) const
+		{
+			pos = posIdx.GetOrDefault(Vector{NAN});
+			ang = angIdx.GetOrDefault(QAngle{NAN, NAN, NAN});
+		}
 	};
 	TR_DEFINE_LUMP(TrTransform_v1, "transform", 1);
 	TR_DEFINE_LUMP(TrIdx<TrTransform_v1>, "transform_idx", 1);

--- a/spt/features/visualizations/player_trace/tr_structs.hpp
+++ b/spt/features/visualizations/player_trace/tr_structs.hpp
@@ -36,6 +36,7 @@ namespace player_trace
 {
 	class TrRecordingCache;
 	class TrRenderingCache;
+	class TrEntityCache;
 	struct TrPlayerTrace;
 
 	// a scope within which we can deref TrIdx & TrSpan
@@ -649,6 +650,9 @@ namespace player_trace
 
 		std::unique_ptr<TrRecordingCache> recordingCache;
 		mutable std::unique_ptr<TrRenderingCache> renderingCache;
+		mutable std::unique_ptr<TrEntityCache> entityCache;
+
+		TrRecordingCache& GetRecordingCache();
 
 		void CollectServerState(bool hostTickSimulating);
 		void CollectPlayerData();
@@ -683,9 +687,10 @@ namespace player_trace
 		}
 
 		TrRenderingCache& GetRenderingCache() const;
-		TrRecordingCache& GetRecordingCache();
+		TrEntityCache& GetEntityCache() const;
 
 		void KillRenderingCache();
+		void KillEntityCache();
 
 		size_t GetMemoryUsage() const
 		{


### PR DESCRIPTION
A couple of organization commits along with a few new tabs in ImGui.

https://github.com/user-attachments/assets/da78b822-75e1-44ac-ac0f-077560f174e9

The entity filter checks all the strings associated with each entity.
<img width="1167" height="680" alt="image" src="https://github.com/user-attachments/assets/e37ec4bb-7371-4484-ae4b-cefee2fd81a3" />
<img width="1359" height="1373" alt="image" src="https://github.com/user-attachments/assets/f0c22cde-8807-4989-bc55-f9b934e316ac" />
<img width="772" height="457" alt="image" src="https://github.com/user-attachments/assets/381ab256-07fc-4f01-951e-c90b3f439abd" />
