### PR TITLE
Add spt_tas_script_new

### DIFF
--- a/spt/features/game_fixes/rng.hpp
+++ b/spt/features/game_fixes/rng.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "..\feature.hpp"
 
+extern ConVar y_spt_set_ivp_seed_on_load;
+
 // RNG prediction
 class RNGStuff : public FeatureWrapper<RNGStuff>
 {

--- a/spt/features/portalled_pause.cpp
+++ b/spt/features/portalled_pause.cpp
@@ -9,7 +9,7 @@
 
 ConVar spt_on_portalled_pause_for("spt_on_portalled_pause_for",
                                   "0",
-                                  0,
+                                  FCVAR_TAS_RESET | FCVAR_DONTRECORD,
                                   "Whenever player portalled, pause for this many ticks.");
 
 namespace patterns

--- a/spt/features/tas.hpp
+++ b/spt/features/tas.hpp
@@ -44,6 +44,7 @@ class TASFeature : public FeatureWrapper<TASFeature>
 {
 public:
 	void Strafe();
+	bool WriteTemplateScript(const char* filePath, const char* saveName, std::string& errMsg);
 	bool tasAddressesWereFound = false;
 
 protected:

--- a/spt/features/taspause.cpp
+++ b/spt/features/taspause.cpp
@@ -4,7 +4,10 @@
 #include "..\utils\game_detection.hpp"
 
 typedef void(__cdecl* _Host_AccumulateTime)(float dt);
-ConVar tas_pause("tas_pause", "0", 0, "Does a pause where you can look around when the game is paused.\n");
+ConVar tas_pause("tas_pause",
+                 "0",
+                 FCVAR_TAS_RESET | FCVAR_DONTRECORD,
+                 "Does a pause where you can look around when the game is paused.\n");
 
 class TASPause : public FeatureWrapper<TASPause>
 {


### PR DESCRIPTION
`spt_tas_script_new` creates a template .srctas file.

<img width="475" height="47" alt="image" src="https://github.com/user-attachments/assets/7ce0be29-34ab-4764-8419-aa5ac7b8f53d" />

Here's what the script looks like:
```
save SAVE_TO_LOAD
demo DEMO_NAME
playspeed 1

settings tas_strafe_version 9
settings tas_strafe_vectorial 1
settings tas_strafe_dir 3
settings y_spt_set_ivp_seed_on_load 1
settings tas_pause 0
settings cl_mouseenable 0

vars

frames

// sXXljdbcgu|flrbud|jdu12r|yaw|pitch|tick|
----------|------|------|-|-|60|
----------|f-----|------|-|-|20|
----------|------|------|-|-|1| cl_mouseenable 1;

// SPT version Aug  6 2025 11:34:30
```