### PR TITLE
Add env var override build number detection

### DIFF
--- a/spt/utils/game_detection.cpp
+++ b/spt/utils/game_detection.cpp
@@ -158,7 +158,12 @@ namespace utils
 
 		if (!HasBuildNumber)
 		{
-			BuildNumber = BuildResult.get();
+			const char* envBuildNumber = std::getenv("SPT_USE_BUILD_NUMBER");
+			if (envBuildNumber)
+				BuildNumber = atoi(envBuildNumber);
+			else
+				BuildNumber = BuildResult.get();
+
 			HasBuildNumber = true;
 		}
 


### PR DESCRIPTION
Add `SPT_USE_BUILD_NUMBER` for overriding build number detection.
Mainly for leaked builds or temporary workaround when the build number detection isn't correct.