### PR TITLE
Add engine server custom interface

### DIFF
--- a/spt.vcxproj
+++ b/spt.vcxproj
@@ -1614,6 +1614,7 @@ del "$(OutDir)spt-version.obj"</Command>
     <ClInclude Include="spt\strafe\strafe_utils.hpp" />
     <ClInclude Include="spt\utils\convar.hpp" />
     <ClInclude Include="spt\utils\custom_interfaces\engine_client.hpp" />
+    <ClInclude Include="spt\utils\custom_interfaces\engine_server.hpp" />
     <ClInclude Include="spt\utils\custom_interfaces\surface.hpp" />
     <ClInclude Include="spt\utils\datamap_wrapper.hpp" />
     <ClInclude Include="spt\utils\ent_list.hpp" />

--- a/spt.vcxproj.filters
+++ b/spt.vcxproj.filters
@@ -1098,6 +1098,9 @@
     <ClInclude Include="spt\flatbuffers_schemas\fb_pack_defs.hpp">
       <Filter>spt\flatbuffers_schemas</Filter>
     </ClInclude>
+    <ClInclude Include="spt\utils\custom_interfaces\engine_server.hpp">
+      <Filter>spt\utils\custom_interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="SDK includes &amp; libs">

--- a/spt/features/afterframes.cpp
+++ b/spt/features/afterframes.cpp
@@ -5,6 +5,7 @@
 #include "..\cvars.hpp"
 #include "signals.hpp"
 #include "dbg.h"
+#include "interfaces.hpp"
 #include <sstream>
 
 AfterframesFeature spt_afterframes;
@@ -45,7 +46,8 @@ void AfterframesFeature::ResumeAfterframesQueue()
 
 bool AfterframesFeature::ShouldLoadFeature()
 {
-	return true;
+	// Can't run commands without EngineConCmd
+	return interfaces::engine_client != nullptr;
 }
 
 void AfterframesFeature::UnloadFeature() {}

--- a/spt/features/afterticks.cpp
+++ b/spt/features/afterticks.cpp
@@ -5,6 +5,7 @@
 #include "..\cvars.hpp"
 #include "signals.hpp"
 #include "dbg.h"
+#include "interfaces.hpp"
 #include <sstream>
 
 AfterticksFeature spt_afterticks;
@@ -64,7 +65,8 @@ int AfterticksFeature::GetTickCount()
 
 bool AfterticksFeature::ShouldLoadFeature()
 {
-	return true;
+	// Can't run commands without EngineConCmd
+	return interfaces::engine_client != nullptr;
 }
 
 void AfterticksFeature::UnloadFeature() 

--- a/spt/features/aim.cpp
+++ b/spt/features/aim.cpp
@@ -7,6 +7,7 @@
 #include "playerio.hpp"
 #include "signals.hpp"
 #include "tas.hpp"
+#include "interfaces.hpp"
 
 #undef min
 #undef max
@@ -330,6 +331,12 @@ CON_COMMAND(_y_spt_setangle,
 		spt_aim.SetPitch(angles[PITCH]);
 		spt_aim.SetYaw(angles[YAW]);
 	}
+}
+
+bool AimFeature::ShouldLoadFeature()
+{
+	// Can't aim without SetViewAngles
+	return interfaces::engine_client != nullptr;
 }
 
 void AimFeature::LoadFeature()

--- a/spt/features/aim.hpp
+++ b/spt/features/aim.hpp
@@ -21,6 +21,7 @@ public:
 	void SetYaw(float yaw);
 	void ResetPitchYawCommands();
 	void SetJump();
+	virtual bool ShouldLoadFeature() override;
 	virtual void LoadFeature() override;
 
 protected:

--- a/spt/features/autocomplete.cpp
+++ b/spt/features/autocomplete.cpp
@@ -37,9 +37,7 @@ DEFINE_AUTOCOMPLETIONFILE_FUNCTION(exec, "cfg", ".cfg");
 
 bool AutocompleteFeature::ShouldLoadFeature()
 {
-	if (utils::DoesGameLookLikeDMoMM())
-		return false;
-	return !!(g_pCVar);
+	return g_pCVar != nullptr && interfaces::engine_server != nullptr;
 }
 
 void AutocompleteFeature::InitHooks() {}

--- a/spt/features/camera.cpp
+++ b/spt/features/camera.cpp
@@ -12,6 +12,7 @@
 #include "spt\utils\interfaces.hpp"
 #include "spt\utils\signals.hpp"
 #include "spt\cvars.hpp"
+#include "spt\sptlib-wrapper.hpp"
 #include "visualizations\player_trace\tr_config.hpp"
 
 #include "usercmd.h"
@@ -419,7 +420,7 @@ void Camera::InitHooks()
 
 bool Camera::CanOverrideView() const
 {
-	return interfaces::engine_client->IsInGame() || spt_demostuff.Demo_IsPlayingBack();
+	return interfaces::_engine_client->IsInGame() || spt_demostuff.Demo_IsPlayingBack();
 }
 
 bool Camera::CanInput() const
@@ -503,7 +504,7 @@ void Camera::HandleDriveMode(bool active)
 
 static ButtonCode_t bindToButtonCode(const char* bind)
 {
-	const char* key = interfaces::engine_client->Key_LookupBinding(bind);
+	const char* key = interfaces::_engine_client->Key_LookupBinding(bind);
 	if (!key)
 		return BUTTON_CODE_INVALID;
 	return interfaces::inputSystem->StringToButtonCode(key);
@@ -563,7 +564,7 @@ void Camera::HandleInput(bool active)
 				{
 					char buf[32] = {0};
 					snprintf(buf, sizeof(buf), "-%s %d", &binds[i][1], code);
-					interfaces::engine->ClientCmd(buf);
+					EngineConCmd(buf);
 					keyBits |= (1 << i);
 				}
 			}
@@ -1096,7 +1097,7 @@ IMPL_HOOK_THISCALL(Camera, void, CInput__MouseMove, void*, void* cmd)
 
 bool Camera::ShouldLoadFeature()
 {
-	return interfaces::engine_client != nullptr && interfaces::engine_vgui != nullptr
+	return interfaces::_engine_client != nullptr && interfaces::engine_vgui != nullptr
 	       && interfaces::vgui_input != nullptr && interfaces::inputSystem != nullptr;
 }
 

--- a/spt/features/cvar.cpp
+++ b/spt/features/cvar.cpp
@@ -184,7 +184,7 @@ void CvarStuff::PreHook()
 void CvarStuff::LoadFeature()
 {
 #ifdef OE
-	if (g_pCVar || interfaces::engine)
+	if (g_pCVar || interfaces::engine_client)
 	{
 		InitCommand(y_spt_cvar);
 		InitCommand(y_spt_cvar_random);

--- a/spt/features/generic.cpp
+++ b/spt/features/generic.cpp
@@ -12,19 +12,6 @@
 #include "..\cvars.hpp"
 #include "..\sptlib-wrapper.hpp"
 
-#ifdef OE
-ConVar y_spt_gamedir(
-    "y_spt_gamedir",
-    "",
-    0,
-    "Sets the game directory, that is used for loading tas scripts and tests. Use the full path for the folder e.g. C:\\Steam\\steamapps\\sourcemods\\hl2oe\\\n");
-
-const char* GetGameDirectoryOE()
-{
-	return y_spt_gamedir.GetString();
-}
-#endif
-
 CON_COMMAND(y_spt_build, "Returns the build number of the game")
 {
 	Msg("The build is: %d\n", utils::GetBuildNumber());
@@ -181,9 +168,6 @@ Vector GenericFeature::GetCameraOrigin()
 
 void GenericFeature::LoadFeature()
 {
-#ifdef OE
-	InitConcommandBase(y_spt_gamedir);
-#endif
 	InitCommand(y_spt_build);
 
 	if (ORIG_CHudDamageIndicator__GetDamagePosition)

--- a/spt/features/playerio.cpp
+++ b/spt/features/playerio.cpp
@@ -124,7 +124,7 @@ void PlayerIOFeature::InitHooks()
 
 bool PlayerIOFeature::ShouldLoadFeature()
 {
-	return interfaces::engine != nullptr && spt_entprops.ShouldLoadFeature();
+	return spt_entprops.ShouldLoadFeature();
 }
 
 void PlayerIOFeature::UnloadFeature()
@@ -712,11 +712,11 @@ CON_COMMAND(tas_print_movement_vars, "Prints movement vars.")
 
 CON_COMMAND(_y_spt_getangles, "Gets the view angles of the player.")
 {
-	if (!interfaces::engine)
+	if (!interfaces::engine_client)
 		return;
 
 	QAngle va;
-	interfaces::engine->GetViewAngles(va);
+	interfaces::engine_client->GetViewAngles(va);
 
 	Warning("View Angle (x): %f\n", va.x);
 	Warning("View Angle (y): %f\n", va.y);
@@ -927,10 +927,8 @@ void PlayerIOFeature::LoadFeature()
 
 	playerioAddressesWereFound = PlayerIOAddressesFound();
 
-	if (interfaces::engine)
-	{
+	if (interfaces::engine_client)
 		InitCommand(_y_spt_getangles);
-	}
 
 	if (playerioAddressesWereFound)
 	{

--- a/spt/features/portalled_pause.cpp
+++ b/spt/features/portalled_pause.cpp
@@ -6,6 +6,7 @@
 #include "ent_utils.hpp"
 #include "game_detection.hpp"
 #include "spt\utils\ent_list.hpp"
+#include "interfaces.hpp"
 
 ConVar spt_on_portalled_pause_for("spt_on_portalled_pause_for",
                                   "0",
@@ -39,7 +40,7 @@ void PortalledPause::PreHook()
 
 void PortalledPause::LoadFeature()
 {
-	if (ORIG_TeleportTouchingEntity)
+	if (ORIG_TeleportTouchingEntity && interfaces::engine_client != nullptr)
 		InitConcommandBase(spt_on_portalled_pause_for);
 }
 

--- a/spt/features/qccmd.cpp
+++ b/spt/features/qccmd.cpp
@@ -6,6 +6,7 @@
 #include "playerio.hpp"
 #include "signals.hpp"
 #include "create_collide.hpp"
+#include "interfaces.hpp"
 
 #include "vphysics_interface.h"
 
@@ -84,7 +85,8 @@ static void Tick(bool simulating)
 
 bool QcCmdFeature::ShouldLoadFeature()
 {
-	return true;
+	// Can't run commands without EngineConCmd
+	return interfaces::engine_client != nullptr;
 }
 
 void QcCmdFeature::InitHooks() {}

--- a/spt/features/saveloads.cpp
+++ b/spt/features/saveloads.cpp
@@ -6,6 +6,7 @@
 #include "..\features\afterticks.hpp"
 #include "spt\features\hud.hpp"
 #include "visualizations/imgui/imgui_interface.hpp"
+#include "interfaces.hpp"
 
 #include <format>
 
@@ -124,7 +125,8 @@ ConVar y_spt_hud_saveloads_showcurindex("y_spt_hud_saveloads_showcurindex",
 
 bool SaveloadsFeature::ShouldLoadFeature()
 {
-	return true;
+	// Can't run commands without EngineConCmd
+	return interfaces::engine_client != nullptr;
 }
 
 void SaveloadsFeature::LoadFeature()

--- a/spt/features/stucksave.cpp
+++ b/spt/features/stucksave.cpp
@@ -11,6 +11,7 @@
 #include "..\utils\ent_list.hpp"
 #include "create_collide.hpp"
 #include "signals.hpp"
+#include "interfaces.hpp"
 
 #define GAME_DLL
 #include "cbase.h"
@@ -46,7 +47,8 @@ static Stucksave spt_stucksave;
 
 bool Stucksave::ShouldLoadFeature()
 {
-	return true;
+	// Can't run commands without EngineConCmd
+	return interfaces::engine_client != nullptr;
 }
 
 namespace patterns

--- a/spt/features/tas.cpp
+++ b/spt/features/tas.cpp
@@ -152,7 +152,7 @@ TASFeature spt_tas;
 
 bool TASFeature::ShouldLoadFeature()
 {
-	return interfaces::engine != nullptr;
+	return interfaces::engine_client != nullptr;
 }
 
 Strafe::StrafeInput GetStrafeInput(float forwardmove, float sidemove, float yaw)
@@ -324,7 +324,7 @@ CON_COMMAND_F(spt_tas_script_new,
 
 void TASFeature::LoadFeature()
 {
-	if (AfterFramesSignal.Works)
+	if (AfterFramesSignal.Works && interfaces::engine_client != nullptr)
 	{
 		InitCommand(tas_script_load);
 		InitCommand(tas_script_search);

--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -568,7 +568,7 @@ CON_COMMAND(y_spt_find_seam_shot, find_seam_shot_help)
 	{
 		if (firstInvocation)
 		{
-			interfaces::engine->GetViewAngles(firstAngle);
+			interfaces::engine_client->GetViewAngles(firstAngle);
 			firstPos = utils::GetPlayerEyePosition();
 			firstInvocation = !firstInvocation;
 
@@ -584,7 +584,7 @@ CON_COMMAND(y_spt_find_seam_shot, find_seam_shot_help)
 				return;
 			}
 			a = firstAngle;
-			interfaces::engine->GetViewAngles(b);
+			interfaces::engine_client->GetViewAngles(b);
 		}
 	}
 	else
@@ -617,7 +617,7 @@ CON_COMMAND(y_spt_find_seam_shot, find_seam_shot_help)
 		if (trace_fire_portal(test, test_normal) - distance > GOOD_DISTANCE_DIFFERENCE)
 		{
 			Msg("Found a seam shot at setang %.8f %.8f 0\n", test.x, test.y);
-			interfaces::engine->SetViewAngles(test);
+			interfaces::engine_client->SetViewAngles(test);
 			return;
 		}
 
@@ -638,7 +638,7 @@ CON_COMMAND(y_spt_find_seam_shot, find_seam_shot_help)
 	} while (difference > eps);
 
 	Msg("Could not find a seam shot. Best guess: setang %.8f %.8f 0\n", test.x, test.y);
-	interfaces::engine->SetViewAngles(test);
+	interfaces::engine_client->SetViewAngles(test);
 }
 #endif
 
@@ -651,7 +651,7 @@ void Tracing::LoadFeature()
 		Warning("spt_tas_strafe_version 2 not available\n");
 
 #ifdef SPT_TRACE_PORTAL_ENABLED
-	if (utils::DoesGameLookLikePortal() && ORIG_TraceFirePortal)
+	if (interfaces::engine_client != nullptr && utils::DoesGameLookLikePortal() && ORIG_TraceFirePortal)
 	{
 		InitCommand(y_spt_find_seam_shot);
 	}

--- a/spt/features/visualizations/player_trace/tr_collect.cpp
+++ b/spt/features/visualizations/player_trace/tr_collect.cpp
@@ -8,6 +8,7 @@
 #include "spt/utils/map_utils.hpp"
 #include "spt/utils/ent_list.hpp"
 #include "spt/utils/game_detection.hpp"
+#include "spt/utils/file.hpp"
 #include "spt/features/playerio.hpp"
 #include "spt/features/ent_props.hpp"
 #include "spt/utils/portal_utils.hpp"
@@ -24,18 +25,18 @@ void TrPlayerTrace::StartRecording()
 	Clear();
 
 	firstRecordedInfo.gameName = utils::GetGameName();
-	if (interfaces::engine)
+	if (interfaces::engine_server)
 	{
 		try
 		{
 			firstRecordedInfo.gameModName =
-			    std::filesystem::path{interfaces::engine->GetGameDirectory()}.filename().string();
+			    std::filesystem::path{GetGameDir()}.filename().string();
 		}
 		catch (...)
 		{
 		}
+		firstRecordedInfo.playerName = interfaces::engine_server->GetClientConVarValue(1, "name");
 	}
-	firstRecordedInfo.playerName = interfaces::engine_server->GetClientConVarValue(1, "name");
 	firstRecordedInfo.gameVersion = utils::GetBuildNumber();
 
 	hasStartRecordingBeenCalled = true;

--- a/spt/scripts/srctas_reader.cpp
+++ b/spt/scripts/srctas_reader.cpp
@@ -16,8 +16,6 @@
 #include "..\features\demo.hpp"
 #include "..\features\tas.hpp"
 
-extern ConVar y_spt_gamedir;
-
 namespace scripts
 {
 	SourceTASReader g_TASReader;
@@ -91,11 +89,6 @@ namespace scripts
 		{
 			DevMsg("Attempting to parse a version 1 TAS script...\n");
 			Reset();
-#if OE
-			const char* dir = y_spt_gamedir.GetString();
-			if (dir == NULL || dir[0] == '\0')
-				Msg("WARNING: Trying to load a script file without setting the game directory with spt_gamedir in old engine!\n");
-#endif
 
 			std::string gameDir = GetGameDir();
 			scriptStream.open(gameDir + "\\" + fileName + SCRIPT_EXT);

--- a/spt/scripts2/srctas_reader2.cpp
+++ b/spt/scripts2/srctas_reader2.cpp
@@ -15,8 +15,6 @@
 #include "..\spt-serverplugin.hpp"
 #include "..\sptlib-wrapper.hpp"
 
-extern ConVar y_spt_gamedir;
-
 namespace scripts2
 {
 	SourceTASReader g_TASReader;
@@ -97,11 +95,6 @@ namespace scripts2
 		{
 			DevMsg("Attempting to parse a version 2 TAS script...\n");
 			Reset();
-#if OE
-			const char* dir = y_spt_gamedir.GetString();
-			if (dir == NULL || dir[0] == '\0')
-				Msg("WARNING: Trying to load a script file without setting the game directory with spt_gamedir in old engine!\n");
-#endif
 
 			std::string gameDir = GetGameDir();
 			scriptStream.open(gameDir + "\\" + fileName + SCRIPT_EXT);

--- a/spt/utils/convar.hpp
+++ b/spt/utils/convar.hpp
@@ -164,12 +164,12 @@ struct ArgsWrapper
 
 	int ArgC() const
 	{
-		return interfaces::engine->Cmd_Argc();
+		return interfaces::engine_client->Cmd_Argc();
 	};
 
 	const char* Arg(int arg) const
 	{
-		return interfaces::engine->Cmd_Argv(arg);
+		return interfaces::engine_client->Cmd_Argv(arg);
 	};
 };
 
@@ -177,7 +177,7 @@ struct ArgsWrapper
 	static void name(ArgsWrapper args); \
 	static void name##_wrapper() \
 	{ \
-		if (!interfaces::engine) \
+		if (!interfaces::engine_client) \
 			return; \
 		ArgsWrapper args; \
 		name(args); \

--- a/spt/utils/custom_interfaces/engine_client.hpp
+++ b/spt/utils/custom_interfaces/engine_client.hpp
@@ -14,7 +14,6 @@ public:
 	virtual int Cmd_Argc() = 0;
 	virtual const char* Cmd_Argv(int arg) = 0;
 #endif
-	virtual const char* GetGameDirectory() = 0;
 };
 
 #ifdef OE
@@ -81,17 +80,6 @@ public:
 	virtual const char* Cmd_Argv(int arg) override
 	{
 		return engine->Cmd_Argv(arg);
-	}
-
-	virtual const char* GetGameDirectory() override
-	{
-		extern const char* GetGameDirectoryOE();
-		return GetGameDirectoryOE();
-	}
-#else
-	virtual const char* GetGameDirectory() override
-	{
-		return engine->GetGameDirectory();
 	}
 #endif
 

--- a/spt/utils/custom_interfaces/engine_server.hpp
+++ b/spt/utils/custom_interfaces/engine_server.hpp
@@ -1,0 +1,72 @@
+#pragma once
+#include "vcall.hpp"
+#include "eiface.h"
+
+class EngineServerWrapper
+{
+public:
+	virtual ~EngineServerWrapper() {};
+	virtual int GetEntityCount() = 0;
+	virtual edict_t* PEntityOfEntIndex(int iEntIndex) = 0;
+	virtual void GetGameDir(char* szGetGameDir, int maxlength) = 0;
+	virtual const char* GetClientConVarValue(int clientIndex, const char* name) = 0;
+};
+
+#ifdef OE
+class IVEngineServerDMoMM
+{
+public:
+	int GetEntityCount()
+	{
+		return utils::vcall<int>(21, this);
+	}
+
+	edict_t* PEntityOfEntIndex(int iEntIndex)
+	{
+		return utils::vcall<edict_t*>(23, this, iEntIndex);
+	}
+
+	void GetGameDir(char* szGetGameDir, int maxlength) 
+	{
+		utils::vcall<void>(59, this, szGetGameDir, maxlength);
+	}
+
+	const char* GetClientConVarValue(int clientIndex, const char* name)
+	{
+		return utils::vcall<const char*>(63, this, clientIndex, name);
+	}
+};
+#endif
+
+/**
+ * Wrapper for an interface similar to EngineServerWrapper.
+ */
+template<class EngineServer>
+class IVEngineServerWrapper : public EngineServerWrapper
+{
+public:
+	IVEngineServerWrapper(EngineServer* engine) : engine(engine) {}
+
+	virtual int GetEntityCount() override
+	{
+		return engine->GetEntityCount();
+	}
+
+	virtual edict_t* PEntityOfEntIndex(int iEntIndex) override
+	{
+		return engine->PEntityOfEntIndex(iEntIndex);
+	}
+
+	virtual void GetGameDir(char* szGetGameDir, int maxlength) override
+	{
+		engine->GetGameDir(szGetGameDir, maxlength);
+	}
+
+	virtual const char* GetClientConVarValue(int clientIndex, const char* name) override
+	{
+		return engine->GetClientConVarValue(clientIndex, name);
+	}
+
+private:
+	EngineServer* engine;
+};

--- a/spt/utils/file.cpp
+++ b/spt/utils/file.cpp
@@ -3,10 +3,6 @@
 #include "interfaces.hpp"
 #include <fstream>
 
-#ifdef OE
-extern ConVar y_spt_gamedir;
-#endif
-
 bool FileExists(const std::string& fileName)
 {
 	std::string dir = fileName;
@@ -17,9 +13,6 @@ bool FileExists(const std::string& fileName)
 
 std::string GetGameDir()
 {
-#ifdef OE
-	return y_spt_gamedir.GetString();
-#else
 	char BUFFER[256];
 	if (!interfaces::engine_server)
 		return std::string();
@@ -28,5 +21,4 @@ std::string GetGameDir()
 		interfaces::engine_server->GetGameDir(BUFFER, ARRAYSIZE(BUFFER));
 		return BUFFER;
 	}
-#endif
 }

--- a/spt/utils/game_detection.cpp
+++ b/spt/utils/game_detection.cpp
@@ -4,6 +4,7 @@
 #include "SPTLib\MemUtils.hpp"
 #include "interfaces.hpp"
 #include "thirdparty\kmp-cpp.hpp"
+#include "file.hpp"
 #include <atomic>
 #include <thread>
 #include <future>
@@ -39,10 +40,10 @@ namespace utils
 		if (cachedCmd)
 			return result; // trust the cmd result more than the game directory
 
-		if (!cachedGameDir && interfaces::engine)
+		if (!cachedGameDir)
 		{
 #ifndef OE
-			auto game_dir = interfaces::engine->GetGameDirectory();
+			auto game_dir = GetGameDir();
 			result = (GetFileName(Convert(game_dir)) == L"portal");
 			cachedGameDir = true;
 #endif
@@ -119,10 +120,10 @@ namespace utils
 	bool DoesGameLookLikeEstranged()
 	{
 		static bool cached = false, result = false;
-		if (!cached && interfaces::engine)
+		if (!cached)
 		{
 #ifndef OE
-			auto game_dir = interfaces::engine->GetGameDirectory();
+			auto game_dir = GetGameDir();
 			result = (GetFileName(Convert(game_dir)) == L"estrangedact1");
 			cached = true;
 #endif

--- a/spt/utils/interfaces.hpp
+++ b/spt/utils/interfaces.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include "custom_interfaces\engine_client.hpp"
+#include "custom_interfaces\engine_server.hpp"
 #include "custom_interfaces\surface.hpp"
 #include "eiface.h"
 #include "tier3\tier3.h"
@@ -23,9 +24,10 @@ class IGameMovement;
 
 namespace interfaces
 {
-	extern std::unique_ptr<EngineClientWrapper> engine;
-	extern IVEngineServer* engine_server;
-	extern IVEngineClient* engine_client;
+	extern std::unique_ptr<EngineClientWrapper> engine_client;
+	extern std::unique_ptr<EngineServerWrapper> engine_server;
+	extern IVEngineServer* _engine_server;
+	extern IVEngineClient* _engine_client;
 	extern std::unique_ptr<SurfaceWrapper> surface;
 	extern IMatSystemSurface* mat_system_surface;
 	extern vgui::ISchemeManager* scheme;


### PR DESCRIPTION
The main thing is to remove `spt_gamedir` so autocomplete for files works in OE.
Adding `EngineServerWrapper` custom interface (mainly for DMoMM). I renamed some variables for consistency.
- `std::unique_ptr<EngineServerWrapper>` engine_server
- `std::unique_ptr<EngineClientWrapper>` engine -> engine_client
- `IVEngineServer*` engine_server -> _engine_server
- `IVEngineClient*` engine_client -> _engine_client

Also, removed some warnings when failing to get the engine client interface, like
```c
Warning("SPT: spt_afterframes has no effect.\n");
Warning("SPT: spt_setpitch and spt_setyaw have no effect.\n");
Warning("SPT: spt_pitchspeed and spt_yawspeed have no effect.\n");
Warning("SPT: spt_stucksave has no effect.\n");
```
Instead, we just don't initialize those commands.
(tbh, failing to load these core game interfaces is unlikely, and we should probably just refuse to load when it happens?)