### PR TITLE
Fix ground detection

### DIFF
--- a/spt/features/tas.cpp
+++ b/spt/features/tas.cpp
@@ -108,7 +108,7 @@ ConVar tas_force_onground(
     FCVAR_TAS_RESET,
     "If enabled, strafing assumes the player is on ground regardless of what the prediction indicates. Useful for save glitch in Portal where the prediction always reports the player being in the air.\n");
 ConVar tas_strafe_version("tas_strafe_version",
-                          "9",
+                          "10",
                           FCVAR_TAS_RESET,
                           "Strafe version. For backwards compatibility with old scripts.");
 

--- a/spt/strafe/strafestuff.cpp
+++ b/spt/strafe/strafestuff.cpp
@@ -171,15 +171,15 @@ namespace Strafe
 		if ((player.DuckPressed && !tas_strafe_autojb.GetBool()) || !tas_strafe_use_tracing.GetBool()
 		    || !utils::spt_serverEntList.GetPlayer())
 			return false;
-		else
-		{
-			trace_t tr;
-			Vector duckedOrigin(player.UnduckedOrigin);
-			duckedOrigin.z -= 36;
-			TracePlayer(tr, duckedOrigin, player.UnduckedOrigin, Strafe::HullType::DUCKED);
 
+		trace_t tr;
+		Vector duckedOrigin(player.UnduckedOrigin);
+		duckedOrigin.z -= 36;
+		TracePlayer(tr, duckedOrigin, player.UnduckedOrigin, Strafe::HullType::DUCKED);
+
+		if (tas_strafe_version.GetInt() < 10)
 			return tr.fraction == 1.0f;
-		}
+		return !tr.startsolid && (tr.fraction == 1.0f);
 	}
 
 	PositionType GetPositionType(PlayerData& player, HullType hull)


### PR DESCRIPTION
Fixed incorrect ground detection bug when `toggle_duck` on complex brushes or some static props.

Code matches `CGameMovement::CanUnduck` using `trace.startsolid`

Bumped `tas_strafe_version` to 10.