### PR TITLE
Fixes #434

### DIFF
--- a/SDK/orangebox_new/include/public/dt_common.h
+++ b/SDK/orangebox_new/include/public/dt_common.h
@@ -103,6 +103,7 @@ typedef enum
 	DPT_Int=0,
 	DPT_Float,
 	DPT_Vector,
+	DPT_VectorXY, // Only encodes the XY of a vector, ignores Z
 	DPT_String,
 	DPT_Array,	// An array of the base types (can't be of datatables).
 	DPT_DataTable,

--- a/spt/features/ent_props.cpp
+++ b/spt/features/ent_props.cpp
@@ -28,6 +28,11 @@ ConVar y_spt_hud_ent_info(
     "Display entity info on HUD. Format is \"[ent index],[prop regex],[prop regex],...,[prop regex];[ent index],...,[prop regex]\".\n");
 #endif
 
+ConVar spt_hud_ent_info_recurse("spt_hud_ent_info_recurse",
+                                "0",
+                                FCVAR_DONTRECORD,
+                                "If enabled, spt_hud_ent_info and spt_print_ent_props will recurse into datatables.");
+
 static const int MAX_ENTRIES = 128;
 static const int INFO_BUFFER_SIZE = 256;
 static wchar INFO_ARRAY[MAX_ENTRIES * INFO_BUFFER_SIZE];
@@ -520,7 +525,9 @@ void EntProps::LoadFeature()
 	if (result)
 	{
 		InitConcommandBase(y_spt_hud_ent_info);
+		InitConcommandBase(spt_hud_ent_info_recurse);
 		SptImGui::RegisterHudCvarCallback(y_spt_hud_ent_info, ImGuiEntInfoCvarCallback, true);
+		SptImGui::RegisterHudCvarCheckbox(spt_hud_ent_info_recurse);
 	}
 #endif
 }

--- a/spt/features/ipc-spt.cpp
+++ b/spt/features/ipc-spt.cpp
@@ -136,8 +136,9 @@ namespace ipc
 		int i;
 		float f;
 		Vector v;
+		Vector2D v2;
 
-		switch (prop->m_RecvType)
+		switch (utils::GetPropTypeVersionAdjust(prop->m_RecvType))
 		{
 		case DPT_Int:
 			i = *reinterpret_cast<int*>(value);
@@ -153,9 +154,14 @@ namespace ipc
 			msg[FormatTempString("%s[1]", prop->GetName())] = v[1];
 			msg[FormatTempString("%s[2]", prop->GetName())] = v[2];
 			break;
-#ifdef SSDK2007
+#ifndef OE
+		case DPT_VectorXY:
+			v2 = *reinterpret_cast<Vector2D*>(value);
+			msg[FormatTempString("%s[0]", prop->GetName())] = v2[0];
+			msg[FormatTempString("%s[1]", prop->GetName())] = v2[1];
+			break;
 		case DPT_String:
-			msg[prop->GetName()] = *reinterpret_cast<const char**>(value);
+			msg[prop->GetName()] = reinterpret_cast<const char*>(value);
 			break;
 #endif
 		default:

--- a/spt/utils/ent_utils.cpp
+++ b/spt/utils/ent_utils.cpp
@@ -32,16 +32,18 @@
 #endif
 
 extern ConVar y_spt_piwsave;
+extern ConVar spt_hud_ent_info_recurse;
 
 namespace utils
 {
-	void GetPropValue(RecvProp* prop, void* ptr, char* buffer, size_t size)
+	void GetPropValue(RecvProp* prop, void* ptr, char* buffer, size_t size, std::vector<propValue>& props)
 	{
 		void* value = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(ptr) + prop->GetOffset());
 		Vector v;
+		Vector2D v2;
 		int ehandle;
 
-		switch (prop->m_RecvType)
+		switch (GetPropTypeVersionAdjust(prop->m_RecvType))
 		{
 		case DPT_Int:
 			if (strstr(prop->GetName(), "m_h") != NULL)
@@ -65,26 +67,34 @@ namespace utils
 			v = *reinterpret_cast<Vector*>(value);
 			sprintf_s(buffer, size, "(%.3f, %.3f, %.3f)", v.x, v.y, v.z);
 			break;
-#ifdef SSDK2007
+#ifndef OE
+		case DPT_VectorXY:
+			v2 = *reinterpret_cast<Vector2D*>(value);
+			sprintf_s(buffer, size, "(%.3f, %.3f)", v2.x, v2.y);
+			break;
 		case DPT_String:
-			sprintf_s(buffer, size, "%s", *reinterpret_cast<const char**>(value));
+			sprintf_s(buffer, size, "%s", reinterpret_cast<const char*>(value));
 			break;
 #endif
+		case DPT_DataTable:
+			Assert(0); // should be handled higher up
+			[[fallthrough]];
 		default:
 			sprintf_s(buffer, size, "unable to parse");
 			break;
 		}
 	}
 
-	const size_t BUFFER_SIZE = 256;
-	static char BUFFER[BUFFER_SIZE];
-
-	void AddProp(std::vector<propValue>& props, const char* name, RecvProp* prop)
+	SendPropType GetPropTypeVersionAdjust(SendPropType original)
 	{
-		props.push_back(propValue(name, BUFFER, prop));
+#ifdef SSDK2007
+		if (original >= DPT_VectorXY && utils::GetBuildNumber() < 5135)
+			return (SendPropType)(original + 1);
+#endif
+		return original;
 	}
 
-	void GetAllProps(RecvTable* table, void* ptr, std::vector<propValue>& props)
+	void GetAllProps(RecvTable* table, void* ptr, std::vector<propValue>& props, std::string prefix)
 	{
 		int numProps = table->m_nProps;
 
@@ -99,12 +109,30 @@ namespace utils
 				if (base)
 					GetAllProps(base, ptr, props);
 			}
-			else if (
-				prop->GetOffset()
-				!= 0) // There's various garbage attributes at offset 0 for a thusfar unbeknownst reason
+			else if (prop->GetOffset() != 0) // custom proxyFns may get a zero offset
 			{
-				GetPropValue(prop, ptr, BUFFER, BUFFER_SIZE);
-				AddProp(props, prop->GetName(), prop);
+				if (GetPropTypeVersionAdjust(prop->GetType()) == DPT_DataTable)
+				{
+					if (spt_hud_ent_info_recurse.GetBool())
+					{
+						GetAllProps(prop->GetDataTable(),
+						            static_cast<char*>(ptr) + prop->GetOffset(),
+						            props,
+						            prefix + std::string(prop->GetName()) + '.');
+					}
+					else
+					{
+						props.emplace_back(prefix + prop->GetName(),
+						                   "recursive datatable",
+						                   prop);
+					}
+				}
+				else
+				{
+					char buf[256];
+					GetPropValue(prop, ptr, buf, sizeof buf, props);
+					props.emplace_back(prefix + prop->GetName(), buf, prop);
+				}
 			}
 		}
 	}
@@ -115,20 +143,19 @@ namespace utils
 
 		if (ent)
 		{
-			snprintf(BUFFER,
-				BUFFER_SIZE,
-				"(%.3f, %.3f, %.3f)",
-				ent->GetAbsOrigin().x,
-				ent->GetAbsOrigin().y,
-				ent->GetAbsOrigin().z);
-			AddProp(props, "AbsOrigin", nullptr);
-			snprintf(BUFFER,
-				BUFFER_SIZE,
-				"(%.3f, %.3f, %.3f)",
-				ent->GetAbsAngles().x,
-				ent->GetAbsAngles().y,
-				ent->GetAbsAngles().z);
-			AddProp(props, "AbsAngles", nullptr);
+			char buf[256];
+			sprintf_s(buf,
+			          "(%.3f, %.3f, %.3f)",
+			          ent->GetAbsOrigin().x,
+			          ent->GetAbsOrigin().y,
+			          ent->GetAbsOrigin().z);
+			props.emplace_back("AbsOrigin", buf, nullptr);
+			sprintf_s(buf,
+			          "(%.3f, %.3f, %.3f)",
+			          ent->GetAbsAngles().x,
+			          ent->GetAbsAngles().y,
+			          ent->GetAbsAngles().z);
+			props.emplace_back("AbsAngles", buf, nullptr);
 			GetAllProps(ent->GetClientClass()->m_pRecvTable, ent, props);
 		}
 	}

--- a/spt/utils/ent_utils.hpp
+++ b/spt/utils/ent_utils.hpp
@@ -20,10 +20,11 @@ namespace utils
 		RecvProp* prop;
 
 		int GetOffset();
-		propValue(const char* name, const char* value, RecvProp* prop) : name(name), value(value), prop(prop) {}
 	};
 
-	void GetAllProps(RecvTable* table, void* ptr, std::vector<propValue>& props);
+	// may need to adjust for different games since RecvProp::m_RecvType changed between versions, see issue #435
+	SendPropType GetPropTypeVersionAdjust(SendPropType original);
+	void GetAllProps(RecvTable* table, void* ptr, std::vector<propValue>& props, std::string prefix = "");
 	void PrintAllProps(int index);
 	Vector GetPlayerEyePosition();
 	QAngle GetPlayerEyeAngles();


### PR DESCRIPTION
UntitledParser uses different send prop types for protocol versions 14 & below than for 15 & above. As far as I remember this corresponds with version 5135 (which is protocol 15) - that has a DPT_VectorXY field. This adjustment takes care of strings which previously showed up as "enable to parse" since they were treated as `DPT_Array`. Also, the cast for DPT_String was incorrect which fixes #434.

Tested `spt_hud_ent_info 0,.*` on portal 5135 & 3420.