### PR TITLE
Mark thirdparty/ and SDK/ as linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,6 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+thirdparty/** linguist-vendored
+SDK/** linguist-vendored


### PR DESCRIPTION
IDK if this will apply retroactively and fix our broken contributor statistics.

Wow! This file hasn't been changed since the initial commit!