### PR TITLE
Fix UTIL_TraceRay signature in 2013

### DIFF
--- a/spt/features/tracing.cpp
+++ b/spt/features/tracing.cpp
@@ -258,6 +258,32 @@ WorldHitInfo Tracing::TraceLineWithWorldInfoServer(const Ray_t& ray,
 	return hitInfo;
 }
 
+void Tracing::UTIL_TraceRay_client(const Ray_t& ray,
+                                   unsigned int mask,
+                                   const IHandleEntity* ignore,
+                                   int collisionGroup,
+                                   trace_t* ptr)
+{
+#ifdef SSDK2013
+	spt_tracing.ORIG_UTIL_TraceRay_client(ray, mask, ignore, collisionGroup, ptr, nullptr);
+#else
+	spt_tracing.ORIG_UTIL_TraceRay_client(ray, mask, ignore, collisionGroup, ptr);
+#endif
+}
+
+void Tracing::UTIL_TraceRay_server(const Ray_t& ray,
+                                   unsigned int mask,
+                                   const IHandleEntity* ignore,
+                                   int collisionGroup,
+                                   trace_t* ptr)
+{
+#ifdef SSDK2013
+	spt_tracing.ORIG_UTIL_TraceRay_server(ray, mask, ignore, collisionGroup, ptr, nullptr);
+#else
+	spt_tracing.ORIG_UTIL_TraceRay_server(ray, mask, ignore, collisionGroup, ptr);
+#endif
+}
+
 IMPL_HOOK_FASTCALL(Tracing,
                    void,
                    CM_ClipBoxToBrush_1,

--- a/spt/features/tracing.hpp
+++ b/spt/features/tracing.hpp
@@ -59,6 +59,25 @@ struct TraceFilterIgnorePlayer : public CTraceFilter
 class Tracing : public FeatureWrapper<Tracing>
 {
 public:
+#ifdef SSDK2013
+	DECL_MEMBER_CDECL(void,
+	                  UTIL_TraceRay_client,
+	                  const Ray_t& ray,
+	                  unsigned int mask,
+	                  const IHandleEntity* ignore,
+	                  int collisionGroup,
+	                  trace_t* ptr,
+	                  void* pExtraShouldHitCheckFn);
+
+	DECL_MEMBER_CDECL(void,
+	                  UTIL_TraceRay_server,
+	                  const Ray_t& ray,
+	                  unsigned int mask,
+	                  const IHandleEntity* ignore,
+	                  int collisionGroup,
+	                  trace_t* ptr,
+	                  void* pExtraShouldHitCheckFn);
+#else
 	DECL_MEMBER_CDECL(void,
 	                  UTIL_TraceRay_client,
 	                  const Ray_t& ray,
@@ -74,6 +93,7 @@ public:
 	                  const IHandleEntity* ignore,
 	                  int collisionGroup,
 	                  trace_t* ptr);
+#endif
 
 	DECL_HOOK_THISCALL(CBaseCombatWeapon*, GetActiveWeapon, IServerUnknown*);
 
@@ -117,6 +137,18 @@ public:
 	                                          unsigned int fMask,
 	                                          ITraceFilter* filter,
 	                                          trace_t& tr);
+
+	// Wrappers for UTIL_TraceRay because 2013 got an extra argument
+	void UTIL_TraceRay_client(const Ray_t& ray,
+	                          unsigned int mask,
+	                          const IHandleEntity* ignore,
+	                          int collisionGroup,
+	                          trace_t* ptr);
+	void UTIL_TraceRay_server(const Ray_t& ray,
+	                          unsigned int mask,
+	                          const IHandleEntity* ignore,
+	                          int collisionGroup,
+	                          trace_t* ptr);
 
 #ifdef SPT_TRACE_PORTAL_ENABLED
 	CBaseCombatWeapon* GetActiveWeapon();

--- a/spt/features/visualizations/fcps/fcps_record.cpp
+++ b/spt/features/visualizations/fcps/fcps_record.cpp
@@ -378,7 +378,7 @@ void FcpsImpl(FcpsEvent& event,
 		entRay.m_Start = ptEntityCenter;
 		entRay.m_Delta = ptEntityOriginalCenter - ptEntityCenter;
 
-		spt_tracing.ORIG_UTIL_TraceRay_server(entRay, fMask, pEntity, iEntityCollisionGroup, &traces[0]);
+		spt_tracing.UTIL_TraceRay_server(entRay, fMask, pEntity, iEntityCollisionGroup, &traces[0]);
 		detail.entTraces.emplace_back(entRay, traces[0], cache.GetIndexOfEnt(traces[0].m_pEnt));
 
 		if (traces[0].startsolid == false)
@@ -418,11 +418,11 @@ void FcpsImpl(FcpsEvent& event,
 				else
 				{
 					testRay.m_Start = ptExtents[counter];
-					spt_tracing.ORIG_UTIL_TraceRay_server(testRay,
-					                                      fMask,
-					                                      pEntity,
-					                                      iEntityCollisionGroup,
-					                                      &traces[0]);
+					spt_tracing.UTIL_TraceRay_server(testRay,
+					                                 fMask,
+					                                 pEntity,
+					                                 iEntityCollisionGroup,
+					                                 &traces[0]);
 					itNudge.testTraces.emplace_back(testRay,
 					                                traces[0],
 					                                cache.GetIndexOfEnt(traces[0].m_pEnt));
@@ -437,11 +437,11 @@ void FcpsImpl(FcpsEvent& event,
 				{
 					testRay.m_Start = ptExtents[counter2];
 					testRay.m_Delta = -testRay.m_Delta;
-					spt_tracing.ORIG_UTIL_TraceRay_server(testRay,
-					                                      fMask,
-					                                      pEntity,
-					                                      iEntityCollisionGroup,
-					                                      &traces[1]);
+					spt_tracing.UTIL_TraceRay_server(testRay,
+					                                 fMask,
+					                                 pEntity,
+					                                 iEntityCollisionGroup,
+					                                 &traces[1]);
 					itNudge.testTraces.emplace_back(testRay,
 					                                traces[1],
 					                                cache.GetIndexOfEnt(traces[1].m_pEnt));

--- a/spt/strafe/strafestuff.cpp
+++ b/spt/strafe/strafestuff.cpp
@@ -116,11 +116,11 @@ namespace Strafe
 			else
 				ray.Init(start, end, mins, maxs);
 
-			spt_tracing.ORIG_UTIL_TraceRay_client(ray,
-			                                      MASK_PLAYERSOLID_BRUSHONLY,
-			                                      utils::spt_clientEntList.GetPlayer(),
-			                                      COLLISION_GROUP_PLAYER_MOVEMENT,
-			                                      &trace);
+			spt_tracing.UTIL_TraceRay_client(ray,
+			                                 MASK_PLAYERSOLID_BRUSHONLY,
+			                                 utils::spt_clientEntList.GetPlayer(),
+			                                 COLLISION_GROUP_PLAYER_MOVEMENT,
+			                                 &trace);
 		}
 		else
 		{
@@ -154,11 +154,11 @@ namespace Strafe
 
 		Ray_t ray;
 		ray.Init(start, end);
-		spt_tracing.ORIG_UTIL_TraceRay_client(ray,
-		                                      MASK_PLAYERSOLID_BRUSHONLY,
-		                                      utils::spt_clientEntList.GetPlayer(),
-		                                      COLLISION_GROUP_PLAYER_MOVEMENT,
-		                                      &trace);
+		spt_tracing.UTIL_TraceRay_client(ray,
+		                                 MASK_PLAYERSOLID_BRUSHONLY,
+		                                 utils::spt_clientEntList.GetPlayer(),
+		                                 COLLISION_GROUP_PLAYER_MOVEMENT,
+		                                 &trace);
 #endif
 	}
 


### PR DESCRIPTION
`spt_hud_oob 1` was causing some random crashes in Portal steampipe because of this.